### PR TITLE
[Doc] Arbitrary : add a note about the derive macro in Arbitrary's documentation

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Setting `PROPTEST_MAX_DEFAULT_SIZE_RANGE` now customizes the default `SizeRange`
   used by the default strategies for collections (like `Vec`). The default remains 100.
 
+### Documentation
+- Reference the derive macro in Arbitrary's documentation
+
 ### Bug Fixes
 - Fixed issue where config contextualization would clobber existing failure persistence config
 

--- a/proptest/src/arbitrary/traits.rs
+++ b/proptest/src/arbitrary/traits.rs
@@ -36,9 +36,14 @@ use crate::strategy::Strategy;
 /// which may be lifted in the future as the [generic associated types (GAT)]
 /// feature of Rust is implemented and stabilized.
 ///
+/// If you do not have unique constraints on how to generate the data for your
+/// custom types, consider using [the derive macro] to implement Arbitrary
+///
 /// [generic associated types (GAT)]: https://github.com/rust-lang/rust/issues/44265
 ///
 /// [`Strategy`]: ../strategy/trait.Strategy.html
+///
+/// [the derive macro]: https://docs.rs/proptest-derive/latest/proptest_derive/
 ///
 /// [HaskellQC]:
 /// https://hackage.haskell.org/package/QuickCheck/docs/Test-QuickCheck-Arbitrary.html


### PR DESCRIPTION
fixes #463