### PR TITLE
[proptest-derive] disable clippy::arc_with_non_send_sync

### DIFF
--- a/proptest-derive/src/ast.rs
+++ b/proptest-derive/src/ast.rs
@@ -108,8 +108,15 @@ impl Impl {
         let _const = call_site_ident(&format!("_IMPL_ARBITRARY_FOR_{}", typ));
 
         // Linearise everything. We're done after this.
+        //
+        // NOTE: The clippy::arc_with_non_send_sync lint is disabled here because the strategies
+        // generated are often not Send or Sync, such as BoxedStrategy.
+        //
+        // The double-curly-braces are not strictly required, but allow the expression to be
+        // annotated with an attribute.
         let q = quote! {
             #[allow(non_upper_case_globals)]
+            #[allow(clippy::arc_with_non_send_sync)]
             const #_const: () = {
             extern crate proptest as _proptest;
 

--- a/proptest-derive/src/tests.rs
+++ b/proptest-derive/src/tests.rs
@@ -79,6 +79,7 @@ test! {
         struct MyUnitStruct;
     } expands to {
         #[allow(non_upper_case_globals)]
+        #[allow(clippy::arc_with_non_send_sync)]
         const _IMPL_ARBITRARY_FOR_MyUnitStruct : () = {
             extern crate proptest as _proptest;
         impl _proptest::arbitrary::Arbitrary for MyUnitStruct {
@@ -99,6 +100,7 @@ test! {
         struct MyTupleUnitStruct();
     } expands to {
         #[allow(non_upper_case_globals)]
+        #[allow(clippy::arc_with_non_send_sync)]
         const _IMPL_ARBITRARY_FOR_MyTupleUnitStruct : () = {
             extern crate proptest as _proptest;
         impl _proptest::arbitrary::Arbitrary for MyTupleUnitStruct {
@@ -119,6 +121,7 @@ test! {
         struct MyNamedUnitStruct {}
     } expands to {
         #[allow(non_upper_case_globals)]
+        #[allow(clippy::arc_with_non_send_sync)]
         const _IMPL_ARBITRARY_FOR_MyNamedUnitStruct : () = {
             extern crate proptest as _proptest;
         impl _proptest::arbitrary::Arbitrary for MyNamedUnitStruct {


### PR DESCRIPTION
This is a new lint added in Rust 1.72. See comment for why.