### PR TITLE
WIP implementation of proptest-attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "proptest",
+    "proptest-attributes",
     "proptest-derive",
 ]
 

--- a/proptest-attributes/Cargo.toml
+++ b/proptest-attributes/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "proptest-attributes"
+version = "0.1.0"
+authors = ["David Barsky <me@davidbarsky.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proptest = { version = "0.9.4", path = "../proptest" }
+syn = { version = "1.0.5", features = ["full"] }
+quote = "1.0.2"
+
+[dev-dependencies]
+trybuild = "1.0"

--- a/proptest-attributes/src/lib.rs
+++ b/proptest-attributes/src/lib.rs
@@ -20,21 +20,21 @@ pub fn proptest(
 
     match inputs.len() {
         1 => {
-            let arg = match inputs.first().unwrap() {
-                FnArg::Typed(arg) => arg,
+            let param = match inputs.first().unwrap() {
+                FnArg::Typed(param) => param,
                 FnArg::Receiver(recv) => {
                     let tokens = quote_spanned! { recv.span() =>
-                        compile_error!("The #[proptest] macro cannot be applied to a method.");
+                        compile_error!("The `#[proptest]` macro cannot be applied to a method.");
                     };
                     return TokenStream::from(tokens);
                 }
             };
-            let arg_name = &arg.pat;
+            let param_name = &param.pat;
             quote! {
                 #[test]
                 #(#attrs)*
                 fn #name() #ret {
-                    proptest::proptest!(|(#arg_name in #expr)| {
+                    proptest::proptest!(|(#param_name in #expr)| {
                         #body
                     })
                 }
@@ -42,7 +42,7 @@ pub fn proptest(
         }
         _ => {
             let tokens = quote_spanned! { input.sig.span() =>
-                compile_error!("The #[proptest] macro can only be applied to a function with a single argument.");
+                compile_error!("The `#[proptest]` macro can only be applied to a function with a single argument.");
             };
             return TokenStream::from(tokens);
         }

--- a/proptest-attributes/src/lib.rs
+++ b/proptest-attributes/src/lib.rs
@@ -1,0 +1,51 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{spanned::Spanned, Expr, FnArg, ItemFn};
+
+#[proc_macro_attribute]
+pub fn proptest(
+    attr: TokenStream,
+    item: TokenStream,
+) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(item as ItemFn);
+    let expr = syn::parse_macro_input!(attr as Expr);
+
+    let ret = &input.sig.output;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let inputs = &input.sig.inputs;
+
+    match inputs.len() {
+        1 => {
+            let arg = match inputs.first().unwrap() {
+                FnArg::Typed(arg) => arg,
+                FnArg::Receiver(recv) => {
+                    let tokens = quote_spanned! { recv.span() =>
+                        compile_error!("The #[proptest] macro cannot be applied to a method.");
+                    };
+                    return TokenStream::from(tokens);
+                }
+            };
+            let arg_name = &arg.pat;
+            quote! {
+                #[test]
+                #(#attrs)*
+                fn #name() #ret {
+                    proptest::proptest!(|(#arg_name in #expr)| {
+                        #body
+                    })
+                }
+            }
+        }
+        _ => {
+            let tokens = quote_spanned! { input.sig.span() =>
+                compile_error!("The #[proptest] macro can only be applied to a function with a single argument.");
+            };
+            return TokenStream::from(tokens);
+        }
+    }
+    .into()
+}

--- a/proptest-attributes/tests/compile-fail/method.rs
+++ b/proptest-attributes/tests/compile-fail/method.rs
@@ -20,3 +20,5 @@ impl SomeStruct {
         prop_assert_eq!(map.get("arn"), Some(&arn));
     }
 }
+
+fn main() {}

--- a/proptest-attributes/tests/compile-fail/method.rs
+++ b/proptest-attributes/tests/compile-fail/method.rs
@@ -1,0 +1,22 @@
+use proptest::{strategy::Strategy, string::string_regex};
+use proptest_attributes::proptest;
+
+#[derive(Debug, Clone, PartialEq)]
+struct FunctionArn(String);
+
+fn gen_function_arn() -> impl Strategy<Value = FunctionArn> {
+    let expr = "arn:aws:lambda:us-east-1:[0-9]{12}:function:custom-runtime";
+    let arn = string_regex(expr).unwrap();
+    arn.prop_map(FunctionArn)
+}
+
+struct SomeStruct;
+
+impl SomeStruct {
+    #[proptest(gen_function_arn())]
+    fn function_arn(&self) {
+        let mut map = HashMap::new();
+        map.insert("arn", arn.clone());
+        prop_assert_eq!(map.get("arn"), Some(&arn));
+    }
+}

--- a/proptest-attributes/tests/compile-fail/method.stderr
+++ b/proptest-attributes/tests/compile-fail/method.stderr
@@ -1,11 +1,5 @@
-error: The #[proptest] macro cannot be applied to a method.
+error: The `#[proptest]` macro cannot be applied to a method.
   --> $DIR/method.rs:17:21
    |
 17 |     fn function_arn(&self) {
    |                     ^^^^^
-
-error[E0601]: `main` function not found in crate `$CRATE`
-  |
-  = note: consider adding a `main` function to `$DIR/tests/compile-fail/method.rs`
-
-For more information about this error, try `rustc --explain E0601`.

--- a/proptest-attributes/tests/compile-fail/method.stderr
+++ b/proptest-attributes/tests/compile-fail/method.stderr
@@ -1,0 +1,11 @@
+error: The #[proptest] macro cannot be applied to a method.
+  --> $DIR/method.rs:17:21
+   |
+17 |     fn function_arn(&self) {
+   |                     ^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  |
+  = note: consider adding a `main` function to `$DIR/tests/compile-fail/method.rs`
+
+For more information about this error, try `rustc --explain E0601`.

--- a/proptest-attributes/tests/compile-fail/multiple-args.rs
+++ b/proptest-attributes/tests/compile-fail/multiple-args.rs
@@ -8,3 +8,5 @@ fn gen_date() -> impl Strategy<Value = String> {
 
 #[proptest(gen_date())]
 fn parse_date(date: String, _second_arg: String) {}
+
+fn main() {}

--- a/proptest-attributes/tests/compile-fail/multiple-args.rs
+++ b/proptest-attributes/tests/compile-fail/multiple-args.rs
@@ -1,0 +1,10 @@
+use proptest::{strategy::Strategy, string::string_regex};
+use proptest_attributes::proptest;
+
+fn gen_date() -> impl Strategy<Value = String> {
+    let expr = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
+    string_regex(expr).unwrap()
+}
+
+#[proptest(gen_date())]
+fn parse_date(date: String, _second_arg: String) {}

--- a/proptest-attributes/tests/compile-fail/multiple-args.stderr
+++ b/proptest-attributes/tests/compile-fail/multiple-args.stderr
@@ -1,11 +1,5 @@
-error: The #[proptest] macro can only be applied to a function with a single argument.
+error: The `#[proptest]` macro can only be applied to a function with a single argument.
   --> $DIR/multiple-args.rs:10:1
    |
 10 | fn parse_date(date: String, _second_arg: String) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0601]: `main` function not found in crate `$CRATE`
-  |
-  = note: consider adding a `main` function to `$DIR/tests/compile-fail/multiple-args.rs`
-
-For more information about this error, try `rustc --explain E0601`.

--- a/proptest-attributes/tests/compile-fail/multiple-args.stderr
+++ b/proptest-attributes/tests/compile-fail/multiple-args.stderr
@@ -1,0 +1,11 @@
+error: The #[proptest] macro can only be applied to a function with a single argument.
+  --> $DIR/multiple-args.rs:10:1
+   |
+10 | fn parse_date(date: String, _second_arg: String) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  |
+  = note: consider adding a `main` function to `$DIR/tests/compile-fail/multiple-args.rs`
+
+For more information about this error, try `rustc --explain E0601`.

--- a/proptest-attributes/tests/hello.rs
+++ b/proptest-attributes/tests/hello.rs
@@ -1,0 +1,67 @@
+use proptest::{
+    prelude::*, prop_assert_eq, strategy::Strategy, string::string_regex,
+};
+use proptest_attributes::proptest;
+
+fn parse_date(s: &str) -> Option<(u32, u32, u32)> {
+    if 10 != s.len() {
+        return None;
+    }
+
+    // NEW: Ignore non-ASCII strings so we don't need to deal with Unicode.
+    if !s.is_ascii() {
+        return None;
+    }
+
+    if "-" != &s[4..5] || "-" != &s[7..8] {
+        return None;
+    }
+
+    let year = &s[0..4];
+    let month = &s[5..7];
+    let day = &s[8..10];
+
+    year.parse::<u32>().ok().and_then(|y| {
+        month
+            .parse::<u32>()
+            .ok()
+            .and_then(|m| day.parse::<u32>().ok().map(|d| (y, m, d)))
+    })
+}
+
+fn gen_valid_date() -> impl Strategy<Value = String> {
+    let expr = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
+    string_regex(expr).unwrap()
+}
+
+fn gen_all_utf8() -> impl Strategy<Value = String> {
+    let expr = "\\PC*";
+    string_regex(expr).unwrap()
+}
+
+prop_compose! {
+  fn gen_parsed_date()(year in 0u32..10000, month in 1u32..13, day in 1u32..32) -> (u32, u32, u32) {
+    (year, month, day)
+  }
+}
+
+#[proptest(gen_valid_date())]
+fn parses_all_valid_dates(s: String) {
+    parse_date(&s).unwrap();
+}
+
+#[proptest(gen_all_utf8())]
+fn doesnt_crash(s: String) {
+    parse_date(&s);
+}
+
+#[proptest(gen_parsed_date())]
+fn parses_date_back_to_original(date_tuple: (u32, u32, u32)) {
+    let (y, m, d) = date_tuple;
+    let (y2, m2, d2) =
+        parse_date(&format!("{:04}-{:02}-{:02}", y, m, d)).unwrap();
+    // prop_assert_eq! is basically the same as assert_eq!, but doesn't
+    // cause a bunch of panic messages to be printed on intermediate
+    // test failures. Which one to use is largely a matter of taste.
+    prop_assert_eq!((y, m, d), (y2, m2, d2));
+}

--- a/proptest-attributes/tests/lib.rs
+++ b/proptest-attributes/tests/lib.rs
@@ -1,0 +1,14 @@
+// Copyright 2019 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
+    t.pass("tests/.*rs");
+}

--- a/proptest-attributes/tests/ui/basic.rs
+++ b/proptest-attributes/tests/ui/basic.rs
@@ -1,0 +1,19 @@
+use proptest::{prop_assert_eq, strategy::Strategy, string::string_regex};
+use proptest_attributes::proptest;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq)]
+struct FunctionArn(String);
+
+fn gen_function_arn() -> impl Strategy<Value = FunctionArn> {
+    let expr = "arn:aws:lambda:us-east-1:[0-9]{12}:function:custom-runtime";
+    let arn = string_regex(expr).unwrap();
+    arn.prop_map(FunctionArn)
+}
+
+#[proptest(gen_function_arn())]
+fn function_arn(arn: FunctionArn) {
+    let mut map = HashMap::new();
+    map.insert("arn", arn.clone());
+    prop_assert_eq!(map.get("arn"), Some(&arn));
+}

--- a/proptest-attributes/tests/ui/basic.rs
+++ b/proptest-attributes/tests/ui/basic.rs
@@ -17,3 +17,5 @@ fn function_arn(arn: FunctionArn) {
     map.insert("arn", arn.clone());
     prop_assert_eq!(map.get("arn"), Some(&arn));
 }
+
+fn main() {}


### PR DESCRIPTION
(cc: @Centril) 

A WIP implementation of the the proc macros discussed in https://github.com/AltSysrq/proptest/issues/153. This currently supports:

- A single argument + strategy per test.

This does not support:

- Everything else discussed in https://github.com/AltSysrq/proptest/issues/153.

That said, _some_ feedback is better than none, so here we are. The changes are better seen than described, so take a look at the modified `parse_date` example, located in `proptest-attributes/tests/hello.rs`:

```rust
use proptest::{
    prelude::*, prop_assert_eq, strategy::Strategy, string::string_regex,
};
use proptest_attributes::proptest;

fn parse_date(s: &str) -> Option<(u32, u32, u32)> {
    if 10 != s.len() {
        return None;
    }

    // NEW: Ignore non-ASCII strings so we don't need to deal with Unicode.
    if !s.is_ascii() {
        return None;
    }

    if "-" != &s[4..5] || "-" != &s[7..8] {
        return None;
    }

    let year = &s[0..4];
    let month = &s[5..7];
    let day = &s[8..10];

    year.parse::<u32>().ok().and_then(|y| {
        month
            .parse::<u32>()
            .ok()
            .and_then(|m| day.parse::<u32>().ok().map(|d| (y, m, d)))
    })
}

fn gen_valid_date() -> impl Strategy<Value = String> {
    let expr = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
    string_regex(expr).unwrap()
}

fn gen_all_utf8() -> impl Strategy<Value = String> {
    let expr = "\\PC*";
    string_regex(expr).unwrap()
}

prop_compose! {
  fn gen_parsed_date()(year in 0u32..10000, month in 1u32..13, day in 1u32..32) -> (u32, u32, u32) {
    (year, month, day)
  }
}

#[proptest(gen_valid_date())]
fn parses_all_valid_dates(s: String) {
    parse_date(&s).unwrap();
}

#[proptest(gen_all_utf8())]
fn doesnt_crash(s: String) {
    parse_date(&s);
}

#[proptest(gen_parsed_date())]
fn parses_date_back_to_original(date_tuple: (u32, u32, u32)) {
    let (y, m, d) = date_tuple;
    let (y2, m2, d2) =
        parse_date(&format!("{:04}-{:02}-{:02}", y, m, d)).unwrap();
    // prop_assert_eq! is basically the same as assert_eq!, but doesn't
    // cause a bunch of panic messages to be printed on intermediate
    // test failures. Which one to use is largely a matter of taste.
    prop_assert_eq!((y, m, d), (y2, m2, d2));
}
```

I think that, beyond what was described in #153, there might be an opportunity to simplify the `prop_compose!` macro with a proc macro.