### PR TITLE
Make libm optional in a std environment

### DIFF
--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -32,6 +32,9 @@ unstable = []
 std = ["rand/std", "lazy_static",
        "regex-syntax", "num-traits/std"]
 
+# std or libm required for mul_add.
+no_std = ["num-traits/libm"]
+
 # For use in no_std environments with access to an allocator
 #alloc = ["hashmap_core"]
 alloc = []
@@ -72,8 +75,6 @@ optional = true
 [dependencies.num-traits]
 version = "0.2.15"
 default-features = false
-# std or libm required for mul_add.
-features = ["libm"]
 
 [dependencies.regex-syntax]
 # If you change this, make sure to also bump the `regex` dependency to a


### PR DESCRIPTION
When adding `proptest` as a `dev-dependency` it will add `libm` transitively no matter what, and this has noticeable effect on our criterion benchmarks.

This happens even if you add `proptest` like this:

```
proptest = {version = "1.5", features = ["std"], default-features = false}
```