### PR TITLE
fix: use anon-const for wrapping expanded impls

### DIFF
--- a/proptest-derive/src/ast.rs
+++ b/proptest-derive/src/ast.rs
@@ -106,8 +106,6 @@ impl Impl {
 
         let _top = call_site_ident(TOP_PARAM_NAME);
 
-        let _const = call_site_ident(&format!("_IMPL_ARBITRARY_FOR_{}", typ));
-
         // Linearise everything. We're done after this.
         //
         // NOTE: The clippy::arc_with_non_send_sync lint is disabled here because the strategies
@@ -118,7 +116,7 @@ impl Impl {
         let q = quote! {
             #[allow(non_upper_case_globals)]
             #[allow(clippy::arc_with_non_send_sync)]
-            const #_const: () = {
+            const _: () = {
             extern crate proptest as _proptest;
 
             impl #impl_generics _proptest::arbitrary::Arbitrary

--- a/proptest-derive/src/tests.rs
+++ b/proptest-derive/src/tests.rs
@@ -80,7 +80,7 @@ test! {
     } expands to {
         #[allow(non_upper_case_globals)]
         #[allow(clippy::arc_with_non_send_sync)]
-        const _IMPL_ARBITRARY_FOR_MyUnitStruct : () = {
+        const _: () = {
             extern crate proptest as _proptest;
         impl _proptest::arbitrary::Arbitrary for MyUnitStruct {
             type Parameters = ();
@@ -101,7 +101,7 @@ test! {
     } expands to {
         #[allow(non_upper_case_globals)]
         #[allow(clippy::arc_with_non_send_sync)]
-        const _IMPL_ARBITRARY_FOR_MyTupleUnitStruct : () = {
+        const _: () = {
             extern crate proptest as _proptest;
         impl _proptest::arbitrary::Arbitrary for MyTupleUnitStruct {
             type Parameters = ();
@@ -122,7 +122,7 @@ test! {
     } expands to {
         #[allow(non_upper_case_globals)]
         #[allow(clippy::arc_with_non_send_sync)]
-        const _IMPL_ARBITRARY_FOR_MyNamedUnitStruct : () = {
+        const _: () = {
             extern crate proptest as _proptest;
         impl _proptest::arbitrary::Arbitrary for MyNamedUnitStruct {
             type Parameters = ();


### PR DESCRIPTION
On latest nightly, with the introduction of https://github.com/rust-lang/rust/issues/120363, proptest derives don't pass lints anymore, e.g.
```console
error: non-local `impl` definition, they should be avoided as they go against expectation
  --> crates/primitives/src/account.rs:15:12
   |
15 | pub struct Account {
   |            ^^^^^^^
   |
   = help: move this `impl` block outside the of the current constant `_IMPL_ARBITRARY_FOR_Account`
   = note: an `impl` definition is non-local if it is nested inside an item and neither the type nor the trait are at the same nesting level as the `impl` block
   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
   = note: the derive macro `AccountPropTestArbitrary` may come from an old version of the `proptest_derive` crate, try updating your dependency with `cargo update -p proptest_derive`
   = note: `-D non-local-definitions` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(non_local_definitions)]`
   = note: this error originates in the derive macro `AccountPropTestArbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This fix is similar to https://github.com/dtolnay/typetag/commit/d51f4adc253f12a02939625ebbab9305ca66f567, i.e. use anon const expressions instead of named ones.