### PR TITLE
Fix re-complication of initial state

### DIFF
--- a/proptest-state-machine/CHANGELOG.md
+++ b/proptest-state-machine/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Removed the limit of number of transitions that can be deleted in shrinking that depended on the number the of transitions given to `prop_state_machine!` or `ReferenceStateMachine::sequential_strategy`.
 - Fixed state-machine macro's inability to handle missing config
 - Fixed logging of state machine transitions to be enabled when verbose config is >= 1. The "std" feature is added to proptest-state-machine as a default feature that allows to switch the logging off in non-std env.
+- Fixed an issue where after simplification of the initial state causes the test to succeed, the initial state would not be re-complicated - causing the test to report a succeeding input as the simplest failing input.

--- a/proptest-state-machine/proptest-regressions/strategy.txt
+++ b/proptest-state-machine/proptest-regressions/strategy.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 2e5fb0b2e70b08bd8a567bf4d9ae66ee2478d832d6bdfb9670f5b98203e78178 # shrinks to seed = [120, 233, 214, 148, 193, 171, 178, 64, 157, 62, 78, 165, 215, 79, 177, 175, 171, 202, 51, 93, 79, 238, 39, 104, 174, 79, 152, 255, 45, 174, 27, 168]
+cc 39927f23e5f67ac32c5219c226c49d87e3e3c995a73cd969d72fbcdf52ac895b # shrinks to seed = [0, 10, 244, 19, 249, 125, 161, 150, 61, 56, 77, 245, 12, 228, 187, 180, 148, 61, 17, 32, 189, 118, 70, 47, 147, 210, 94, 127, 210, 23, 128, 75]


### PR DESCRIPTION
This PR fixes an issue where, after the initial state in a state machine test has been simplified, it will not be re-complicated when this results in a successful run. As a result, when this situation is encountered, the test will report a "minimal failing input" that is actually a successful input - the input that is just barely simpler than the minimal failing input.

I've also added a proptest that detects the failure, along with two regression seeds, for good measure.