### PR TITLE
feat: introduce `Sequential::new`

### DIFF
--- a/proptest-state-machine/src/strategy.rs
+++ b/proptest-state-machine/src/strategy.rs
@@ -102,13 +102,13 @@ pub trait ReferenceStateMachine {
         BoxedStrategy<Self::State>,
         BoxedStrategy<Self::Transition>,
     > {
-        Sequential {
-            size: size.into(),
-            init_state: Self::init_state,
-            preconditions: Self::preconditions,
-            transitions: Self::transitions,
-            next: Self::apply,
-        }
+        Sequential::new(
+            size.into(),
+            Self::init_state,
+            Self::preconditions,
+            Self::transitions,
+            Self::apply,
+        )
     }
 }
 
@@ -144,6 +144,26 @@ pub struct Sequential<State, Transition, StateStrategy, TransitionStrategy> {
     preconditions: fn(state: &State, transition: &Transition) -> bool,
     transitions: fn(state: &State) -> TransitionStrategy,
     next: fn(state: State, transition: &Transition) -> State,
+}
+
+impl<State, Transition, StateStrategy, TransitionStrategy>
+    Sequential<State, Transition, StateStrategy, TransitionStrategy>
+{
+    pub fn new(
+        size: SizeRange,
+        init_state: fn() -> StateStrategy,
+        preconditions: fn(state: &State, transition: &Transition) -> bool,
+        transitions: fn(state: &State) -> TransitionStrategy,
+        next: fn(state: State, transition: &Transition) -> State,
+    ) -> Self {
+        Self {
+            size,
+            init_state,
+            preconditions,
+            transitions,
+            next,
+        }
+    }
 }
 
 impl<State, Transition, StateStrategy, TransitionStrategy> Debug


### PR DESCRIPTION
The `Sequential` struct is where most of the useful functionality of `proptest-state-machine` lives. Currently, it can only be constructed via the `ReferenceStateMachine` trait.

By introducing a dedicated ctor function, users are not bound to use the `ReferenceStateMachine` trait but can initialise the test to their liking whilst still being able to use all of the shrinking functionality built into `Sequential`.