### PR TITLE
deps: Update criterion to v0.5

### DIFF
--- a/proptest-derive/Cargo.toml
+++ b/proptest-derive/Cargo.toml
@@ -29,7 +29,7 @@ proptest = { version = "1.0.0", path = "../proptest" }
 # compiletest-rs fail to compile, but the stable fallback works fine.
 compiletest_rs = { version = "0.9", features = ["tmp", "stable"] }
 # criterion is used for benchmarks.
-criterion = "0.2"
+criterion = "0.5"
 
 [dependencies]
 proc-macro2 = "1.0"


### PR DESCRIPTION
This removes a notice about future-incompatible code from criterion 0.2.