### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/proptest-derive/Cargo.toml
+++ b/proptest-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "proptest-derive"
 version       = "0.4.0"
 authors       = ["Mazdak Farrokhzad <twingoow@gmail.com>"]
-license       = "MIT/Apache-2.0"
+license       = "MIT OR Apache-2.0"
 readme        = "README.md"
 
 repository    = "https://github.com/proptest-rs/proptest"

--- a/proptest-state-machine/Cargo.toml
+++ b/proptest-state-machine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proptest-state-machine"
 version = "0.1.0"
 authors = ["Tomáš Zemanovič"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 repository = "https://github.com/proptest-rs/proptest"
 homepage = "https://proptest-rs.github.io/proptest/proptest/state-machine.html"

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proptest"
 version = "1.2.0"
 authors = ["Jason Lingle"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/proptest-rs/proptest"
 homepage = "https://proptest-rs.github.io/proptest/proptest/index.html"

--- a/proptest/test-persistence-location/single-crate/Cargo.toml
+++ b/proptest/test-persistence-location/single-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "single-crate"
 version = "0.0.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [workspace]

--- a/proptest/test-persistence-location/workspace/member/Cargo.toml
+++ b/proptest/test-persistence-location/workspace/member/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "member"
 version = "0.0.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies.proptest]


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields