### PR TITLE
Fix bounds generation for generics in derive(Arbitrary)

### DIFF
--- a/proptest-derive/tests/use_tracker.rs
+++ b/proptest-derive/tests/use_tracker.rs
@@ -1,0 +1,30 @@
+// Copyright 2018 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::marker::PhantomData;
+
+use proptest::prelude::Arbitrary;
+use proptest_derive::Arbitrary;
+
+#[derive(Debug)]
+struct NotArbitrary;
+
+#[derive(Debug, Arbitrary)]
+// Generic types are not in alphabetical order on purpose.
+struct Foo<V, T, U> {
+    v: V,
+    t: T,
+    u: PhantomData<U>,
+}
+
+#[test]
+fn asserting_arbitrary() {
+    fn assert_arbitrary<T: Arbitrary>() {}
+
+    assert_arbitrary::<Foo<i32, i32, NotArbitrary>>();
+}


### PR DESCRIPTION
The implementation of UseTracker expects that iteration over items of
used_map gives items in insertion order. However, the order of BTreeSet
is based on Ord, not insertion.

I use a Vec of tuples. An alternative would be indexmap crate, but since
the maps are supposed to be very small, it is probably not worthy. There
already was a mention about the crate in the comments worrying about
compile times.