### PR TITLE
state-machine prerequisites

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Other Notes
 - Minimal failing input is now printed using debug pretty-printing
+- Made public `VarBitSet`, `SizeRange` read-only methods and num sampling
+  functions in preparation for release of a `proptest-state-machine` crate.
 
 ## 1.1.0
 

--- a/proptest/src/bits.rs
+++ b/proptest/src/bits.rs
@@ -444,11 +444,13 @@ pub(crate) mod varsize {
     #[cfg(not(feature = "bit-set"))]
     type Inner = Vec<bool>;
 
+    /// A bit set is a set of bit flags.
     #[derive(Debug, Clone)]
-    pub(crate) struct VarBitSet(Inner);
+    pub struct VarBitSet(Inner);
 
     impl VarBitSet {
-        pub(crate) fn saturated(len: usize) -> Self {
+        /// Create a bit set of `len` set values.
+        pub fn saturated(len: usize) -> Self {
             (0..len).collect::<VarBitSet>()
         }
 
@@ -517,7 +519,7 @@ pub(crate) mod varsize {
     }
 }
 
-pub(crate) use self::varsize::VarBitSet;
+pub use self::varsize::VarBitSet;
 
 #[cfg(test)]
 mod test {

--- a/proptest/src/collection.rs
+++ b/proptest/src/collection.rs
@@ -77,20 +77,23 @@ impl SizeRange {
         self.with(Default::default())
     }
 
-    pub(crate) fn start(&self) -> usize {
+    /// The lower bound of the range (inclusive).
+    pub fn start(&self) -> usize {
         self.0.start
     }
 
     /// Extract the ends `[low, high]` of a `SizeRange`.
-    pub(crate) fn start_end_incl(&self) -> (usize, usize) {
+    pub fn start_end_incl(&self) -> (usize, usize) {
         (self.start(), self.end_incl())
     }
 
-    pub(crate) fn end_incl(&self) -> usize {
+    /// The upper bound of the range (inclusive).
+    pub fn end_incl(&self) -> usize {
         self.0.end - 1
     }
 
-    pub(crate) fn end_excl(&self) -> usize {
+    /// The upper bound of the range (exclusive).
+    pub fn end_excl(&self) -> usize {
         self.0.end
     }
 

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -18,6 +18,8 @@ use crate::test_runner::TestRunner;
 use rand::distributions::uniform::{SampleUniform, Uniform};
 use rand::distributions::{Distribution, Standard};
 
+/// Generate a random value of `X`, sampled uniformly from the half
+/// open range `[low, high)` (excluding `high`). Panics if `low >= high`.
 pub(crate) fn sample_uniform<X: SampleUniform>(
     run: &mut TestRunner,
     start: X,
@@ -26,7 +28,9 @@ pub(crate) fn sample_uniform<X: SampleUniform>(
     Uniform::new(start, end).sample(run.rng())
 }
 
-pub(crate) fn sample_uniform_incl<X: SampleUniform>(
+/// Generate a random value of `X`, sampled uniformly from the closed
+/// range `[low, high]` (inclusive). Panics if `low > high`.
+pub fn sample_uniform_incl<X: SampleUniform>(
     run: &mut TestRunner,
     start: X,
     end: X,


### PR DESCRIPTION
There are proptest crate-only changes separated from #310 that are needed for the new proptest-state-machine crate