### PR TITLE
proptest-derive: upgrade to stable proc macro ecosystem

### DIFF
--- a/proptest-derive/Cargo.toml
+++ b/proptest-derive/Cargo.toml
@@ -32,10 +32,10 @@ compiletest_rs = { version = "0.3.19", features = ["tmp", "stable"] }
 criterion = "0.2"
 
 [dependencies]
-proc-macro2 = "0.4"
+proc-macro2 = "1.0"
 
-syn = { version = "0.15.17", features = ["visit", "extra-traits", "full"] }
-quote = "0.6"
+syn = { version = "1.0", features = ["visit", "extra-traits", "full"] }
+quote = "1.0"
 
 [[bench]]
 name = "large_enum"

--- a/proptest-derive/src/ast.rs
+++ b/proptest-derive/src/ast.rs
@@ -805,6 +805,6 @@ struct Tuple<I>(I);
 impl<T: ToTokens, I: Clone + IntoIterator<Item = T>> ToTokens for Tuple<I> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let iter = self.0.clone();
-        quote_append!(tokens, ( #(#iter),* ) );
+        tokens.append_all(iter);
     }
 }

--- a/proptest-derive/src/error.rs
+++ b/proptest-derive/src/error.rs
@@ -426,9 +426,9 @@ error!(
 error!(
     set_again(meta: &syn::Meta),
     E0017,
-    "The attribute modifier `{}` inside `#[proptest(..)]` has already been \
+    "The attribute modifier `{:?}` inside `#[proptest(..)]` has already been \
      set. To fix the error, please remove at least one such modifier.",
-    meta.name()
+    meta.path()
 );
 
 // Happens when `<modifier>` in `#[proptest(<modifier>)]` is unknown to
@@ -472,11 +472,11 @@ error!(
 error!(
     weight_malformed(meta: &syn::Meta),
     E0021,
-    "The attribute modifier `{0}` inside `#[proptest(..)]` must have the \
-    format `#[proptest({0} = <integer>)]` where `<integer>` is an integer that \
-    fits within a `u32`. An example: `#[proptest({0} = 2)]` to set a relative \
+    "The attribute modifier `{0:?}` inside `#[proptest(..)]` must have the \
+    format `#[proptest({0:?} = <integer>)]` where `<integer>` is an integer that \
+    fits within a `u32`. An example: `#[proptest({0:?} = 2)]` to set a relative \
     weight of 2.",
-    meta.name()
+    meta.path()
 );
 
 // Happens when both `#[proptest(params = "<type>")]` and
@@ -526,10 +526,10 @@ fatal!(
 error!(
     strategy_malformed(meta: &syn::Meta),
     E0026,
-    "The attribute modifier `{0}` inside `#[proptest(..)]` must have the \
-     format `#[proptest({0} = \"<expr>\")]` where `<expr>` is a valid Rust \
+    "The attribute modifier `{0:?}` inside `#[proptest(..)]` must have the \
+     format `#[proptest({0:?} = \"<expr>\")]` where `<expr>` is a valid Rust \
      expression.",
-    meta.name()
+    meta.path()
 );
 
 // Happens when `#[proptest(filter..)]` is malformed.
@@ -538,10 +538,10 @@ error!(
 error!(
     filter_malformed(meta: &syn::Meta),
     E0027,
-    "The attribute modifier `{0}` inside `#[proptest(..)]` must have the \
-     format `#[proptest({0} = \"<expr>\")]` where `<expr>` is a valid Rust \
+    "The attribute modifier `{0:?}` inside `#[proptest(..)]` must have the \
+     format `#[proptest({0:?} = \"<expr>\")]` where `<expr>` is a valid Rust \
      expression.",
-    meta.name()
+    meta.path()
 );
 
 // Any attributes on a skipped variant has no effect - so we emit this error


### PR DESCRIPTION
Upgrade proptest-derive to the stable versions of proc-macro2, syn, and
quote.