### PR TITLE
Detect empty ranges during tree creation

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Setting `PROPTEST_MAX_DEFAULT_SIZE_RANGE` now customizes the default `SizeRange`
   used by the default strategies for collections (like `Vec`). The default remains 100.
+- Empty ranges panic during tree creation instead of during sampling.
 
 ### Bug Fixes
 - Fixed issue where config contextualization would clobber existing failure persistence config


### PR DESCRIPTION
Currently, if an empty range is used as base for a strategy, the generation will fail during the call to the `rand` crate as it cannot sample from an empty range. This PR creates a panic during the tree construction (the soonest we can) with a descriptive message, facilitating tracking the source of the issue.

Solves https://github.com/proptest-rs/proptest/issues/449

The panic message test pattern follows Rust's core library https://github.com/rust-lang/rust/blob/a1bad57fa59a8069a6ebb05cd6a2ae73c88b2e98/src/test/run-pass/panic-uninitialized-zeroed.rs