### PR TITLE
Const generic arbitrary

### DIFF
--- a/proptest/src/arbitrary/arrays.rs
+++ b/proptest/src/arbitrary/arrays.rs
@@ -25,14 +25,24 @@ macro_rules! array {
     )* };
 }
 
-array!(
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-    22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
-);
+impl<A: Arbitrary, const N: usize> Arbitrary for [A; N] {
+    type Parameters = A::Parameters;
+    type Strategy = UniformArrayStrategy<A::Strategy, [A; N]>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        let base = any_with::<A>(args);
+        UniformArrayStrategy::new(base)
+    }
+}
+
 
 #[cfg(test)]
 mod test {
     no_panic_test!(
         array_16 => [u8; 16]
+    );
+
+    no_panic_test!(
+        array_1024 => [u8; 1024]
     );
 }

--- a/proptest/src/arbitrary/arrays.rs
+++ b/proptest/src/arbitrary/arrays.rs
@@ -12,19 +12,6 @@
 use crate::arbitrary::{any_with, Arbitrary};
 use crate::array::UniformArrayStrategy;
 
-macro_rules! array {
-    ($($n: expr),*) => { $(
-        impl<A: Arbitrary> Arbitrary for [A; $n] {
-            type Parameters = A::Parameters;
-            type Strategy = UniformArrayStrategy<A::Strategy, [A; $n]>;
-            fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
-                let base = any_with::<A>(args);
-                UniformArrayStrategy::new(base)
-            }
-        }
-    )* };
-}
-
 impl<A: Arbitrary, const N: usize> Arbitrary for [A; N] {
     type Parameters = A::Parameters;
     type Strategy = UniformArrayStrategy<A::Strategy, [A; N]>;


### PR DESCRIPTION
In the previous ticket, I added `Strategy` impls for const generic arrays of strategies, but forgot about `Arbitrary` :facepalm: 

This one adds `Arbitrary` impls for const generic arrays of types which impl `Arbitrary`.

As with the previous PR, I don't think this is a breaking change.