### PR TITLE
Delete unseen transitions in state machine test

### DIFF
--- a/proptest-state-machine/CHANGELOG.md
+++ b/proptest-state-machine/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### New Features
+
+- Remove unseen transitions on a first step of shrinking.
+  ([\#388](https://github.com/proptest-rs/proptest/pull/388))
+
 ## 0.2.0
 
 ### Other Notes

--- a/proptest-state-machine/src/strategy.rs
+++ b/proptest-state-machine/src/strategy.rs
@@ -313,12 +313,10 @@ impl<
 
             let included_count = self.included_transitions.count();
 
-            if seen_count >= included_count {
-                // the test runner saw all the transitions and failed on the
-                // last one, so we cant delete any transitions from the end.
-            } else {
+            if seen_count < included_count {
                 // the test runner did not see all the transitions so we can
-                // delete the transitions that were not seen and thus not executed.
+                // delete the transitions that were not seen because they were
+                // not executed
 
                 let mut kept_count = 0;
                 for ix in 0..self.transitions.len() {


### PR DESCRIPTION
This PR adds a new shrinking step to `proptest_state_machine::SequentialValueTree` that deletes all transitions not seen by the test runner as the first step. This is related to #387.

To do that it changes the value type from a `Vec<Transition>` to a new wrapper type `ObservedVec<T>`. This new type contains a counter that is shared with `SequentialValueTree` and keeps track of how many transitions have been seen by the test runner.

The shared counter is reset on each call to `simplify` / `complicate`, therefore it is no longer valid to call `current` multiple times without calling `simplify` and/or `complicate` in between.

Given my (admittedly limited) understanding of how `proptest` works this is not an issue as the intention is for the value tree to be used in a loop where each iteration starts with a call to `current` which produces a value that is used in a test run and based on the test result `simplify` or `complicate` is called at least one time before the next iteration.

Any feedback would be welcome! 