### PR TITLE
add boxed union feature to circumvent stack overflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,3 +70,6 @@ jobs:
       - name: Clean and Run tests for derive
         if: ${{ matrix.build == 'nightly' }}
         run: cd proptest-derive && cargo clean && cargo test
+      - name: Clean and Run tests for derive with features enabled
+        if: ${{ matrix.build == 'nightly' }}
+        run: cd proptest-derive && cargo clean && cargo test --features boxed_union

--- a/proptest-derive/Cargo.toml
+++ b/proptest-derive/Cargo.toml
@@ -37,6 +37,10 @@ proc-macro2 = "1.0"
 syn = { version = "1.0.0", features = ["visit", "extra-traits", "full"] }
 quote = "1.0"
 
+[features]
+# Don't generate TupleUnion structs in #[derive(Arbitrary)] code
+boxed_union = []
+
 [[bench]]
 name = "large_enum"
 harness = false

--- a/proptest-derive/src/tests.rs
+++ b/proptest-derive/src/tests.rs
@@ -87,7 +87,7 @@ test! {
             type Strategy = fn() -> Self;
 
             fn arbitrary_with(_top: Self::Parameters) -> Self::Strategy {
-                || MyUnitStruct {}
+                (|| MyUnitStruct {}) as fn() -> _
             }
         }
         };
@@ -108,7 +108,7 @@ test! {
             type Strategy = fn() -> Self;
 
             fn arbitrary_with(_top: Self::Parameters) -> Self::Strategy {
-                || MyTupleUnitStruct {}
+                (|| MyTupleUnitStruct {}) as fn() -> _
             }
         }
         };
@@ -129,7 +129,7 @@ test! {
             type Strategy = fn() -> Self;
 
             fn arbitrary_with(_top: Self::Parameters) -> Self::Strategy {
-                || MyNamedUnitStruct {}
+                (|| MyNamedUnitStruct {}) as fn () -> _
             }
         }
         };


### PR DESCRIPTION
For enums with a lot of variants the `Strategy` synthesized by the `#[derive(Arbitrary)]` macro is a right-deep `TupleUnion`.

This commit adds a `boxed_union` feature, which when enabled will change the `enum` expansion to use `Union<BoxedStrategy<Self>>`.

see github issues:
https://github.com/proptest-rs/proptest/issues/249 https://github.com/proptest-rs/proptest/issues/152

code included from https://github.com/proptest-rs/proptest/issues/249#issuecomment-1367820389