### PR TITLE
Use const generics to remove 32 element array size restriction

### DIFF
--- a/proptest/src/arbitrary/arrays.rs
+++ b/proptest/src/arbitrary/arrays.rs
@@ -12,27 +12,12 @@
 use crate::arbitrary::{any_with, Arbitrary};
 use crate::array::UniformArrayStrategy;
 
-macro_rules! array {
-    ($($n: expr),*) => { $(
-        impl<A: Arbitrary> Arbitrary for [A; $n] {
-            type Parameters = A::Parameters;
-            type Strategy = UniformArrayStrategy<A::Strategy, [A; $n]>;
-            fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
-                let base = any_with::<A>(args);
-                UniformArrayStrategy::new(base)
-            }
-        }
-    )* };
-}
+impl<A: Arbitrary, const N: usize> Arbitrary for [A; N] {
+    type Parameters = A::Parameters;
+    type Strategy = UniformArrayStrategy<A::Strategy, [A; N]>;
 
-array!(
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-    22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
-);
-
-#[cfg(test)]
-mod test {
-    no_panic_test!(
-        array_16 => [u8; 16]
-    );
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        let base = any_with::<A>(args);
+        UniformArrayStrategy::new(base)
+    }
 }

--- a/proptest/src/array.rs
+++ b/proptest/src/array.rs
@@ -18,6 +18,10 @@
 //!
 //! General implementations are available for sizes 1 through 32.
 
+use crate::std_facade::vec::Vec;
+
+use core::convert::TryInto;
+use core::iter;
 use core::marker::PhantomData;
 
 use crate::strategy::*;
@@ -80,8 +84,112 @@ pub struct ArrayValueTree<T> {
     last_shrinker: Option<usize>,
 }
 
+/// Create a strategy to generate fixed-length arrays.
+///
+/// All values within the new strategy are generated using the given
+/// strategy. The length of the array corresponds to the suffix of the
+/// name of this function.
+///
+/// See [`UniformArrayStrategy`](struct.UniformArrayStrategy.html) for
+/// example usage.
+pub fn uniform<S: Strategy, const N: usize>(
+    strategy: S,
+) -> UniformArrayStrategy<S, [S::Value; N]> {
+    UniformArrayStrategy {
+        strategy,
+        _marker: PhantomData,
+    }
+}
+
+impl<S: Strategy, const N: usize> Strategy for [S; N] {
+    type Tree = ArrayValueTree<[S::Tree; N]>;
+    type Value = [S::Value; N];
+
+    fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+        let tree_vec = self
+            .iter()
+            .map(|strategy| strategy.new_tree(runner))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let tree = match tree_vec.try_into() {
+            Ok(tree) => tree,
+            Err(_) => panic!("Incorrect tree length"),
+        };
+
+        Ok(ArrayValueTree {
+            tree,
+            shrinker: 0,
+            last_shrinker: None,
+        })
+    }
+}
+
+impl<S: Strategy, const N: usize> Strategy
+    for UniformArrayStrategy<S, [S::Value; N]>
+{
+    type Tree = ArrayValueTree<[S::Tree; N]>;
+    type Value = [S::Value; N];
+
+    fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+        let tree_vec = iter::repeat_with(|| self.strategy.new_tree(runner))
+            .take(N)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let tree = match tree_vec.try_into() {
+            Ok(tree) => tree,
+            Err(_) => unreachable!("Incorrect tree length"),
+        };
+
+        Ok(ArrayValueTree {
+            tree,
+            shrinker: 0,
+            last_shrinker: None,
+        })
+    }
+}
+
+impl<T: ValueTree, const N: usize> ValueTree for ArrayValueTree<[T; N]> {
+    type Value = [T::Value; N];
+
+    fn current(&self) -> [T::Value; N] {
+        self.tree
+            .iter()
+            .map(|tree| tree.current())
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("Incorrect tree size")
+    }
+
+    fn simplify(&mut self) -> bool {
+        while self.shrinker < N {
+            if self.tree[self.shrinker].simplify() {
+                self.last_shrinker = Some(self.shrinker);
+                return true;
+            } else {
+                self.shrinker += 1;
+            }
+        }
+
+        false
+    }
+
+    fn complicate(&mut self) -> bool {
+        if let Some(shrinker) = self.last_shrinker {
+            self.shrinker = shrinker;
+            if self.tree[shrinker].complicate() {
+                true
+            } else {
+                self.last_shrinker = None;
+                false
+            }
+        } else {
+            false
+        }
+    }
+}
+
 macro_rules! small_array {
-    ($n:tt $uni:ident : $($ix:expr),*) => {
+    ($n:tt $uni:ident) => {
         /// Create a strategy to generate fixed-length arrays.
         ///
         /// All values within the new strategy are generated using the given
@@ -90,160 +198,46 @@ macro_rules! small_array {
         ///
         /// See [`UniformArrayStrategy`](struct.UniformArrayStrategy.html) for
         /// example usage.
-        pub fn $uni<S : Strategy>
-            (strategy: S) -> UniformArrayStrategy<S, [S::Value; $n]>
-        {
-            UniformArrayStrategy {
-                strategy,
-                _marker: PhantomData
-            }
+        pub fn $uni<S: Strategy>(
+            strategy: S,
+        ) -> UniformArrayStrategy<S, [S::Value; $n]> {
+            uniform(strategy)
         }
-
-        impl<S : Strategy> Strategy for [S; $n] {
-            type Tree = ArrayValueTree<[S::Tree; $n]>;
-            type Value = [S::Value; $n];
-
-            fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-                Ok(ArrayValueTree {
-                    tree: [$(self[$ix].new_tree(runner)?,)*],
-                    shrinker: 0,
-                    last_shrinker: None,
-                })
-            }
-        }
-
-        impl<S : Strategy> Strategy
-        for UniformArrayStrategy<S, [S::Value; $n]> {
-            type Tree = ArrayValueTree<[S::Tree; $n]>;
-            type Value = [S::Value; $n];
-
-            fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-                Ok(ArrayValueTree {
-                    tree: [$({
-                        let _ = $ix;
-                        self.strategy.new_tree(runner)?
-                    },)*],
-                    shrinker: 0,
-                    last_shrinker: None,
-                })
-            }
-        }
-
-        impl<T : ValueTree> ValueTree for ArrayValueTree<[T;$n]> {
-            type Value = [T::Value;$n];
-
-            fn current(&self) -> [T::Value;$n] {
-                [$(self.tree[$ix].current(),)*]
-            }
-
-            fn simplify(&mut self) -> bool {
-                while self.shrinker < $n {
-                    if self.tree[self.shrinker].simplify() {
-                        self.last_shrinker = Some(self.shrinker);
-                        return true;
-                    } else {
-                        self.shrinker += 1;
-                    }
-                }
-
-                false
-            }
-
-            fn complicate(&mut self) -> bool {
-                if let Some(shrinker) = self.last_shrinker {
-                    self.shrinker = shrinker;
-                    if self.tree[shrinker].complicate() {
-                        true
-                    } else {
-                        self.last_shrinker = None;
-                        false
-                    }
-                } else {
-                    false
-                }
-            }
-        }
-    }
+    };
 }
 
-small_array!(1 uniform1:
-             0);
-small_array!(2 uniform2:
-             0, 1);
-small_array!(3 uniform3:
-             0, 1, 2);
-small_array!(4 uniform4:
-             0, 1, 2, 3);
-small_array!(5 uniform5:
-             0, 1, 2, 3, 4);
-small_array!(6 uniform6:
-             0, 1, 2, 3, 4, 5);
-small_array!(7 uniform7:
-             0, 1, 2, 3, 4, 5, 6);
-small_array!(8 uniform8:
-             0, 1, 2, 3, 4, 5, 6, 7);
-small_array!(9 uniform9:
-             0, 1, 2, 3, 4, 5, 6, 7, 8);
-small_array!(10 uniform10:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-small_array!(11 uniform11:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-small_array!(12 uniform12:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-small_array!(13 uniform13:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
-small_array!(14 uniform14:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
-small_array!(15 uniform15:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-small_array!(16 uniform16:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-small_array!(17 uniform17:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-small_array!(18 uniform18:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17);
-small_array!(19 uniform19:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18);
-small_array!(20 uniform20:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19);
-small_array!(21 uniform21:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20);
-small_array!(22 uniform22:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21);
-small_array!(23 uniform23:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21, 22);
-small_array!(24 uniform24:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21, 22, 23);
-small_array!(25 uniform25:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21, 22, 23, 24);
-small_array!(26 uniform26:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21, 22, 23, 24, 25);
-small_array!(27 uniform27:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21, 22, 23, 24, 25, 26);
-small_array!(28 uniform28:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21, 22, 23, 24, 25, 26, 27);
-small_array!(29 uniform29:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28);
-small_array!(30 uniform30:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29);
-small_array!(31 uniform31:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30);
-small_array!(32 uniform32:
-             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-             18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
+small_array!(1 uniform1);
+small_array!(2 uniform2);
+small_array!(3 uniform3);
+small_array!(4 uniform4);
+small_array!(5 uniform5);
+small_array!(6 uniform6);
+small_array!(7 uniform7);
+small_array!(8 uniform8);
+small_array!(9 uniform9);
+small_array!(10 uniform10);
+small_array!(11 uniform11);
+small_array!(12 uniform12);
+small_array!(13 uniform13);
+small_array!(14 uniform14);
+small_array!(15 uniform15);
+small_array!(16 uniform16);
+small_array!(17 uniform17);
+small_array!(18 uniform18);
+small_array!(19 uniform19);
+small_array!(20 uniform20);
+small_array!(21 uniform21);
+small_array!(22 uniform22);
+small_array!(23 uniform23);
+small_array!(24 uniform24);
+small_array!(25 uniform25);
+small_array!(26 uniform26);
+small_array!(27 uniform27);
+small_array!(28 uniform28);
+small_array!(29 uniform29);
+small_array!(30 uniform30);
+small_array!(31 uniform31);
+small_array!(32 uniform32);
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
This PR replaces the macro generated code for small arrays (with less than 32 elements) with const-generic code that have no size restrictions. I'm not sure if this is a desired feature, but I found it could be useful to me so I gave a shot at trying to implement it. The `uniform{1..32}` functions are still generated as "proxy functions" in order to keep backwards compatibility.