### PR TITLE
Remove byteorder dependency

### DIFF
--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -27,7 +27,7 @@ default-code-coverage = ["std", "fork", "timeout", "bit-set"]
 unstable = []
 
 # Enables the use of standard-library dependent features
-std = ["rand/std", "byteorder/std", "lazy_static",
+std = ["rand/std", "lazy_static",
        "regex-syntax", "num-traits/std"]
 
 # For use in no_std environments with access to an allocator
@@ -96,10 +96,6 @@ version = "0.3"
 
 [dependencies.rand_chacha]
 version = "0.3"
-default-features = false
-
-[dependencies.byteorder]
-version = "1.2.3"
 default-features = false
 
 [dependencies.rusty-fork]


### PR DESCRIPTION
The Rust standard library includes some byteorder-like helper functions for a while already. This commit replaces the use of byteorder with these helper functions.

----

I have no particular reason for this except for trying to remove a dependency. `byteorder` is not a "bad" dependency, but it still seemed unnecessary to me to do what is being done here.

Feel free to tell me that this is not worth it. :-)