### PR TITLE
Added link to docs in README header

### DIFF
--- a/proptest/README.md
+++ b/proptest/README.md
@@ -3,6 +3,9 @@
 [![Build Status](https://travis-ci.org/AltSysrq/proptest.svg?branch=master)](https://travis-ci.org/AltSysrq/proptest)
 [![Build status](https://ci.appveyor.com/api/projects/status/ofe98xfthbx1m608/branch/master?svg=true)](https://ci.appveyor.com/project/AltSysrq/proptest/branch/master)
 [![](http://meritbadge.herokuapp.com/proptest)](https://crates.io/crates/proptest)
+[![](https://docs.rs/proptest/badge.svg)][api-docs]
+
+[api-docs]: https://altsysrq.github.io/rustdoc/proptest/latest/proptest/
 
 ## Introduction
 


### PR DESCRIPTION
Added a badge linking to the latest documentation in the README. There is already a link in the documentation but its hard to find.

By the way, what's the rationale for hosting the API doc on https://altsysrq.github.io/rustdoc/proptest/latest/proptest/ as opposed to https://docs.rs/proptest/0.9.4/proptest/?