### PR TITLE
Fix prop_assert_ne! requiring import of prop_assert!

### DIFF
--- a/proptest/src/sugar.rs
+++ b/proptest/src/sugar.rs
@@ -823,20 +823,20 @@ macro_rules! prop_assert_ne {
     ($left:expr, $right:expr) => {{
         let left = $left;
         let right = $right;
-        prop_assert!(
+        $crate::prop_assert!(
             left != right,
             "assertion failed: `(left != right)`\
              \n  left: `{:?}`,\n right: `{:?}`",
-                     left, right);
+            left, right);
     }};
 
     ($left:expr, $right:expr, $fmt:tt $($args:tt)*) => {{
         let left = $left;
         let right = $right;
-        prop_assert!(left != right, concat!(
-            "assertion failed: `(left != right)`\
-             \n  left: `{:?}`,\n right: `{:?}`: ", $fmt),
-                     left, right $($args)*);
+        $crate::prop_assert!(left != right, concat!(
+                "assertion failed: `(left != right)`\
+                 \n  left: `{:?}`,\n right: `{:?}`: ", $fmt),
+            left, right $($args)*);
     }};
 }
 


### PR DESCRIPTION
Closes #256

Test failures carry over from 1.0.0 tag (which this PR is based off)