### PR TITLE
bump version to 1.2.0

### DIFF
--- a/proptest-derive/CHANGELOG.md
+++ b/proptest-derive/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Other Notes
+- Upgraded `syn`, `quote`, and `proc-macro2` to 1.0
+
 ## 0.3.0
 
 ### Breaking changes

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Minimal failing input is now printed using debug pretty-printing
 - Made public `VarBitSet`, `SizeRange` read-only methods and num sampling
   functions in preparation for release of a `proptest-state-machine` crate.
+- Removed dependency on `quick_error`
+- Start publishing MSRV
 
 ## 1.1.0
 

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.2.0
+
 ### Breaking Changes
 
 - `PROPTEST_` environment variables now take precedence over tests' non-default
@@ -13,6 +15,7 @@
 ### New Features
 
 ### Other Notes
+
 - Minimal failing input is now printed using debug pretty-printing
 - Made public `VarBitSet`, `SizeRange` read-only methods and num sampling
   functions in preparation for release of a `proptest-state-machine` crate.

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proptest"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Jason Lingle"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
If this is good I will tag the commit with `v1.2.0`