### PR TITLE
Update syn and friends to v1

### DIFF
--- a/proptest-derive/Cargo.toml
+++ b/proptest-derive/Cargo.toml
@@ -32,10 +32,10 @@ compiletest_rs = { version = "0.9", features = ["tmp", "stable"] }
 criterion = "0.2"
 
 [dependencies]
-proc-macro2 = "0.4"
+proc-macro2 = "1.0"
 
-syn = { version = "0.15.17", features = ["visit", "extra-traits", "full"] }
-quote = "0.6"
+syn = { version = "1.0.0", features = ["visit", "extra-traits", "full"] }
+quote = "1.0"
 
 [[bench]]
 name = "large_enum"

--- a/proptest-derive/src/ast.rs
+++ b/proptest-derive/src/ast.rs
@@ -783,31 +783,3 @@ impl<'a> ToTokens for FreshVar<'a> {
 fn call_site_ident(ident: &str) -> syn::Ident {
     syn::Ident::new(ident, Span::call_site())
 }
-
-//==============================================================================
-// Util
-//==============================================================================
-
-/// A comma separated tuple to a token stream when more than 1, or just flat
-/// when 1.
-#[derive(Copy, Clone)]
-struct Tuple2<S>(S);
-
-impl<'a, T: ToTokens> ToTokens for Tuple2<&'a [T]> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self.0 {
-            [x] => x.to_tokens(tokens),
-            _ => Tuple(self.0).to_tokens(tokens),
-        }
-    }
-}
-
-/// Append a comma separated tuple to a token stream.
-struct Tuple<I>(I);
-
-impl<T: ToTokens, I: Clone + IntoIterator<Item = T>> ToTokens for Tuple<I> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let iter = self.0.clone();
-        quote_append!(tokens, ( #(#iter),* ) );
-    }
-}

--- a/proptest-derive/src/error.rs
+++ b/proptest-derive/src/error.rs
@@ -11,6 +11,7 @@
 use std::fmt::Display;
 
 use proc_macro2::TokenStream;
+use quote::ToTokens;
 
 use crate::attr::ParsedAttributes;
 use syn;
@@ -428,7 +429,7 @@ error!(
     E0017,
     "The attribute modifier `{}` inside `#[proptest(..)]` has already been \
      set. To fix the error, please remove at least one such modifier.",
-    meta.name()
+    meta.path().into_token_stream()
 );
 
 // Happens when `<modifier>` in `#[proptest(<modifier>)]` is unknown to
@@ -442,6 +443,7 @@ error!(
     expected
 );
 
+// TODO: `unkown_modifier` is misspelled
 // Happens when `<modifier>` in `#[proptest(<modifier>)]` is unknown to us.
 error!(
     unkown_modifier(modifier: &str),
@@ -476,7 +478,7 @@ error!(
     format `#[proptest({0} = <integer>)]` where `<integer>` is an integer that \
     fits within a `u32`. An example: `#[proptest({0} = 2)]` to set a relative \
     weight of 2.",
-    meta.name()
+    meta.path().into_token_stream()
 );
 
 // Happens when both `#[proptest(params = "<type>")]` and
@@ -529,7 +531,7 @@ error!(
     "The attribute modifier `{0}` inside `#[proptest(..)]` must have the \
      format `#[proptest({0} = \"<expr>\")]` where `<expr>` is a valid Rust \
      expression.",
-    meta.name()
+    meta.path().into_token_stream()
 );
 
 // Happens when `#[proptest(filter..)]` is malformed.
@@ -541,7 +543,7 @@ error!(
     "The attribute modifier `{0}` inside `#[proptest(..)]` must have the \
      format `#[proptest({0} = \"<expr>\")]` where `<expr>` is a valid Rust \
      expression.",
-    meta.name()
+    meta.path().into_token_stream()
 );
 
 // Any attributes on a skipped variant has no effect - so we emit this error


### PR DESCRIPTION
I was curious why `syn` v0.15 still has so many downloads. I think this may be the main culprit :grin:

This updates all of the proc_macro related bits to v1. I'm planning on updating `syn` to v2, but figured breaking things into two PRs would make reviewing easier. The changes are largely:

- Handling `Meta::Word(_)` -> `Meta::Path(_)` since this was changed to take arbitrary paths instead of a single ident
  - Fix: Ensure that the path is just a single ident
- `IntSuffix` got replaced with just returning a `&str` for the suffix
  - Fix: Switch all the logic to just use the `&str`. Could also make our own version of `IntSuffix`, but wasn't sure if that would be worth it
- `Tuple` and `Tuple2` were causing a lot of headaches
  - Fix: Remove them since they seem unused?