### PR TITLE
note that PROPTEST_CASES env var requires the std feature

### DIFF
--- a/book/src/proptest/tutorial/config.md
+++ b/book/src/proptest/tutorial/config.md
@@ -6,9 +6,8 @@ and want to run more or fewer, there are a few ways to do this.
 
 The first way is to set the environment-variable `PROPTEST_CASES` to a
 value that can be successfully parsed as a `u32`. The value you set to this
-variable is now the new default.
-(This only applies when the `std` feature of proptest is enabled, which it is by
-default.)
+variable is now the new default. (This only applies when the `std` feature of
+proptest is enabled, which it is by default.)
 
 Another way is to use `#![proptest_config(expr)]` inside `proptest!` where
 `expr : Config`. To only change the number of test cases, you can simply

--- a/book/src/proptest/tutorial/config.md
+++ b/book/src/proptest/tutorial/config.md
@@ -7,6 +7,8 @@ and want to run more or fewer, there are a few ways to do this.
 The first way is to set the environment-variable `PROPTEST_CASES` to a
 value that can be successfully parsed as a `u32`. The value you set to this
 variable is now the new default.
+(This only applies when the `std` feature of proptest is enabled, which it is by
+default.)
 
 Another way is to use `#![proptest_config(expr)]` inside `proptest!` where
 `expr : Config`. To only change the number of test cases, you can simply

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -182,7 +182,8 @@ pub struct Config {
     /// This does not include implicitly-replayed persisted failing cases.
     ///
     /// The default is 256, which can be overridden by setting the
-    /// `PROPTEST_CASES` environment variable.
+    /// `PROPTEST_CASES` environment variable. (This only applies when the `std`
+    /// feature is enabled, which it is by default.)
     pub cases: u32,
 
     /// The maximum number of individual inputs that may be rejected before the

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -346,8 +346,7 @@ pub struct Config {
     /// since on nostd proptest has no way to produce output.
     ///
     /// The default is `0`, which can be overridden by setting the
-    /// `PROPTEST_VERBOSE` environment variable. (The variable is only
-    /// considered when the `std` feature is enabled, which it is by default.)
+    /// `PROPTEST_VERBOSE` environment variable.
     #[cfg(feature = "std")]
     pub verbose: u32,
 

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -182,22 +182,25 @@ pub struct Config {
     /// This does not include implicitly-replayed persisted failing cases.
     ///
     /// The default is 256, which can be overridden by setting the
-    /// `PROPTEST_CASES` environment variable. (This only applies when the `std`
-    /// feature is enabled, which it is by default.)
+    /// `PROPTEST_CASES` environment variable. (The variable is only considered
+    /// when the `std` feature is enabled, which it is by default.)
     pub cases: u32,
 
     /// The maximum number of individual inputs that may be rejected before the
     /// test as a whole aborts.
     ///
     /// The default is 65536, which can be overridden by setting the
-    /// `PROPTEST_MAX_LOCAL_REJECTS` environment variable.
+    /// `PROPTEST_MAX_LOCAL_REJECTS` environment variable. (The variable is only
+    /// considered when the `std` feature is enabled, which it is by default.)
     pub max_local_rejects: u32,
 
     /// The maximum number of combined inputs that may be rejected before the
     /// test as a whole aborts.
     ///
     /// The default is 1024, which can be overridden by setting the
-    /// `PROPTEST_MAX_GLOBAL_REJECTS` environment variable.
+    /// `PROPTEST_MAX_GLOBAL_REJECTS` environment variable. (The variable is
+    /// only considered when the `std` feature is enabled, which it is by
+    /// default.)
     pub max_global_rejects: u32,
 
     /// The maximum number of times all `Flatten` combinators will attempt to
@@ -205,7 +208,9 @@ pub struct Config {
     /// explosion that can happen with nested `Flatten`s.
     ///
     /// The default is 1_000_000, which can be overridden by setting the
-    /// `PROPTEST_MAX_FLAT_MAP_REGENS` environment variable.
+    /// `PROPTEST_MAX_FLAT_MAP_REGENS` environment variable. (The variable is
+    /// only considered when the `std` feature is enabled, which it is by
+    /// default.)
     pub max_flat_map_regens: u32,
 
     /// Indicates whether and how to persist failed test results.
@@ -272,7 +277,9 @@ pub struct Config {
     /// aborted.
     ///
     /// The default is `0` (i.e., no timeout), which can be overridden by
-    /// setting the `PROPTEST_TIMEOUT` environment variable.
+    /// setting the `PROPTEST_TIMEOUT` environment variable. (The variable is
+    /// only considered when the `std` feature is enabled, which it is by
+    /// default.)
     #[cfg(feature = "timeout")]
     pub timeout: u32,
 
@@ -285,7 +292,9 @@ pub struct Config {
     /// (which it is by default).
     ///
     /// The default is `0` (i.e., no limit), which can be overridden by setting
-    /// the `PROPTEST_MAX_SHRINK_TIME` environment variable.
+    /// the `PROPTEST_MAX_SHRINK_TIME` environment variable. (The variable is
+    /// only considered when the `std` feature is enabled, which it is by
+    /// default.)
     #[cfg(feature = "std")]
     pub max_shrink_time: u32,
 
@@ -301,7 +310,8 @@ pub struct Config {
     /// proptest to better accommodate its special values.
     ///
     /// The default is `std::u32::MAX`, which can be overridden by setting the
-    /// `PROPTEST_MAX_SHRINK_ITERS` environment variable.
+    /// `PROPTEST_MAX_SHRINK_ITERS` environment variable. (The variable is only
+    /// considered when the `std` feature is enabled, which it is by default.)
     pub max_shrink_iters: u32,
 
     /// A function to create new result caches.
@@ -336,7 +346,8 @@ pub struct Config {
     /// since on nostd proptest has no way to produce output.
     ///
     /// The default is `0`, which can be overridden by setting the
-    /// `PROPTEST_VERBOSE` environment variable.
+    /// `PROPTEST_VERBOSE` environment variable. (The variable is only
+    /// considered when the `std` feature is enabled, which it is by default.)
     #[cfg(feature = "std")]
     pub verbose: u32,
 
@@ -347,6 +358,9 @@ pub struct Config {
     ///
     /// - `xs` — `RngAlgorithm::XorShift`
     /// - `cc` — `RngAlgorithm::ChaCha`
+    ///
+    /// (The variable is only considered when the `std` feature is enabled,
+    /// which it is by default.)
     pub rng_algorithm: RngAlgorithm,
 
     // Needs to be public so FRU syntax can be used.


### PR DESCRIPTION
I just lost a whole bunch of time trying to figure out why setting `PROPTEST_CASES` has no effect, until I read its code and saw that this relies on the `std` feature. Would be better to document that more clearly.