### PR TITLE
Remove quick_error dependency

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -23,6 +23,10 @@
 - Add `Arbitrary` impls for `core::num::NonZero*`
 - Adds ability to disable failure persistence via env var `PROPTEST_DISABLE_FAILURE_PERSISTENCE`
 
+### Other Notes
+
+- `proptest` no longer depends on the `quick-error` crate.
+
 ## 1.0.0
 
 ### Breaking Changes

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -27,7 +27,7 @@ unstable = []
 
 # Enables the use of standard-library dependent features
 std = ["rand/std", "byteorder/std", "lazy_static",
-       "quick-error", "regex-syntax", "num-traits/std"]
+       "regex-syntax", "num-traits/std"]
 
 # For use in no_std environments with access to an allocator
 #alloc = ["hashmap_core"]
@@ -72,10 +72,6 @@ version = "0.2.15"
 default-features = false
 # std or libm required for mul_add.
 features = ["libm"]
-
-[dependencies.quick-error]
-version = "2.0.0"
-optional = true
 
 [dependencies.regex-syntax]
 # If you change this, make sure to also bump the `regex` dependency to a

--- a/proptest/src/lib.rs
+++ b/proptest/src/lib.rs
@@ -71,11 +71,6 @@ extern crate bit_set;
 #[macro_use]
 extern crate lazy_static;
 
-// Only required for the string module.
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate quick_error;
-
 #[cfg(feature = "fork")]
 #[macro_use]
 extern crate rusty_fork;

--- a/proptest/src/string.rs
+++ b/proptest/src/string.rs
@@ -54,33 +54,40 @@ impl Default for StringParam {
     }
 }
 
-// quick_error! uses bare trait objects, so we enclose its invocation here in a
-// module so the lint can be disabled just for it.
-#[allow(bare_trait_objects)]
-mod error_container {
-    use super::*;
+/// Errors which may occur when preparing a regular expression for use with
+/// string generation.
+#[derive(Debug)]
+pub enum Error {
+    /// The string passed as the regex was not syntactically valid.
+    RegexSyntax(ParseError),
+    /// The regex was syntactically valid, but contains elements not
+    /// supported by proptest.
+    UnsupportedRegex(&'static str),
+}
 
-    quick_error! {
-        /// Errors which may occur when preparing a regular expression for use with
-        /// string generation.
-        #[derive(Debug)]
-        pub enum Error {
-            /// The string passed as the regex was not syntactically valid.
-            RegexSyntax(err: ParseError) {
-                from()
-                    source(err)
-                    display("{}", err)
-            }
-            /// The regex was syntactically valid, but contains elements not
-            /// supported by proptest.
-            UnsupportedRegex(message: &'static str) {
-                display("{}", message)
-            }
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::RegexSyntax(err) => write!(f, "{}", err),
+            Error::UnsupportedRegex(message) => write!(f, "{}", message),
         }
     }
 }
 
-pub use self::error_container::Error;
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::RegexSyntax(err) => Some(err),
+            Error::UnsupportedRegex(_) => None,
+        }
+    }
+}
+
+impl From<ParseError> for Error {
+    fn from(err: ParseError) -> Error {
+        Error::RegexSyntax(err)
+    }
+}
 
 opaque_strategy_wrapper! {
     /// Strategy which generates values (i.e., `String` or `Vec<u8>`) matching


### PR DESCRIPTION
This removes the direct dependency on the quick-error crate, replacing the single use of `quick_error!` with (brief, straightforward) manual trait impls. quick-error remains a *transitive* dependency because it's pulled in by rusty-fork.