### PR TITLE
Fix feature = "cargo-clippy" deprecation

### DIFF
--- a/proptest/src/arbitrary/_alloc/collections.rs
+++ b/proptest/src/arbitrary/_alloc/collections.rs
@@ -9,7 +9,7 @@
 
 //! Arbitrary implementations for `std::collections`.
 
-//#![cfg_attr(feature="cargo-clippy", allow(implicit_hasher))]
+//#![cfg_attr(clippy, allow(implicit_hasher))]
 
 //==============================================================================
 // Imports:

--- a/proptest/src/arbitrary/_core/cell.rs
+++ b/proptest/src/arbitrary/_core/cell.rs
@@ -17,7 +17,7 @@ wrap_from!(UnsafeCell);
 
 lazy_just!(BorrowError, || {
     // False positive:
-    #[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
+    #[cfg_attr(clippy, allow(let_and_return))]
     {
         let _rc = RefCell::new(());
         let _bm = _rc.borrow_mut();
@@ -28,7 +28,7 @@ lazy_just!(BorrowError, || {
 });
 lazy_just!(BorrowMutError, || {
     // False positive:
-    #[cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
+    #[cfg_attr(clippy, allow(let_and_return))]
     {
         let _rc = RefCell::new(());
         let _bm = _rc.borrow_mut();

--- a/proptest/src/bits.rs
+++ b/proptest/src/bits.rs
@@ -32,7 +32,7 @@ use crate::strategy::*;
 use crate::test_runner::*;
 
 /// Trait for types which can be handled with `BitSetStrategy`.
-#[cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty))]
+#[cfg_attr(clippy, allow(len_without_is_empty))]
 pub trait BitSetLike: Clone + fmt::Debug {
     /// Create a new value of `Self` with space for up to `max` bits, all
     /// initialised to zero.

--- a/proptest/src/lib.rs
+++ b/proptest/src/lib.rs
@@ -17,7 +17,7 @@
 #![forbid(future_incompatible)]
 #![deny(missing_docs, bare_trait_objects)]
 #![no_std]
-#![cfg_attr(feature = "cargo-clippy", allow(
+#![cfg_attr(clippy, allow(
     doc_markdown,
     // We have a lot of these lints for associated types... And we don't care.
     type_complexity

--- a/proptest/src/option.rs
+++ b/proptest/src/option.rs
@@ -9,7 +9,7 @@
 
 //! Strategies for generating `std::Option` values.
 
-#![cfg_attr(feature = "cargo-clippy", allow(expl_impl_clone_on_copy))]
+#![cfg_attr(clippy, allow(expl_impl_clone_on_copy))]
 
 use core::fmt;
 use core::marker::PhantomData;

--- a/proptest/src/result.rs
+++ b/proptest/src/result.rs
@@ -26,7 +26,7 @@
 //! "maybe err" since the success case results in an easier to understand code
 //! path.
 
-#![cfg_attr(feature = "cargo-clippy", allow(expl_impl_clone_on_copy))]
+#![cfg_attr(clippy, allow(expl_impl_clone_on_copy))]
 
 use core::fmt;
 use core::marker::PhantomData;


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html