### PR TITLE
Add edge bias feature to bias for testing edge cases.

### DIFF
--- a/proptest/src/arbitrary/_std/time.rs
+++ b/proptest/src/arbitrary/_std/time.rs
@@ -17,8 +17,11 @@ use crate::num;
 use crate::strategy::statics::{self, static_map};
 
 arbitrary!(Duration, SMapped<(u64, u32), Self>;
-    static_map(any::<(u64, u32)>(), |(a, b)| Duration::new(a, b))
-);
+    static_map(any::<(u64, u32)>(), |(a, b)|
+    // Duration::new panics if nanoseconds are over one billion (one second)
+    // and overflowing into the seconds would overflow the second counter.
+    Duration::new(a, b % 1_000_000_000)
+));
 
 // Instant::now() "never" returns the same Instant, so no shrinking may occur!
 arbitrary!(Instant; Self::now());

--- a/proptest/src/num/float_samplers.rs
+++ b/proptest/src/num/float_samplers.rs
@@ -438,20 +438,29 @@ macro_rules! float_sampler {
                         let intervals = split_interval([low, high]);
                         let size = (intervals.count - 1) as usize;
 
-                        let interval = intervals.get(index.index(size) as $int_typ);
-                        let small_intervals = split_interval(interval);
+                        if size <= 0
+                        {
+                            prop_assert!((intervals.start == high && intervals.step < 0.0) ||
+                                (intervals.start == low && intervals.step > 0.0));
+                            prop_assert!(intervals.count == 1);
+                        }
+                        else
+                        {
+                            let interval = intervals.get(index.index(size) as $int_typ);
+                            let small_intervals = split_interval(interval);
 
-                        let start = small_intervals.get(0);
-                        let end = small_intervals.get(small_intervals.count - 1);
-                        let (low_interval, high_interval) = if  start[0] < end[0] {
-                            (start, end)
-                        } else {
-                            (end, start)
-                        };
+                            let start = small_intervals.get(0);
+                            let end = small_intervals.get(small_intervals.count - 1);
+                            let (low_interval, high_interval) = if  start[0] < end[0] {
+                                (start, end)
+                            } else {
+                                (end, start)
+                            };
 
-                        prop_assert!(
-                            interval[0] == low_interval[0] &&
-                            interval[1] == high_interval[1]);
+                            prop_assert!(
+                                interval[0] == low_interval[0] &&
+                                interval[1] == high_interval[1]);
+                        }
                     }
                 }
             }

--- a/proptest/src/test_runner/failure_persistence/noop.rs
+++ b/proptest/src/test_runner/failure_persistence/noop.rs
@@ -11,7 +11,7 @@ use crate::std_facade::{fmt, Box, Vec};
 use core::any::Any;
 
 use crate::test_runner::failure_persistence::{
-    FailurePersistence, PersistedSeed,
+    FailurePersistence, PersistedEdgeBias, PersistedSeed,
 };
 
 /// Failure persistence option that loads and saves nothing at all.
@@ -22,7 +22,7 @@ impl FailurePersistence for NoopFailurePersistence {
     fn load_persisted_failures2(
         &self,
         _source_file: Option<&'static str>,
-    ) -> Vec<PersistedSeed> {
+    ) -> Vec<(PersistedSeed, PersistedEdgeBias)> {
         Vec::new()
     }
 
@@ -30,6 +30,7 @@ impl FailurePersistence for NoopFailurePersistence {
         &mut self,
         _source_file: Option<&'static str>,
         _seed: PersistedSeed,
+        _current_edge_bias: PersistedEdgeBias,
         _shrunken_value: &dyn fmt::Debug,
     ) {
     }
@@ -68,7 +69,7 @@ mod tests {
     #[test]
     fn seeds_not_recoverable() {
         let mut p = NoopFailurePersistence::default();
-        p.save_persisted_failure2(HI_PATH, INC_SEED, &"");
+        p.save_persisted_failure2(HI_PATH, INC_SEED, INC_EDGE_BIAS, &"");
         assert!(p.load_persisted_failures2(HI_PATH).is_empty());
         assert!(p.load_persisted_failures2(None).is_empty());
         assert!(p.load_persisted_failures2(UNREL_PATH).is_empty());

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -9,11 +9,13 @@
 
 use crate::std_facade::{Arc, String, ToOwned, Vec};
 use core::result::Result;
-use core::{fmt, str, u8, convert::TryInto};
+use core::{convert::TryInto, fmt, str, u8};
 
 use rand::{self, Rng, RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use rand_xorshift::XorShiftRng;
+
+use crate::test_runner::failure_persistence::to_base16;
 
 /// Identifies a particular RNG algorithm supported by proptest.
 ///
@@ -347,12 +349,6 @@ impl Seed {
     }
 
     pub(crate) fn to_persistence(&self) -> String {
-        fn to_base16(dst: &mut String, src: &[u8]) {
-            for byte in src {
-                dst.push_str(&format!("{:02x}", byte));
-            }
-        }
-
         match *self {
             Seed::XorShift(ref seed) => {
                 let dwords = [


### PR DESCRIPTION
It works by randomly changing some generated values to be one of the random edge cases. The first tests are done with 100% edge cases, and then the chance goes down over the number of test cases until it's 0%.

The average amount of edge case tests can be controlled by edge_bias configuration option. It defaults to 0.25. (25% of generated values are edge cases over all the tests.)

In failure the edge bias is persisted to the persistence file along with the seed, so it should be reproducible.

So far it only does ints, floats and ranges.

I also got some validation for the system, because some of the existing tests started failing.

For example the time::Duration test failed because if both secs and nanos are MAX, the nanos will overflow into secs, and then secs will overflow and the function panics.

Note that I'm not sure if the fix I made is the best, since I just mod by a billion, so it biases the random distribution a bit. I don't know if this is undesireable.

float_samplers test subbsequent_splits_always_match_bounds also started failing (for f32 and f64 versions both) because it couldn't generate multiple intervals for values like
```
minimal failing input: (low, high) = (
    1.7976931348623155e308,
    1.7976931348623157e308,
), index = Index(
    0,
)
```
I fixed it by checking for intervals.count == 1, but I feel like that's not the best solution. From reading the other tests, it feels like the intervals are supposed to be able to be split, but in the end I didn't look fully into it.

I also think the tests should include nans and infinities as edge cases, but I didn't add those because it would cause a lot of things to fail, because they're made with the assumption that those are not generated. (Or expecting and asserting.)

Except for the strings, this should implement https://github.com/proptest-rs/proptest/issues/82

I just started with Rust, so I hope there's nothing too stupid in there...