### PR TITLE
Implement is_minimal_case

### DIFF
--- a/proptest/src/is_minimal_case.rs
+++ b/proptest/src/is_minimal_case.rs
@@ -37,7 +37,7 @@ thread_local! {
 /// }
 /// ```
 pub fn is_minimal_case() -> bool {
-    IS_MINIMAL_CASE.get()
+    IS_MINIMAL_CASE.with(|cell| cell.get())
 }
 
 /// Helper struct that helps to ensure panic safety when entering a minimal case.
@@ -49,13 +49,13 @@ pub(crate) struct MinimalCaseGuard;
 
 impl MinimalCaseGuard {
     pub(crate) fn begin_minimal_case() -> Self {
-        IS_MINIMAL_CASE.replace(true);
+        IS_MINIMAL_CASE.with(|cell| cell.replace(true));
         Self
     }
 }
 
 impl Drop for MinimalCaseGuard {
     fn drop(&mut self) {
-        IS_MINIMAL_CASE.replace(false);
+        IS_MINIMAL_CASE.with(|cell| cell.replace(false));
     }
 }

--- a/proptest/src/is_minimal_case.rs
+++ b/proptest/src/is_minimal_case.rs
@@ -1,0 +1,61 @@
+use core::cell::Cell;
+
+thread_local! {
+    static IS_MINIMAL_CASE: Cell<bool> = Cell::new(false);
+}
+
+/// When run inside a property test, indicates whether the current case being tested
+/// is the minimal test case.
+///
+/// `proptest` typically runs a large number of test cases for each
+/// property test. If it finds a failing test case, it tries to shrink it
+/// in the hopes of finding a simpler test case. When debugging a failing
+/// property test, we are often only interested in the actual minimal
+/// failing case. After the minimal test case has been identified,
+/// the test is rerun with the minimal input, and this function
+/// returns `true` when called inside the test.
+///
+/// The results are undefined if property tests are nested, meaning that a property test
+/// is run inside another property test.
+///
+/// # Example
+///
+/// ```rust
+/// use proptest::{proptest, prop_assert, is_minimal_case};
+/// # fn export_to_file_for_analysis() {}
+///
+/// proptest! {
+///     #[test]
+///     fn test_is_not_five(num in 0 .. 10) {
+///         if is_minimal_case() {
+///             eprintln!("Minimal test case is {num:?}");
+///             export_to_file_for_analysis(num);
+///         }
+///
+///         prop_assert!(num != 5);
+///     }
+/// }
+/// ```
+pub fn is_minimal_case() -> bool {
+    IS_MINIMAL_CASE.get()
+}
+
+/// Helper struct that helps to ensure panic safety when entering a minimal case.
+///
+/// Specifically, if the test case panics, we must ensure that we still
+/// correctly reset the thread-local variable.
+#[non_exhaustive]
+pub(crate) struct MinimalCaseGuard;
+
+impl MinimalCaseGuard {
+    pub(crate) fn begin_minimal_case() -> Self {
+        IS_MINIMAL_CASE.replace(true);
+        Self
+    }
+}
+
+impl Drop for MinimalCaseGuard {
+    fn drop(&mut self) {
+        IS_MINIMAL_CASE.replace(false);
+    }
+}

--- a/proptest/src/lib.rs
+++ b/proptest/src/lib.rs
@@ -54,6 +54,9 @@ mod product_frunk;
 #[macro_use]
 mod product_tuple;
 
+mod is_minimal_case;
+pub use is_minimal_case::is_minimal_case;
+
 #[macro_use]
 extern crate bitflags;
 #[cfg(feature = "bit-set")]

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -24,7 +24,7 @@ use std::env;
 use std::fs;
 #[cfg(feature = "fork")]
 use tempfile;
-
+use crate::is_minimal_case::MinimalCaseGuard;
 use crate::strategy::*;
 use crate::test_runner::config::*;
 use crate::test_runner::errors::*;
@@ -735,13 +735,35 @@ impl TestRunner {
                 let why = self
                     .shrink(
                         &mut case,
-                        test,
+                        &test,
                         replay_from_fork,
                         result_cache,
                         fork_output,
                         is_from_persisted_seed,
                     )
                     .unwrap_or(why);
+
+                // Run minimal test again
+                let _guard = MinimalCaseGuard::begin_minimal_case();
+                let minimal_result = call_test(
+                    self,
+                    case.current(),
+                    &test,
+                    &mut iter::empty(),
+                    &mut *noop_result_cache(),
+                    // TODO: What should fork_output be?
+                    fork_output,
+                    is_from_persisted_seed,
+                );
+
+                if !matches!(minimal_result, Err(TestCaseError::Fail(_))) {
+                    // TODO: Is it appropriate to use eprintln! here?
+                    // It seems appropriate to atleast notify the user somehow
+                    // that the minimal test case does not consistently fail
+                    eprintln!("unexpected behavior: minimal case did not result in test \
+                               failure on second test run");
+                }
+
                 Err(TestError::Fail(why, case.current()))
             }
             Err(TestCaseError::Reject(whence)) => {


### PR DESCRIPTION
This is a draft for an implementation of the idea suggested in #161.

Currently, using `proptest` for debugging is very cumbersome because you cannot easily run code only for the minimal failing test case. In my experience, I usually only care about the minimal test case, but if I want to print some debug info about that failing test case, I'll have to print for *all* test cases, which is borderline useless.

This PR introduces a method `is_minimal_case` that you can call inside a `proptest` to determine if the current test case is the minimal failing case. To do this, the minimal test case is run one more time after it has been identified, and a thread local boolean is set before and after.

This allows you to write tests like these:
```rust
use proptest::{proptest, prop_assert, is_minimal_case};

proptest! {
    #[test]
    fn test_is_not_five(num in 0 .. 10) {
        if is_minimal_case() {
            eprintln!("Minimal test case is {num:?}");
            export_to_file_for_analysis(num);
        }

        prop_assert!(num != 5);
    }
}
```

A nice side effect of this is that it makes it much easier to use `proptest` with a debugger: Simple add an `if` condition like the one above, and put a breakpoint on a statement inside the branch. Then you can run the debugger only through the minimal failing test case.

I haven't yet written any tests, because I'm frankly not quite sure how best to go about it. I suppose at a minimum we should have a test where a `TestRunner` is manually invoked with a dummy test case, where we test that the reported minimal test case is what we expect. But I'm not sure how best to write such a test in a way that fits well with the rest of the code base. I'd be very grateful to have some suggestions here.

I'm not sure how to correctly handle forking here - if anything in particular even needs to be done differently. And whether or not I should forward `is_from_persistent_seed`. Since I'm not so familiar with the code base I don't really understand the ramifications.

Happy to make any necessary adjustments to the PR.