### PR TITLE
Follow new lint rule in macro generation

### DIFF
--- a/proptest/src/sugar.rs
+++ b/proptest/src/sugar.rs
@@ -971,11 +971,11 @@ macro_rules! proptest_helper {
             $($mod)* |$crate::sugar::NamedArguments(
                 _, $crate::proptest_helper!(@_WRAPPAT ($($parm),*)))|
             {
-                let _: () = $body;
+                let (): () = $body;
                 Ok(())
             })
         {
-            Ok(_) => (),
+            Ok(()) => (),
             Err(e) => panic!("{}\n{}", e, runner),
         }
     }};
@@ -991,11 +991,11 @@ macro_rules! proptest_helper {
             $($mod)* |$crate::sugar::NamedArguments(
                 _, $crate::proptest_helper!(@_EXT _PAT ($($arg)*)))|
             {
-                let _: () = $body;
+                let (): () = $body;
                 Ok(())
             })
         {
-            Ok(_) => (),
+            Ok(()) => (),
             Err(e) => panic!("{}\n{}", e, runner),
         }
     }};


### PR DESCRIPTION
clippy::ignored_unit_patterns is a new lint rule that the generated code seems to be violating. This fixes it so the generated code passes lint checks that the end user wants.