### PR TITLE
fix: check preconditions on correct state

### DIFF
--- a/proptest-state-machine/CHANGELOG.md
+++ b/proptest-state-machine/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Fixed checking of pre-conditions with a shrinked or complicated initial state.
+  ([\#482](https://github.com/proptest-rs/proptest/pull/482/commits/9b61544d75f5e44aad742f4546f0e83f2639394c))
+
 ## 0.3.0
 
 ### New Features

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -768,6 +768,8 @@ impl TestRunner {
         #[cfg(feature = "std")]
         let start_time = time::Instant::now();
 
+        verbose_message!(self, TRACE, "Starting shrinking");
+
         if case.simplify() {
             loop {
                 #[cfg(feature = "std")]
@@ -858,12 +860,24 @@ impl TestRunner {
                     // the function under test is acceptable.
                     Ok(_) | Err(TestCaseError::Reject(..)) => {
                         if !case.complicate() {
+                            verbose_message!(
+                                self,
+                                TRACE,
+                                "Cannot complicate further"
+                            );
+
                             break;
                         }
                     }
                     Err(TestCaseError::Fail(why)) => {
                         last_failure = Some(why);
                         if !case.simplify() {
+                            verbose_message!(
+                                self,
+                                TRACE,
+                                "Cannot simplify further"
+                            );
+
                             break;
                         }
                     }


### PR DESCRIPTION
When shrinking a state machine test, proptest either shrinks a transition, deletes a transition or attempts to shrink the initial state. The `check_acceptable` function however uses the `last_valid_initial_state` which isn't the correct one if we just shrank / complicated the initial state.