### PR TITLE
[Fix] NonZero : only impl Arbitrary for 128-bit NonZero nums in non-wasm targets

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Bug Fixes
 
+- Don't implement Arbitrary for NonZeroU128 and NonZeroI128 on wasm targets where
+  u128 and i128 Arbitrary impls don't exist
+
 ### New Features
 
 ### Other Notes

--- a/proptest/src/arbitrary/_core/mod.rs
+++ b/proptest/src/arbitrary/_core/mod.rs
@@ -17,6 +17,7 @@ mod fmt;
 mod iter;
 mod marker;
 mod mem;
+mod non_zero;
 mod num;
 mod option;
 mod result;

--- a/proptest/src/arbitrary/_core/non_zero.rs
+++ b/proptest/src/arbitrary/_core/non_zero.rs
@@ -8,14 +8,15 @@
 // except according to those terms.
 
 use core::convert::TryFrom;
+#[cfg(not(target_arch = "wasm32"))]
+use core::num::{NonZeroI128, NonZeroU128};
 use core::num::{
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize,
-    NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU16,
+    NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
 };
 
+use crate::arbitrary::{any, Arbitrary, StrategyFor};
 use crate::strategy::{FilterMap, Strategy};
-
-use super::{any, Arbitrary, StrategyFor};
 
 macro_rules! non_zero_impl {
     ($nz:ty, $prim:ty) => {
@@ -37,6 +38,7 @@ non_zero_impl!(NonZeroU8, u8);
 non_zero_impl!(NonZeroU16, u16);
 non_zero_impl!(NonZeroU32, u32);
 non_zero_impl!(NonZeroU64, u64);
+#[cfg(not(target_arch = "wasm32"))]
 non_zero_impl!(NonZeroU128, u128);
 non_zero_impl!(NonZeroUsize, usize);
 
@@ -44,6 +46,7 @@ non_zero_impl!(NonZeroI8, i8);
 non_zero_impl!(NonZeroI16, i16);
 non_zero_impl!(NonZeroI32, i32);
 non_zero_impl!(NonZeroI64, i64);
+#[cfg(not(target_arch = "wasm32"))]
 non_zero_impl!(NonZeroI128, i128);
 non_zero_impl!(NonZeroIsize, isize);
 
@@ -54,13 +57,16 @@ mod test {
         u16 => core::num::NonZeroU16,
         u32 => core::num::NonZeroU32,
         u64 => core::num::NonZeroU64,
-        u128 => core::num::NonZeroU128,
         usize => core::num::NonZeroUsize,
         i8 => core::num::NonZeroI8,
         i16 => core::num::NonZeroI16,
         i32 => core::num::NonZeroI32,
         i64 => core::num::NonZeroI64,
-        i128 => core::num::NonZeroI128,
         isize => core::num::NonZeroIsize
+    );
+    #[cfg(not(target_arch = "wasm32"))]
+    no_panic_test!(
+        u128 => core::num::NonZeroU128,
+        i128 => core::num::NonZeroI128
     );
 }

--- a/proptest/src/arbitrary/mod.rs
+++ b/proptest/src/arbitrary/mod.rs
@@ -30,7 +30,6 @@ pub mod functor;
 mod macros;
 
 mod arrays;
-mod non_zero;
 mod primitives;
 mod sample;
 mod tuples;

--- a/proptest/src/test_runner/errors.rs
+++ b/proptest/src/test_runner/errors.rs
@@ -117,7 +117,7 @@ impl<T: fmt::Debug> fmt::Display for TestError<T> {
             TestError::Fail(ref why, ref what) => {
                 writeln!(f, "Test failed: {}.", why)?;
                 write!(f, "minimal failing input: {:#?}", what)
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
fixes #321 