### PR TITLE
Use pretty printing for minimal input

### DIFF
--- a/proptest/src/test_runner/errors.rs
+++ b/proptest/src/test_runner/errors.rs
@@ -92,7 +92,7 @@ impl<T: fmt::Debug> fmt::Display for TestError<T> {
             TestError::Abort(ref why) => write!(f, "Test aborted: {}", why),
             TestError::Fail(ref why, ref what) => write!(
                 f,
-                "Test failed: {}; minimal failing input: {:?}",
+                "Test failed: {}; minimal failing input: {:#?}",
                 why, what
             ),
         }

--- a/proptest/src/test_runner/errors.rs
+++ b/proptest/src/test_runner/errors.rs
@@ -90,11 +90,10 @@ impl<T: fmt::Debug> fmt::Display for TestError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TestError::Abort(ref why) => write!(f, "Test aborted: {}", why),
-            TestError::Fail(ref why, ref what) => write!(
-                f,
-                "Test failed: {}; minimal failing input: {:#?}",
-                why, what
-            ),
+            TestError::Fail(ref why, ref what) => {
+                writeln!(f, "Test failed: {}.", why)?;
+                write!(f, "minimal failing input: {:#?}", what)
+            },
         }
     }
 }


### PR DESCRIPTION
This PR changes the `minimal failing output` to use *pretty-printed* `Debug` output instead of the default `Debug` output. The current status quo is that for complicated data structures, the output is borderline unreadable. Pretty printing using `{:#?}` alleviates this. I believe pretty-printing is the right thing to do in virtually all cases.

I also believe that this does not constitute a breaking change.