### PR TITLE
Update x86 dependency.

### DIFF
--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -112,7 +112,7 @@ version = "3.0"
 optional = true
 
 [dependencies.x86]
-version = "0.33.0"
+version = "0.47.0"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
Make sure to replace legacy llvm inline assembly with new asm syntax by updating the x86 crate to the latest version.

Fixes compilation for `hardware-rng` feature on current rustc versions.