### PR TITLE
[replays-dont-count-cases] 

### DIFF
--- a/proptest-derive/src/ast.rs
+++ b/proptest-derive/src/ast.rs
@@ -465,7 +465,7 @@ impl ToTokens for ToReg {
             ToReg::Range(to) => {
                 let params: Vec<_> = (0..to).map(param).collect();
                 NestedTuple(&params).to_tokens(tokens)
-            },
+            }
             ToReg::API => call_site_ident(API_PARAM_NAME).to_tokens(tokens),
         }
     }
@@ -520,8 +520,7 @@ impl<'a, T: ToTokens> ToTokens for NestedTuple<'a, T> {
         let NestedTuple(elems) = self;
         if elems.is_empty() {
             quote_append!(tokens, ());
-        }
-        else if let [x] = elems {
+        } else if let [x] = elems {
             x.to_tokens(tokens);
         } else {
             let chunks = elems.chunks(NESTED_TUPLE_CHUNK_SIZE);
@@ -547,7 +546,11 @@ impl<'a, T: ToTokens> ToTokens for NestedTuple<'a, T> {
     }
 }
 
-fn map_ctor_to_tokens(tokens: &mut TokenStream, ctors: &[Ctor], closure: &MapClosure) {
+fn map_ctor_to_tokens(
+    tokens: &mut TokenStream,
+    ctors: &[Ctor],
+    closure: &MapClosure,
+) {
     let ctors = NestedTuple(ctors);
 
     quote_append!(tokens,

--- a/proptest-derive/tests/enum.rs
+++ b/proptest-derive/tests/enum.rs
@@ -468,7 +468,7 @@ enum ZeroOneTwo {
 #[derive(Arbitrary, Debug)]
 enum Nested {
     First(SameType),
-    Second(ZeroOneTwo, OneTwo)
+    Second(ZeroOneTwo, OneTwo),
 }
 
 #[test]

--- a/proptest-derive/tests/misc.rs
+++ b/proptest-derive/tests/misc.rs
@@ -67,7 +67,6 @@ enum Quux {
     },
 }
 
-
 #[test]
 fn asserting_arbitrary() {
     fn assert_arbitrary<T: Arbitrary>() {}

--- a/proptest-derive/tests/struct.rs
+++ b/proptest-derive/tests/struct.rs
@@ -11,7 +11,7 @@ use proptest_derive::Arbitrary;
 
 #[derive(Debug, Arbitrary)]
 struct T1 {
-    f1: u8
+    f1: u8,
 }
 
 #[derive(Debug, Arbitrary)]
@@ -104,7 +104,7 @@ struct T20 {
     f17: u128,
     f18: f32,
     f19: f64,
-    f20: bool
+    f20: bool,
 }
 
 #[test]

--- a/proptest/src/arbitrary/arrays.rs
+++ b/proptest/src/arbitrary/arrays.rs
@@ -22,7 +22,6 @@ impl<A: Arbitrary, const N: usize> Arbitrary for [A; N] {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     no_panic_test!(

--- a/proptest/src/lib.rs
+++ b/proptest/src/lib.rs
@@ -24,12 +24,7 @@
 ))]
 #![cfg_attr(
     feature = "unstable",
-    feature(
-        allocator_api,
-        try_trait_v2,
-        generator_trait,
-        never_type
-    )
+    feature(allocator_api, try_trait_v2, generator_trait, never_type)
 )]
 #![cfg_attr(all(feature = "std", feature = "unstable"), feature(ip))]
 #![cfg_attr(

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -46,7 +46,8 @@ const VERBOSE: &str = "PROPTEST_VERBOSE";
 #[cfg(feature = "std")]
 const RNG_ALGORITHM: &str = "PROPTEST_RNG_ALGORITHM";
 #[cfg(feature = "std")]
-const DISABLE_FAILURE_PERSISTENCE: &str = "PROPTEST_DISABLE_FAILURE_PERSISTENCE";
+const DISABLE_FAILURE_PERSISTENCE: &str =
+    "PROPTEST_DISABLE_FAILURE_PERSISTENCE";
 
 #[cfg(feature = "std")]
 fn contextualize_config(mut result: Config) -> Config {
@@ -127,9 +128,7 @@ fn contextualize_config(mut result: Config) -> Config {
                 "RngAlgorithm",
                 RNG_ALGORITHM,
             ),
-            DISABLE_FAILURE_PERSISTENCE => {
-                result.failure_persistence = None
-            }
+            DISABLE_FAILURE_PERSISTENCE => result.failure_persistence = None,
 
             _ => {
                 if var.starts_with("PROPTEST_") {

--- a/proptest/src/test_runner/errors.rs
+++ b/proptest/src/test_runner/errors.rs
@@ -33,8 +33,32 @@ pub enum TestCaseError {
     Fail(Reason),
 }
 
+/// Indicates the type of test that ran successfully.
+///
+/// This is used for managing whether or not a success is counted against
+/// configured `PROPTEST_CASES`; only `NewCases` shall be counted.
+///
+/// TODO-v2: Ideally `TestCaseResult = Result<TestCaseOk, TestCaseError>`
+/// however this breaks source compability in version 1.x.x because
+/// `TestCaseResult` is public.
+#[derive(Debug, Clone)]
+pub(crate) enum TestCaseOk {
+    NewCaseSuccess,
+    PersistedCaseSuccess,
+    ReplayFromForkSuccess,
+    CacheHitSuccess,
+    Reject,
+}
+
 /// Convenience for the type returned by test cases.
 pub type TestCaseResult = Result<(), TestCaseError>;
+
+/// Intended to replace `TestCaseResult` in v2.
+///
+/// TODO-v2: Ideally `TestCaseResult = Result<TestCaseOk, TestCaseError>`
+/// however this breaks source compability in version 1.x.x because
+/// `TestCaseResult` is public.
+pub(crate) type TestCaseResultV2 = Result<TestCaseOk, TestCaseError>;
 
 impl TestCaseError {
     /// Rejects the generated test input as invalid for this test case. This


### PR DESCRIPTION
replays/persisted failures are not counted against successful cases.

this way when `PROPTEST_CASES` <= `number of persisted cases` we will not end up never creating new cases to test against. rather, all persisted cases will be tested _and then_ a new number of cases will run equal to the number of `PROPTEST_CASES`.

addresses https://github.com/proptest-rs/proptest/issues/290