### PR TITLE
Remove `#![feature(core_intrinsics)]` usage

### DIFF
--- a/proptest/src/lib.rs
+++ b/proptest/src/lib.rs
@@ -27,10 +27,6 @@
     feature(allocator_api, try_trait_v2, generator_trait, never_type)
 )]
 #![cfg_attr(all(feature = "std", feature = "unstable"), feature(ip))]
-#![cfg_attr(
-    all(feature = "alloc", not(feature = "std")),
-    feature(core_intrinsics)
-)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // std_facade is used in a few macros, so it needs to be public.


### PR DESCRIPTION
This is for some reason enabled when using `alloc` instead of `std`, which prevents crates from using `proptest` on stable with only the `alloc` feature enabled.