### PR TITLE
Make VarBitSet saturated + FromIterator efficient

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `regex-syntax` version 0.7 is now used.
 - Print a seed to stderr for a failed test even when a regressions file is already present.
+- Fixed a performance issue with `VarBitSet::saturated` that can slow down `VecStrategy`
 
 ## 1.2.0
 

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -56,6 +56,8 @@ atomic64bit = []
 # passed (see https://github.com/proptest-rs/proptest/issues/124).
 break-dead-code = []
 
+bit-set = [ "dep:bit-set", "dep:bit-vec" ]
+
 [dependencies]
 bitflags = "2"
 unarray = "0.1.4"
@@ -82,8 +84,10 @@ optional = true
 
 [dependencies.bit-set]
 version = "0.5.0"
-# It doesn't currently work with no_std
-# default-features = false
+optional = true
+
+[dependencies.bit-vec]
+version = "0.6.0"
 optional = true
 
 [dependencies.rand]


### PR DESCRIPTION
I noticed that `VarBitSet::saturated` takes a significant amount of time when generating data with `VecStrategy`. There are two perf issues:

1. not making use of the size hint in `FromIterator` leads to repeated grow calls
2. saturated should use `from_elem` since we're setting all bits