### PR TITLE
Fix prop_state_machine cannot find value `config`

### DIFF
--- a/proptest-state-machine/src/test_runner.rs
+++ b/proptest-state-machine/src/test_runner.rs
@@ -190,7 +190,7 @@ macro_rules! prop_state_machine {
                 fn $test_name(
                     (initial_state, transitions) in <$test $(< $( $ty_param ),+ >)? as StateMachineTest>::Reference::sequential_strategy($size)
                 ) {
-                    $test $(::< $( $ty_param ),+ >)? ::test_sequential(config, initial_state, transitions)
+                    $test $(::< $( $ty_param ),+ >)? ::test_sequential(Default::default(), initial_state, transitions)
                 }
             }
         )*


### PR DESCRIPTION
When `#![proptest_config(..)]` is not provided, the macro should use the default proptest config. This PR fixes an issue that prevents this from working -- there's a reference to `config` that should be `Default::default()` instead:
```
error[E0425]: cannot find value `config` in this scope
     |
2132 | /     prop_state_machine! {
2133 | |         #[test]
2134 | |         fn run(sequential 1..20 => MyTest);
2135 | |     }
     | |_____^ not found in this scope
     |
     = note: this error originates in the macro `prop_state_machine` (in Nightly builds, run with -Z macro-backtrace for more info)
```