### PR TITLE
Make tests pass and improve shrinking for prop_flat_map

### DIFF
--- a/proptest-derive/Cargo.toml
+++ b/proptest-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "proptest-derive"
-version       = "0.3.0"
+version       = "0.3.1"
 authors       = ["Mazdak Farrokhzad <twingoow@gmail.com>"]
 license       = "MIT/Apache-2.0"
 readme        = "README.md"
@@ -22,7 +22,7 @@ edition = "2018"
 proc-macro = true
 
 [dev-dependencies]
-proptest = { version = "1.0.0", path = "../proptest" }
+proptest = { version = "1.1.0", path = "../proptest" }
 # We don't actually run the tests on stable since some of them use nightly
 # features. However, due to
 # https://github.com/laumann/compiletest-rs/issues/166, the default features of

--- a/proptest-derive/Cargo.toml
+++ b/proptest-derive/Cargo.toml
@@ -27,7 +27,7 @@ proptest = { version = "1.0.0", path = "../proptest" }
 # features. However, due to
 # https://github.com/laumann/compiletest-rs/issues/166, the default features of
 # compiletest-rs fail to compile, but the stable fallback works fine.
-compiletest_rs = { version = "0.3.19", features = ["tmp", "stable"] }
+compiletest_rs = { version = "0.8.0", features = ["tmp", "stable"] }
 # criterion is used for benchmarks.
 criterion = "0.2"
 

--- a/proptest-derive/tests/compile-fail/no-arbitrary.rs
+++ b/proptest-derive/tests/compile-fail/no-arbitrary.rs
@@ -13,5 +13,5 @@ fn main() {}
 
 struct T0;
 
-#[derive(Debug, Arbitrary)] //~ Arbitrary` is not satisfied [E0277]
-struct T1 { f0: T0, }
+#[derive(Debug, Arbitrary)] //~ ERROR Arbitrary` is not satisfied [E0277]
+struct T1 { f0: T0, }       //~ ERROR Arbitrary` is not satisfied [E0277]

--- a/proptest-derive/tests/compiletest.rs
+++ b/proptest-derive/tests/compiletest.rs
@@ -17,7 +17,7 @@ fn run_mode(src: &'static str, mode: &'static str) {
     config.target_rustcflags =
         Some("-L ../target/debug/deps --edition=2018".to_owned());
     if let Ok(name) = env::var("TESTNAME") {
-        config.filter = Some(name);
+        config.filters = vec![name];
     }
     config.src_base = format!("tests/{}", src).into();
 

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -1,3 +1,20 @@
+## Unreleased
+
+### Breaking Changes
+
+- `prop_flat_map` can only be used with closures that produce a strategy that
+  implements `Copy`.
+
+- Half-bounded ranges (`x..`, `..x`, and `..=x`) are no longer supported for
+  `f32` and `f64`.
+
+### New Features
+
+- The shrink strategy for `prop_flat_map` now shrinks the "outer" strategy
+  first (the one that produces the values given to `prop_flat_map`) and
+  shrinks the "inner" strategy" (the one produced by `prop_flat_map`) only
+  when the outer strategy cannot be shrunk further.
+
 ## 1.0.0
 
 ### Breaking Changes

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proptest"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Jason Lingle"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -53,7 +53,7 @@ macro_rules! int_any {
     };
 }
 
-macro_rules! numeric_api {
+macro_rules! int_api {
     ($typ:ident, $epsilon:expr) => {
         impl Strategy for ::core::ops::Range<$typ> {
             type Tree = BinarySearch;
@@ -131,6 +131,40 @@ macro_rules! numeric_api {
                         self.end,
                     ),
                     self.end,
+                ))
+            }
+        }
+    };
+}
+
+macro_rules! float_api {
+    ($typ:ident, $epsilon:expr) => {
+        impl Strategy for ::core::ops::Range<$typ> {
+            type Tree = BinarySearch;
+            type Value = $typ;
+
+            fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                Ok(BinarySearch::new_clamped(
+                    self.start,
+                    $crate::num::sample_uniform(runner, self.clone()),
+                    self.end - $epsilon,
+                ))
+            }
+        }
+
+        impl Strategy for ::core::ops::RangeInclusive<$typ> {
+            type Tree = BinarySearch;
+            type Value = $typ;
+
+            fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                Ok(BinarySearch::new_clamped(
+                    *self.start(),
+                    $crate::num::sample_uniform_incl(
+                        runner,
+                        *self.start(),
+                        *self.end(),
+                    ),
+                    *self.end(),
                 ))
             }
         }
@@ -234,7 +268,7 @@ macro_rules! signed_integer_bin_search {
                 }
             }
 
-            numeric_api!($typ, 1);
+            int_api!($typ, 1);
         }
     };
 }
@@ -322,7 +356,7 @@ macro_rules! unsigned_integer_bin_search {
                 }
             }
 
-            numeric_api!($typ, 1);
+            int_api!($typ, 1);
         }
     };
 }
@@ -842,7 +876,7 @@ macro_rules! float_bin_search {
                 }
             }
 
-            numeric_api!($typ, 0.0);
+            float_api!($typ, 0.0);
         }
     };
 }
@@ -1032,7 +1066,7 @@ mod test {
     }
 
     mod contract_sanity {
-        macro_rules! contract_sanity {
+        macro_rules! contract_sanity_int {
             ($t:tt) => {
                 mod $t {
                     use crate::strategy::check_strategy_sanity;
@@ -1067,18 +1101,40 @@ mod test {
                 }
             };
         }
-        contract_sanity!(u8);
-        contract_sanity!(i8);
-        contract_sanity!(u16);
-        contract_sanity!(i16);
-        contract_sanity!(u32);
-        contract_sanity!(i32);
-        contract_sanity!(u64);
-        contract_sanity!(i64);
-        contract_sanity!(usize);
-        contract_sanity!(isize);
-        contract_sanity!(f32);
-        contract_sanity!(f64);
+
+        macro_rules! contract_sanity_float {
+            ($t:tt) => {
+                mod $t {
+                    use crate::strategy::check_strategy_sanity;
+
+                    const FOURTY_TWO: $t = 42 as $t;
+                    const FIFTY_SIX: $t = 56 as $t;
+
+                    #[test]
+                    fn range() {
+                        check_strategy_sanity(FOURTY_TWO..FIFTY_SIX, None);
+                    }
+
+                    #[test]
+                    fn range_inclusive() {
+                        check_strategy_sanity(FOURTY_TWO..=FIFTY_SIX, None);
+                    }
+                }
+            };
+        }
+
+        contract_sanity_int!(u8);
+        contract_sanity_int!(i8);
+        contract_sanity_int!(u16);
+        contract_sanity_int!(i16);
+        contract_sanity_int!(u32);
+        contract_sanity_int!(i32);
+        contract_sanity_int!(u64);
+        contract_sanity_int!(i64);
+        contract_sanity_int!(usize);
+        contract_sanity_int!(isize);
+        contract_sanity_float!(f32);
+        contract_sanity_float!(f64);
     }
 
     #[test]


### PR DESCRIPTION
This pull request aims to address issues #268 and #181, alas by introducing some potentially but hopefully minor breaking changes.  I'm more than happy to discuss whether there's a better way to implement these improvements, without breaking anything or at least breaking less.

The tests in `proptest` and `proptest-derive` all pass again. This came at the cost of removing half-bounded ranges as strategies for `f32` and `f64`. Those were the failing tests for `proptest`. After looking at how the `rand` crate generates floats in a range and how `proptest` tries to use that generator, I concluded that there is no way to make the tests pass. Moreover, the tests are fairly representative of what should be a common use of half-bounded float ranges as strategies, so they would fail also in real-world use and simply shouldn't be supported.

In my opinion, the current shrinking strategy for values produced by `prop_flat_map` is almost always a poor choice. It first tries to shrink the inner value and only when this fails, shrinks the outer value on which the inner value depends. I ran into this when trying to generate a graph with a number of vertices and a set of vectors that store attributes, one per vertex. The most natural way to do this is to generate the number of vertices and then `prop_flat_map` this to a strategy that generates a graph with that number of vertices and a set of vectors, each of this length. Shrinking is completely ineffective here because it will try tons of possibilities of messing with the vector entries and with the edge set of the graph before trying to shrink the number of vertices. As a result, shrinking will either take hours or will fail to produce a meaningfully shrunk input, depending on the bound on the number of shrinks.

I reimplemented the shrinking strategy for `FlattenValueTree` so it shrinks the outer value first and only when that fails, refines the result by shrinking the inner value. Unfortunately, given the API in the `Strategy` trait, I didn't see a way to do this without requiring that the strategy produced by the closure given to `prop_flat_map` implement `Clone`, a requirement that wasn't there before. This may break some custom strategies, but I expect it to break less code than trying to mess with the `Strategy` trait itself and, at least in my use cases, seems like a small price to pay for getting a useful shrinking strategy from `prop_flat_map`.

As I said above, I expect some objections to these changes and am more than happy to discuss whether this can be done better.  However, I think the change to the shrinking strategy of `FlattenValueTree` is crucial, only its implementation may be suboptimal.