### PR TITLE
Verbosity of shrink disabled and persisted failure messages

### DIFF
--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -760,6 +760,16 @@ impl TestRunner {
         fork_output: &mut ForkOutput,
         is_from_persisted_seed: bool,
     ) -> Option<Reason> {
+        // exit early if shrink disabled
+        if self.config.max_shrink_iters == 0 {
+            verbose_message!(
+                self,
+                INFO_LOG,
+                "Shrinking disabled by configuration"
+            );
+            return None
+        }
+
         #[cfg(feature = "std")]
         use std::time;
 


### PR DESCRIPTION
re #453 handle exit early with INFO message
To be determined best way to handle the failure persisted message
https://github.com/proptest-rs/proptest/issues/453#issuecomment-2155796541