### PR TITLE
add AsRef<Index> impl for Index

### DIFF
--- a/proptest/src/sample.rs
+++ b/proptest/src/sample.rs
@@ -244,6 +244,14 @@ impl Index {
     }
 }
 
+// This impl is handy for generic code over any type that exposes an internal `Index` -- with it,
+// a plain `Index` can be passed in as well.
+impl AsRef<Index> for Index {
+    fn as_ref(&self) -> &Index {
+        self
+    }
+}
+
 mapfn! {
     [] fn UsizeToIndex[](raw: usize) -> Index {
         Index(raw)


### PR DESCRIPTION
This is useful for generic code, as the comment says. As a workaround
I've had to define a newtype wrapper around `Index` to achieve the same
goal, so it would be lovely to have this be upstream! 😄

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/altsysrq/proptest/134)
<!-- Reviewable:end -->
