### PR TITLE
doc: fix broken links in book

### DIFF
--- a/book/src/proptest/tutorial/enums.md
+++ b/book/src/proptest/tutorial/enums.md
@@ -5,7 +5,8 @@ limited. Creating such strategies with `prop_compose!` is possible but
 generally is not very readable, so in most cases defining the function by
 hand is preferable.
 
-The core building block is the [`prop_oneof!`](macro.prop_oneof.html)
+The core building block is the
+[`prop_oneof!`](https://docs.rs/proptest/latest/proptest/macro.prop_oneof.html)
 macro, in which you list one case for each case in your `enum`. For `enum`s
 which have no data, the strategy for each case is
 `Just(YourEnum::TheCase)`. Enum cases with data generally require putting

--- a/book/src/proptest/tutorial/test-runner.md
+++ b/book/src/proptest/tutorial/test-runner.md
@@ -1,11 +1,10 @@
 # Using the Test Runner
 
 Rather than manually shrinking, proptest's
-[`TestRunner`](test_runner/struct.TestRunner.html) provides this
-functionality for us and additionally handles things like panics. The
-method we're interested in is `run`. We simply
-give it the strategy and a function to test inputs and it takes care of the
-rest.
+[`TestRunner`](https://docs.rs/proptest/latest/proptest/test_runner/struct.TestRunner.html)
+provides this functionality for us and additionally handles things like panics.
+The method we're interested in is `run`. We simply give it the strategy and a
+function to test inputs and it takes care of the rest.
 
 ```rust
 # extern crate proptest;


### PR DESCRIPTION
[TestRunner doc page](https://proptest-rs.github.io/proptest/proptest/tutorial/test-runner.html) and [Enums doc page](https://proptest-rs.github.io/proptest/proptest/tutorial/enums.html) have broken links to `TestRunner` and `prop_oneof!` respectively. Fixing these to point to correct doc.rs link