### PR TITLE
Add features `handle-panics` and `backtrace` 

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Setting `PROPTEST_MAX_DEFAULT_SIZE_RANGE` now customizes the default `SizeRange`
   used by the default strategies for collections (like `Vec`). The default remains 100.
+- Added `handle-panics` feature which enables catching panics raised in tests and turning them into failures
+- Added `backtrace` feature which enables capturing backtraces for both test failures and panics,
+  if `handle-panics` feature is enabled
 
 ## 1.4.0
 

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -58,6 +58,8 @@ bit-set = [ "dep:bit-set", "dep:bit-vec" ]
 # In particular, hides all intermediate panics flowing into stderr during shrink phase
 handle-panics = ["std"]
 
+backtrace = ["std"]
+
 [dependencies]
 bitflags = "2"
 unarray = "0.1.4"

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -54,6 +54,10 @@ atomic64bit = []
 
 bit-set = [ "dep:bit-set", "dep:bit-vec" ]
 
+# Enables proper handling of panics
+# In particular, hides all intermediate panics flowing into stderr during shrink phase
+handle-panics = ["std"]
+
 [dependencies]
 bitflags = "2"
 unarray = "0.1.4"

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -58,6 +58,9 @@ bit-set = [ "dep:bit-set", "dep:bit-vec" ]
 # In particular, hides all intermediate panics flowing into stderr during shrink phase
 handle-panics = ["std"]
 
+# Enables gathering of failure backtraces
+# * when test failure is reported via `prop_assert_*` macro
+# * when normal assertion fails or panic fires, if `handle-panics` feature is enabled too
 backtrace = ["std"]
 
 [dependencies]

--- a/proptest/src/collection.rs
+++ b/proptest/src/collection.rs
@@ -714,7 +714,7 @@ mod test {
 
             match result {
                 Ok(true) => num_successes += 1,
-                Err(TestError::Fail(_, value)) => {
+                Err(TestError::Fail(_, _, value)) => {
                     // The minimal case always has between 5 (due to min
                     // length) and 9 (min element value = 1) elements, and
                     // always sums to exactly 9.

--- a/proptest/src/strategy/flatten.rs
+++ b/proptest/src/strategy/flatten.rs
@@ -293,7 +293,7 @@ mod test {
 
             match result {
                 Ok(_) => {}
-                Err(TestError::Fail(_, v)) => {
+                Err(TestError::Fail(_, _, v)) => {
                     failures += 1;
                     assert_eq!((10001, 10002), v);
                 }

--- a/proptest/src/strategy/unions.rs
+++ b/proptest/src/strategy/unions.rs
@@ -495,8 +495,8 @@ mod test {
 
             match result {
                 Ok(true) => passed += 1,
-                Err(TestError::Fail(_, 15)) => converged_low += 1,
-                Err(TestError::Fail(_, 30)) => converged_high += 1,
+                Err(TestError::Fail(_, _, 15)) => converged_low += 1,
+                Err(TestError::Fail(_, _, 30)) => converged_high += 1,
                 e => panic!("Unexpected result: {:?}", e),
             }
         }
@@ -572,8 +572,8 @@ mod test {
 
             match result {
                 Ok(true) => passed += 1,
-                Err(TestError::Fail(_, 15)) => converged_low += 1,
-                Err(TestError::Fail(_, 30)) => converged_high += 1,
+                Err(TestError::Fail(_, _, 15)) => converged_low += 1,
+                Err(TestError::Fail(_, _, 30)) => converged_high += 1,
                 e => panic!("Unexpected result: {:?}", e),
             }
         }

--- a/proptest/src/string.rs
+++ b/proptest/src/string.rs
@@ -171,10 +171,7 @@ pub fn string_regex_parsed(expr: &Hir) -> ParseResult<String> {
 /// [`regex` crate's documentation](https://docs.rs/regex/*/regex/#opt-out-of-unicode-support)
 /// for more information.
 pub fn bytes_regex(regex: &str) -> ParseResult<Vec<u8>> {
-    let hir = ParserBuilder::new()
-        .utf8(false)
-        .build()
-        .parse(regex)?;
+    let hir = ParserBuilder::new().utf8(false).build().parse(regex)?;
     bytes_regex_parsed(&hir)
 }
 
@@ -361,8 +358,8 @@ fn unsupported<T>(error: &'static str) -> Result<T, Error> {
 mod test {
     use std::collections::HashSet;
 
-    use regex::Regex;
     use regex::bytes::Regex as BytesRegex;
+    use regex::Regex;
 
     use super::*;
 
@@ -402,7 +399,8 @@ mod test {
         max_distinct: usize,
         iterations: usize,
     ) {
-        let generated = generate_byte_values_matching_regex(pattern, iterations);
+        let generated =
+            generate_byte_values_matching_regex(pattern, iterations);
         assert!(
             generated.len() >= min_distinct,
             "Expected to generate at least {} strings, but only \
@@ -477,7 +475,8 @@ mod test {
                 if !ok {
                     panic!(
                         "Generated string {:?} which does not match {:?}",
-                        printable_ascii(&s), pattern
+                        printable_ascii(&s),
+                        pattern
                     );
                 }
 
@@ -584,10 +583,15 @@ mod test {
     fn test_non_utf8_byte_strings() {
         do_test_bytes(r"(?-u)[\xC0-\xFF]\x20", 64, 64, 512);
         do_test_bytes(r"(?-u)\x20[\x80-\xBF]", 64, 64, 512);
-        do_test_bytes(r#"(?x-u)
+        do_test_bytes(
+            r#"(?x-u)
   \xed (( ( \xa0\x80 | \xad\xbf | \xae\x80 | \xaf\xbf )
           ( \xed ( \xb0\x80 | \xbf\xbf ) )? )
-        | \xb0\x80 | \xbe\x80 | \xbf\xbf )"#, 15, 15, 120);
+        | \xb0\x80 | \xbe\x80 | \xbf\xbf )"#,
+            15,
+            15,
+            120,
+        );
     }
 
     fn assert_send_and_sync<T: Send + Sync>(_: T) {}

--- a/proptest/src/sugar.rs
+++ b/proptest/src/sugar.rs
@@ -754,7 +754,10 @@ macro_rules! prop_assert {
             let message = format!($($fmt)*);
             let message = format!("{} at {}:{}", message, file!(), line!());
             return ::core::result::Result::Err(
-                $crate::test_runner::TestCaseError::fail(message));
+                $crate::test_runner::TestCaseError::Fail(
+                    message.into(),
+                    $crate::test_runner::Backtrace::capture(),
+                ));
         }
     };
 }

--- a/proptest/src/test_runner/backtrace.rs
+++ b/proptest/src/test_runner/backtrace.rs
@@ -1,0 +1,135 @@
+//-
+// Copyright 2024
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core::fmt;
+/// Holds test failure backtrace, if captured
+///
+/// If feature `backtrace` is disabled, it's a zero-sized struct with no logic
+///
+/// If `backtrace` is enabled, attempts to capture backtrace using `std::backtrace::Backtrace` -
+/// if requested
+#[derive(Clone, Default)]
+pub struct Backtrace(internal::Backtrace);
+
+impl Backtrace {
+    /// Creates empty backtrace object
+    ///
+    /// Used when client code doesn't care
+    pub fn empty() -> Self {
+        Self(internal::Backtrace::empty())
+    }
+    /// Tells whether there's backtrace captured
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    /// Attempts to capture backtrace - but only if `backtrace` feature is enabled
+    #[inline(always)]
+    pub fn capture() -> Self {
+        Self(internal::Backtrace::capture())
+    }
+}
+
+impl fmt::Debug for Backtrace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for Backtrace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+#[cfg(feature = "backtrace")]
+mod internal {
+    use core::fmt;
+    use std::backtrace as bt;
+    use std::sync::Arc;
+
+    // `std::backtrace::Backtrace` isn't `Clone`, so we have
+    // to use `Arc` to also maintain `Send + Sync`
+    #[derive(Clone, Default)]
+    pub struct Backtrace(Option<Arc<bt::Backtrace>>);
+
+    impl Backtrace {
+        pub fn empty() -> Self {
+            Self(None)
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.0.is_none()
+        }
+
+        #[inline(always)]
+        pub fn capture() -> Self {
+            let bt = bt::Backtrace::capture();
+            // Store only if we have backtrace
+            if bt.status() == bt::BacktraceStatus::Captured {
+                Self(Some(Arc::new(bt)))
+            } else {
+                Self(None)
+            }
+        }
+    }
+
+    impl fmt::Debug for Backtrace {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            if let Some(ref arc) = self.0 {
+                fmt::Debug::fmt(arc.as_ref(), f)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl fmt::Display for Backtrace {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            if let Some(ref arc) = self.0 {
+                fmt::Display::fmt(arc.as_ref(), f)
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "backtrace"))]
+mod internal {
+    use core::fmt;
+
+    #[derive(Clone, Default)]
+    pub struct Backtrace;
+
+    impl Backtrace {
+        pub fn empty() -> Self {
+            Self
+        }
+
+        pub fn is_empty(&self) -> bool {
+            true
+        }
+
+        pub fn capture() -> Self {
+            Self
+        }
+    }
+
+    impl fmt::Debug for Backtrace {
+        fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+            Ok(())
+        }
+    }
+
+    impl fmt::Display for Backtrace {
+        fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+            Ok(())
+        }
+    }
+}

--- a/proptest/src/test_runner/errors.rs
+++ b/proptest/src/test_runner/errors.rs
@@ -138,10 +138,17 @@ impl<T: fmt::Debug> fmt::Display for TestError<T> {
             TestError::Abort(ref why) => write!(f, "Test aborted: {}", why),
             TestError::Fail(ref why, ref bt, ref what) => {
                 writeln!(f, "Test failed: {}.", why)?;
+
                 if !bt.is_empty() {
-                    writeln!(f, "{bt}")?;
+                    writeln!(f, "\nstack backtrace:\n{bt}")?;
+                    // No need for extra newline, backtrace seems to print it anyway
+                } else {
+                    // Extra empty line between failure description and minimal failing input
+                    writeln!(f)?;
                 }
-                write!(f, "minimal failing input: {:#?}", what)
+
+                writeln!(f, "minimal failing input: {:#?}", what)?;
+                Ok(())
             }
         }
     }

--- a/proptest/src/test_runner/errors.rs
+++ b/proptest/src/test_runner/errors.rs
@@ -125,7 +125,8 @@ impl<T: PartialEq> PartialEq for TestError<T> {
             (Self::Fail(l0, _, l2), Self::Fail(r0, _, r2)) => {
                 l0 == r0 && l2 == r2
             }
-            _ => false,
+            (TestError::Abort(_), TestError::Fail(_, _, _))
+            | (TestError::Fail(_, _, _), TestError::Abort(_)) => false,
         }
     }
 }

--- a/proptest/src/test_runner/errors.rs
+++ b/proptest/src/test_runner/errors.rs
@@ -1,5 +1,5 @@
 //-
-// Copyright 2017, 2018 The proptest developers
+// Copyright 2017, 2018, 2024 The proptest developers
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -13,6 +13,8 @@ use crate::std_facade::fmt;
 use std::string::ToString;
 
 use crate::test_runner::Reason;
+
+use super::Backtrace;
 
 /// Errors which can be returned from test cases to indicate non-successful
 /// completion.
@@ -30,7 +32,7 @@ pub enum TestCaseError {
     /// a new input and try again.
     Reject(Reason),
     /// The code under test failed the test.
-    Fail(Reason),
+    Fail(Reason, Backtrace),
 }
 
 /// Indicates the type of test that ran successfully.
@@ -76,7 +78,7 @@ impl TestCaseError {
     /// The string should indicate the location of the failure, but may
     /// generally be any string.
     pub fn fail(reason: impl Into<Reason>) -> Self {
-        TestCaseError::Fail(reason.into())
+        TestCaseError::Fail(reason.into(), Backtrace::empty())
     }
 }
 
@@ -86,7 +88,13 @@ impl fmt::Display for TestCaseError {
             TestCaseError::Reject(ref whence) => {
                 write!(f, "Input rejected at {}", whence)
             }
-            TestCaseError::Fail(ref why) => write!(f, "Case failed: {}", why),
+            TestCaseError::Fail(ref why, ref bt) => {
+                if bt.is_empty() {
+                    write!(f, "Case failed: {why}")
+                } else {
+                    write!(f, "Case failed: {why}\n{bt}")
+                }
+            }
         }
     }
 }

--- a/proptest/src/test_runner/mod.rs
+++ b/proptest/src/test_runner/mod.rs
@@ -1,5 +1,5 @@
 //-
-// Copyright 2017, 2018 The proptest developers
+// Copyright 2017, 2018, 2024 The proptest developers
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -12,6 +12,7 @@
 //! You do not normally need to access things in this module directly except
 //! when implementing new low-level strategies.
 
+mod backtrace;
 mod config;
 mod errors;
 mod failure_persistence;
@@ -22,6 +23,7 @@ mod result_cache;
 mod rng;
 mod runner;
 
+pub use self::backtrace::*;
 pub use self::config::*;
 pub use self::errors::*;
 pub use self::failure_persistence::*;

--- a/proptest/src/test_runner/replay.rs
+++ b/proptest/src/test_runner/replay.rs
@@ -83,7 +83,7 @@ fn step_to_char(step: &TestCaseResult) -> char {
     match *step {
         Ok(_) => '+',
         Err(TestCaseError::Reject(_)) => '!',
-        Err(TestCaseError::Fail(_)) => '-',
+        Err(TestCaseError::Fail(_, _)) => '-',
     }
 }
 

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -9,7 +9,7 @@
 
 use crate::std_facade::{Arc, String, ToOwned, Vec};
 use core::result::Result;
-use core::{fmt, str, u8, convert::TryInto};
+use core::{convert::TryInto, fmt, str, u8};
 
 use rand::{self, Rng, RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -210,7 +210,7 @@ where
     })
 }
 
-#[cfg(all(feature = "handle-panics", feature = "std"))]
+#[cfg(feature = "handle-panics")]
 mod panicky {
     use std::{ptr, mem};
     use std::cell::Cell;
@@ -285,8 +285,9 @@ mod panicky {
     }
 }
 
-#[cfg(all(not(feature = "handle-panics"), feature = "std"))]
+#[cfg(not(feature = "handle-panics"))]
 mod panicky {
+    use std::panic::Panic;
     pub fn with_hook<R>(
         _: impl FnMut(&PanicInfo<'_>) -> bool,
         body: impl FnOnce() -> R,

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -244,6 +244,7 @@ mod panicky {
             // It's assumed that if container's ptr is not null, ptr to `FnMut` is non-null too
             let hook = unsafe { &mut *(*handler).0 };
             (hook)(info);
+            return;
         }
 
         if let Some(hook) = unsafe { DEF_HOOK.as_ref() } {

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -285,7 +285,7 @@ mod panicky {
     }
 }
 
-#[cfg(not(all(feature = "handle-panics", feature = "std")))]
+#[cfg(all(not(feature = "handle-panics"), feature = "std"))]
 mod panicky {
     pub fn with_hook<R>(
         _: impl FnMut(&PanicInfo<'_>) -> bool,

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -214,6 +214,18 @@ where
 
 #[cfg(feature = "handle-panics")]
 mod panicky {
+    //! Implementation of scoped panic hooks
+    //!
+    //! 1. `with_hook` serves as entry point, it executes body closure with panic hook closure
+    //!     installed as scoped panic hook
+    //! 2. Upon first execution, current panic hook is replaced with `scoped_hook_dispatcher`
+    //!     in a thread-safe manner, and original hook is stored for later use
+    //! 3. When panic occurs, `scoped_hook_dispatcher` either delegates execution to scoped
+    //!     panic hook, if one is installed, or back to original hook stored earlier.
+    //!     This preserves original behavior when scoped hook isn't used
+    //! 4. When `with_hook` is used, it replaces stored scoped hook pointer with pointer to
+    //!     hook closure passed as parameter. Old hook pointer is set to be restored unconditionally
+    //!     via drop guard. Then, normal body closure is executed.
     use std::boxed::Box;
     use std::cell::Cell;
     use std::panic::{set_hook, take_hook, PanicInfo};
@@ -221,9 +233,11 @@ mod panicky {
     use std::{mem, ptr};
 
     thread_local! {
-        // Pointers to arbitrary fn's are fat, and Rust doesn't allow crafting null pointers
-        // to fat objects. So we just store const pointer to tuple with whatever data we need
-        static HANDLER: Cell<*const (*mut dyn FnMut(&PanicInfo<'_>),)> = Cell::new(ptr::null());
+        /// Pointer to currently installed scoped panic hook, if any
+        ///
+        /// NB: pointers to arbitrary fn's are fat, and Rust doesn't allow crafting null pointers
+        /// to fat objects. So we just store const pointer to tuple with whatever data we need
+        static SCOPED_HOOK_PTR: Cell<*const (*mut dyn FnMut(&PanicInfo<'_>),)> = Cell::new(ptr::null());
     }
 
     static INIT_ONCE: Once = Once::new();
@@ -232,21 +246,24 @@ mod panicky {
     /// NB: no need for external sync, value is mutated only once, when init is performed
     static mut DEFAULT_HOOK: Option<Box<dyn Fn(&PanicInfo<'_>) + Send + Sync>> =
         None;
-
+    /// Replaces currently installed panic hook with `scoped_hook_dispatcher` once,
+    /// in a thread-safe manner
     fn init() {
         INIT_ONCE.call_once(|| {
             let old_handler = take_hook();
-            set_hook(Box::new(scoping_hook));
+            set_hook(Box::new(scoped_hook_dispatcher));
             unsafe {
                 DEFAULT_HOOK = Some(old_handler);
             }
         });
     }
-
-    fn scoping_hook(info: &PanicInfo<'_>) {
-        let handler = HANDLER.get();
+    /// Panic hook which delegates execution to scoped hook,
+    /// if one installed, or to default hook
+    fn scoped_hook_dispatcher(info: &PanicInfo<'_>) {
+        let handler = SCOPED_HOOK_PTR.get();
         if !handler.is_null() {
-            // It's assumed that if container's ptr is not null, ptr to `FnMut` is non-null too
+            // It's assumed that if container's ptr is not null, ptr to `FnMut` is non-null too.
+            // Correctness **must** be ensured by hook switch code in `with_hook`
             let hook = unsafe { &mut *(*handler).0 };
             (hook)(info);
             return;
@@ -256,7 +273,7 @@ mod panicky {
             (hook)(info);
         }
     }
-
+    /// Executes stored closure when dropped
     struct Finally<F: FnOnce()>(Option<F>);
 
     impl<F: FnOnce()> Finally<F> {
@@ -272,22 +289,33 @@ mod panicky {
             }
         }
     }
-
+    /// Executes main closure `body` while installing `guard` as scoped panic hook,
+    /// for execution duration.
+    ///
+    /// Any panics which happen during execution of `body` are passed to `guard` hook
+    /// to collect any info necessary, although unwind process is **NOT** interrupted.
+    /// See module documentation for details
+    ///
+    /// # Parameters
+    /// * `panic_hook` - scoped panic hook, functions for the duration of `body` execution
+    /// * `body` - actual logic covered by `panic_hook`
+    ///
+    /// # Returns
+    /// `body`'s return value
     pub fn with_hook<R>(
-        mut guard: impl FnMut(&PanicInfo<'_>),
+        mut panic_hook: impl FnMut(&PanicInfo<'_>),
         body: impl FnOnce() -> R,
     ) -> R {
         init();
-
+        // Construct scoped hook pointer
         let guard_tuple = (unsafe {
-            // to erase all lifetimes, it won't be used for longer
-            // than func scope anyway
-            mem::transmute(&mut guard as *mut dyn FnMut(&PanicInfo<'_>))
+            // `mem::transmute` is needed due to borrow checker restrictions to erase all lifetimes
+            mem::transmute(&mut panic_hook as *mut dyn FnMut(&PanicInfo<'_>))
         },);
-
-        let old_tuple = HANDLER.replace(&guard_tuple);
+        let old_tuple = SCOPED_HOOK_PTR.replace(&guard_tuple);
+        // Old scoped hook **must** be restored before leaving function scope to keep it sound
         let _undo = Finally::new(|| {
-            HANDLER.set(old_tuple);
+            SCOPED_HOOK_PTR.set(old_tuple);
         });
         body()
     }
@@ -296,6 +324,8 @@ mod panicky {
 #[cfg(not(feature = "handle-panics"))]
 mod panicky {
     use std::panic::PanicInfo;
+    /// Simply executes `body` and returns its execution result.
+    /// Hook parameter is ignored
     pub fn with_hook<R>(
         _: impl FnMut(&PanicInfo<'_>),
         body: impl FnOnce() -> R,


### PR DESCRIPTION
* `handle-panics` attempts to capture panic backtrace when one happens, instead of spitting it to console
* `backtrace` enables actual backtraces using `std::backtrace`
* Short backtrace printed second time after test failure is produced by toplevel test func reporting its failure via panic, can be remedied by rewriting helper macros so that they return failure instead of panicking.
* Collected backtrace is still 50+ frames long. Unfortunately it seems to be impossible to even enumerate frames on stable, yet alone use existing short backtrace style. `Backtrace::frames()` and `BacktraceFrame` are still experimental.

P.S: Sorry for "PR spam", prev one #419 was closed prematurely due to accident

closes #356