### PR TITLE
fix nightly derive tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,71 +3,70 @@ name: Rust
 on:
   push:
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         build:
-        - pinned
-        - stable
-        - beta
-        - nightly
+          - pinned
+          - stable
+          - beta
+          - nightly
         include:
-        - build: pinned
-          os: ubuntu-18.04
-          rust: 1.60.0
-        - build: stable
-          os: ubuntu-18.04
-          rust: stable
-        - build: beta
-          os: ubuntu-18.04
-          rust: beta
-        - build: nightly
-          os: ubuntu-18.04
-          rust: nightly
+          - build: pinned
+            os: ubuntu-18.04
+            rust: 1.60.0
+          - build: stable
+            os: ubuntu-18.04
+            rust: stable
+          - build: beta
+            os: ubuntu-18.04
+            rust: beta
+          - build: nightly
+            os: ubuntu-18.04
+            rust: nightly
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: ${{ matrix.rust }}
-    - name: Build
-      run: cd proptest && cargo build --verbose
-    - name: Run tests
-      run: cd proptest && cargo test --verbose
-    - name: Build coverage no-default-features
-      if: ${{ matrix.build == 'stable' }}
-      env:
-        RUST_FLAGS: '-C link-dead-code'
-      run: cd proptest && cargo build --no-default-features --features default-code-coverage
-    - name: Build fork no-default-features
-      if: ${{ matrix.build == 'stable' }}
-      run: cd proptest && cargo build --no-default-features --features fork
-    - name: Build lib std no-default-features
-      if: ${{ matrix.build == 'stable' }}
-      run: cd proptest && cargo build --lib --no-default-features --features std
-    - name: Build rng no-default-features
-      if: ${{ matrix.build == 'nightly' }}
-      run: cd proptest && cargo build --no-default-features --features "alloc unstable hardware-rng"
-    - name: Run presisrnce tests
-      if: ${{ matrix.build == 'nightly' }}
-      run: cd proptest/test-persistence-location && ./run-tests.sh
-    - name: Clean
-      run: cargo clean
-    - name: Build derive
-      run: cd proptest-derive && cargo build
-    - name: Run tests for derive
-      if: ${{ matrix.build == 'nightly' }}
-      run: cd proptest-derive && cargo test
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: ${{ matrix.rust }}
+      - name: Build
+        run: cd proptest && cargo build --verbose
+      - name: Run tests
+        run: cd proptest && cargo test --verbose
+      - name: Build coverage no-default-features
+        if: ${{ matrix.build == 'stable' }}
+        env:
+          RUST_FLAGS: "-C link-dead-code"
+        run: cd proptest && cargo build --no-default-features --features default-code-coverage
+      - name: Build fork no-default-features
+        if: ${{ matrix.build == 'stable' }}
+        run: cd proptest && cargo build --no-default-features --features fork
+      - name: Build lib std no-default-features
+        if: ${{ matrix.build == 'stable' }}
+        run: cd proptest && cargo build --lib --no-default-features --features std
+      - name: Build rng no-default-features
+        if: ${{ matrix.build == 'nightly' }}
+        run: cd proptest && cargo build --no-default-features --features "alloc unstable hardware-rng"
+      - name: Run presisrnce tests
+        if: ${{ matrix.build == 'nightly' }}
+        run: cd proptest/test-persistence-location && ./run-tests.sh
+      - name: Clean
+        run: cargo clean
+      - name: Build derive
+        run: cd proptest-derive && cargo build
+      - name: Clean and Run tests for derive
+        if: ${{ matrix.build == 'nightly' }}
+        run: cd proptest-derive && cargo clean && cargo test


### PR DESCRIPTION
nightly needs to be cleaned before running derive tests otherwise it will fail with
```
unexpected error: '10:1: 10:30: multiple candidates for `dylib`
dependency `proptest_derive` found [E0464]'
```
and other errors