### PR TITLE
Return an error when creating a `Tree` for an empty range

### DIFF
--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -55,11 +55,18 @@ macro_rules! int_any {
 
 macro_rules! numeric_api {
     ($typ:ident, $epsilon:expr) => {
+        const EMPTY_RANGE_ERR_MSG: &str = "Empty range cannot be sampled from. \
+            (hint: use an inclusive range (`..=`) instead of an exclusive range (`..`))";
+
         impl Strategy for ::core::ops::Range<$typ> {
             type Tree = BinarySearch;
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                if self.is_empty() {
+                    return Err(EMPTY_RANGE_ERR_MSG.into());
+                }
+
                 Ok(BinarySearch::new_clamped(
                     self.start,
                     $crate::num::sample_uniform(runner, self.clone()),
@@ -90,6 +97,10 @@ macro_rules! numeric_api {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                if self.start == ::core::$typ::MAX {
+                    return Err(EMPTY_RANGE_ERR_MSG.into());
+                }
+
                 Ok(BinarySearch::new_clamped(
                     self.start,
                     $crate::num::sample_uniform_incl(
@@ -107,6 +118,10 @@ macro_rules! numeric_api {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                if self.end == ::core::$typ::MIN {
+                    return Err(EMPTY_RANGE_ERR_MSG.into());
+                }
+
                 Ok(BinarySearch::new_clamped(
                     ::core::$typ::MIN,
                     $crate::num::sample_uniform(


### PR DESCRIPTION
Empty ranges are not valid strategies since no values can be sampled from them. However, it's relatively easy to create one accidentally and pass it to a `proptest`, see #72 and #178. When this happens, the resulting error message does not make it clear that the bug is in the user's code, not in `proptest`. This is different from `SizeRange`, which explicitly checks for empty ranges and provides a helpful hint: 

https://github.com/AltSysrq/proptest/blob/bc2d867a7cd06060e0b565b72fce1d94cc2fe943/proptest/src/collection.rs#L108-L110

This PR makes `new_tree` return an error if called with an empty range. As a result, the user sees a more descriptive error message when they make this mistake:

```
thread 'merge::tests::merge' panicked at 'Test aborted: Empty range cannot be sampled from. (hint: use an inclusive range (`..=`) instead of an exclusive range (`..`))
	successes: 59
	local rejects: 0
	global rejects: 0
', src/merge.rs:152:5
```