### PR TITLE
Use `array::from_fn` instead of `unarray::build_array`

### DIFF
--- a/proptest/src/array.rs
+++ b/proptest/src/array.rs
@@ -149,7 +149,7 @@ impl<T: ValueTree, const N: usize> ValueTree for ArrayValueTree<[T; N]> {
     type Value = [T::Value; N];
 
     fn current(&self) -> [T::Value; N] {
-        unarray::build_array(|i| self.tree[i].current())
+        core::array::from_fn(|i| self.tree[i].current())
     }
 
     fn simplify(&mut self) -> bool {


### PR DESCRIPTION
`core::array::from_fn` is stable since 1.63, and the current MSRV is 1.64.

Ideally `unarray` would get entirely replaced but `core::array::try_from_fn` is
still unstable.