### PR TITLE
state-machine: fix logging by adding "std" feature

### DIFF
--- a/proptest-state-machine/CHANGELOG.md
+++ b/proptest-state-machine/CHANGELOG.md
@@ -1,1 +1,5 @@
 ## Unreleased
+
+### Bug Fixes
+
+- Fixed logging of state machine transitions to be enabled when verbose config is >= 1. The "std" feature is added to proptest-state-machine as a default feature that allows to switch the logging off in non-std env.

--- a/proptest-state-machine/Cargo.toml
+++ b/proptest-state-machine/Cargo.toml
@@ -13,8 +13,18 @@ description = """
 State machine based testing support for proptest.
 """
 
+[features]
+default = ["std"]
+
+# Enables the use of standard-library dependent features
+std = ["proptest/std"]
+
 [dependencies]
-proptest = { version = "1.2.0", path = "../proptest" }
+proptest = { version = "1.2.0", path = "../proptest", default-features = true, features = [
+    "fork",
+    "timeout",
+    "bit-set",
+] }
 
 [dev-dependencies]
 message-io = "0.17.0"

--- a/proptest-state-machine/src/test_runner.rs
+++ b/proptest-state-machine/src/test_runner.rs
@@ -73,9 +73,12 @@ pub trait StateMachineTest {
             <Self::Reference as ReferenceStateMachine>::Transition,
         >,
     ) {
+        #[cfg(feature = "std")]
+        use proptest::test_runner::INFO_LOG;
+
         let trans_len = transitions.len();
         #[cfg(feature = "std")]
-        if config.verbose >= super::INFO_LOG {
+        if config.verbose >= INFO_LOG {
             eprintln!();
             eprintln!("Running a test case with {} transitions.", trans_len);
         }
@@ -89,7 +92,7 @@ pub trait StateMachineTest {
 
         for (ix, transition) in transitions.into_iter().enumerate() {
             #[cfg(feature = "std")]
-            if config.verbose >= super::INFO_LOG {
+            if config.verbose >= INFO_LOG {
                 eprintln!();
                 eprintln!(
                     "Applying transition {}/{}: {:?}",


### PR DESCRIPTION
Before the feature was finalized, the state machine support was included in the core proptest crate that uses "std" feature. After crate split, the "std" feature was missing in the new crate so the code was dead.

The "std" feature is added to proptest-state-machine as a default feature allowing to switch the logging off in non-std env.