### PR TITLE
[Fix] Config : don't clobber existing failure-persistence config during contextualization

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Setting `PROPTEST_MAX_DEFAULT_SIZE_RANGE` now customizes the default `SizeRange`
   used by the default strategies for collections (like `Vec`). The default remains 100.
 
+### Bug Fixes
+- Fixed issue where config contextualization would clobber existing failure persistence config
+
 ## 1.4.0
 
 ### Breaking Changes

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -80,8 +80,6 @@ pub fn contextualize_config(mut result: Config) -> Config {
         }
     }
 
-    result.failure_persistence =
-        Some(Box::new(FileFailurePersistence::default()));
     for (var, value) in
         env::vars_os().filter_map(|(k, v)| k.into_string().ok().map(|k| (k, v)))
     {
@@ -186,8 +184,11 @@ fn default_default_config() -> Config {
 // defaults.
 #[cfg(feature = "std")]
 lazy_static! {
-    static ref DEFAULT_CONFIG: Config =
-        contextualize_config(default_default_config());
+    static ref DEFAULT_CONFIG: Config = {
+        let mut default_config = default_default_config();
+        default_config.failure_persistence = Some(Box::new(FileFailurePersistence::default()));
+        contextualize_config(default_config)
+    };
 }
 
 /// Configuration for how a proptest test should be run.


### PR DESCRIPTION
fixes #423 