### PR TITLE
[fix-ci-nigtly] 

### DIFF
--- a/proptest-derive/Cargo.toml
+++ b/proptest-derive/Cargo.toml
@@ -27,7 +27,7 @@ proptest = { version = "1.0.0", path = "../proptest" }
 # features. However, due to
 # https://github.com/laumann/compiletest-rs/issues/166, the default features of
 # compiletest-rs fail to compile, but the stable fallback works fine.
-compiletest_rs = { version = "0.3.19", features = ["tmp", "stable"] }
+compiletest_rs = { version = "0.9", features = ["tmp", "stable"] }
 # criterion is used for benchmarks.
 criterion = "0.2"
 

--- a/proptest-derive/src/error.rs
+++ b/proptest-derive/src/error.rs
@@ -165,7 +165,7 @@ impl Context {
         self.errors.push(msg.to_string());
     }
 
-    /// Add an error to the context and procuce and produce an erroring
+    /// Add an error to the context and produce an erroring
     /// computation that will halt the macro.
     pub fn fatal<T: Display, A>(&mut self, msg: T) -> DeriveResult<A> {
         self.error(msg);

--- a/proptest-derive/tests/compile-fail/no-arbitrary.rs
+++ b/proptest-derive/tests/compile-fail/no-arbitrary.rs
@@ -13,5 +13,5 @@ fn main() {}
 
 struct T0;
 
-#[derive(Debug, Arbitrary)] //~ Arbitrary` is not satisfied [E0277]
-struct T1 { f0: T0, }
+#[derive(Debug, Arbitrary)] //~ the trait bound `T0: Arbitrary` is not satisfied [E0277]
+struct T1 { f0: T0, } //~ the trait bound `T0: Arbitrary` is not satisfied [E0277]

--- a/proptest-derive/tests/compiletest.rs
+++ b/proptest-derive/tests/compiletest.rs
@@ -17,7 +17,7 @@ fn run_mode(src: &'static str, mode: &'static str) {
     config.target_rustcflags =
         Some("-L ../target/debug/deps --edition=2018".to_owned());
     if let Ok(name) = env::var("TESTNAME") {
-        config.filter = Some(name);
+        config.filters = vec![name];
     }
     config.src_base = format!("tests/{}", src).into();
 

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 - Sampling from large ranges of floats such as `(0f32)..` no longer panics
   with newer versions of the `rand` crate
+- [dependencies.x86] was bumped to latest current version. x86 crate does
+  was on a very old version 0.33.0 which used a removed macro from rust.
+- The calculation for the arbitrary impl of Layout was using a max_size that
+  was too large and overflowing Layout. This has been fixed.
+- Test for arbitrary AllocError was referring to AllocErr which
+  does not exist, this was fixed.
+- NoneError has been removed from rust so it was subsequently
+  removed from proptest. It was blocking compilation. evidence:
+  https://github.com/rust-lang/rust/issues/85614
+- `try_reserve` is stable so removed from unstable features
+- `try_trait` has been changed to `try_trait_v2` so that was adjusted
+  in `Cargo.toml`.
 
 ### New Features
 
@@ -641,7 +653,7 @@ features.
   These are "higher order" `Arbitrary` traits that correspond to the `Arbitrary1`
   and `Arbitrary2` type classes in Haskell's QuickCheck. They are mainly provided
   to support a common set of container-like types in custom deriving self-recursive
-  types in  `proptest_derive`. More on this later releases.
+  types in `proptest_derive`. More on this later releases.
 
 - The strategies in `proptest::option` and `proptest::result` now accept a type
   `Probability` which is a wrapper around `f64`. Conversions from types such as

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -68,8 +68,10 @@ version = "1.2"
 optional = true
 
 [dependencies.num-traits]
-version = "0.2.2"
+version = "0.2.15"
 default-features = false
+# std or libm required for mul_add.
+features = ["libm"]
 
 [dependencies.quick-error]
 version = "2.0.0"

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -113,7 +113,7 @@ version = "3.0"
 optional = true
 
 [dependencies.x86]
-version = "0.33.0"
+version = "0.52.0"
 optional = true
 
 [dev-dependencies]

--- a/proptest/src/arbitrary/_alloc/alloc.rs
+++ b/proptest/src/arbitrary/_alloc/alloc.rs
@@ -29,7 +29,9 @@ arbitrary!(self::alloc::Layout, SFnPtrMap<(Range<u8>, StrategyFor<usize>), Self>
     // 2. "when rounded up to the nearest multiple of align, must not overflow".
     static_map((0u8..32u8, any::<usize>()), |(align_power, size)| {
         let align = 1usize << align_power;
-        let max_size = 0usize.wrapping_sub(align);
+        // TODO: This may only work on 64 bit processors, but previously it was broken
+        // even on 64 bit so still an improvement. 63 -> uint size - 1.
+        let max_size = (1usize << 63) - (1 << usize::from(align_power));
         // Not quite a uniform distribution due to clamping,
         // but probably good enough
         self::alloc::Layout::from_size_align(cmp::min(max_size, size), align).unwrap()
@@ -51,7 +53,7 @@ mod test {
 
     no_panic_test!(
         layout => self::alloc::Layout,
-        alloc_err => self::alloc::AllocErr
+        alloc_err => self::alloc::AllocError
         //collection_alloc_err => alloc::collections::CollectionAllocErr
     );
 }

--- a/proptest/src/arbitrary/_core/option.rs
+++ b/proptest/src/arbitrary/_core/option.rs
@@ -46,9 +46,6 @@ lift1!(['static] opt::IntoIter<A>, Probability;
     base, prob => weighted(prob, base).prop_map(Option::into_iter)
 );
 
-#[cfg(feature = "unstable")]
-arbitrary!(opt::NoneError; opt::NoneError);
-
 #[cfg(test)]
 mod test {
     no_panic_test!(

--- a/proptest/src/lib.rs
+++ b/proptest/src/lib.rs
@@ -26,10 +26,9 @@
     feature = "unstable",
     feature(
         allocator_api,
-        try_trait,
+        try_trait_v2,
         generator_trait,
-        never_type,
-        try_reserve
+        never_type
     )
 )]
 #![cfg_attr(all(feature = "std", feature = "unstable"), feature(ip))]

--- a/proptest/src/num/float_samplers.rs
+++ b/proptest/src/num/float_samplers.rs
@@ -21,6 +21,8 @@ macro_rules! float_sampler {
             use rand::distributions::uniform::{
                 SampleBorrow, SampleUniform, Uniform, UniformSampler,
             };
+            #[cfg(not(feature = "std"))]
+            use num_traits::float::Float;
 
             #[must_use]
             // Returns the previous float value. In other words the greatest value representable


### PR DESCRIPTION
ci was broken on nightly this series of fixes should correct it

* dependencies.x86 was bumped to latest current version. x86 crate does not advertise an MSRV, but this was just broken on even our MSRV because the old x86 version was using a macro removed from rust, so bumping to latest seems fair.
* the calculation for the arbitrary impl of Layout was using a max_size that was too large and overflowing Layout. this has been fixed.
* test for arbitrary AllocError was referering to AllocErr which does not exist, this was fixed.
* NoneError has been removed from rust so it was subsequently removed from proptest. It was blocking compilation. evidence: https://github.com/rust-lang/rust/issues/85614
* try_reserve is stable so removed from unstable features
* try_trait has been changed to try_trait_v2 so that was fixed in Cargo.toml.