### PR TITLE
update actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,12 +12,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.18'
+          mdbook-version: "0.4.18"
 
       - run: cd book && mdbook build
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,16 +21,16 @@ jobs:
           - nightly
         include:
           - build: pinned
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             rust: 1.60.0
           - build: stable
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             rust: stable
           - build: beta
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             rust: beta
           - build: nightly
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             rust: nightly
 
     steps:


### PR DESCRIPTION
update actions to use supported os and latest versions.

i noticed our builds have been stuck, possibly it's because we're no longer on a supported version of ubuntu. https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software