### PR TITLE
build(deps): Update `bit-set` and `bit-vec` to 0.8.0

### DIFF
--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -82,11 +82,11 @@ version = "0.8"
 optional = true
 
 [dependencies.bit-set]
-version = "0.5.2"
+version = "0.8.0"
 optional = true
 
 [dependencies.bit-vec]
-version = "0.6.0"
+version = "0.8.0"
 optional = true
 
 [dependencies.rand]


### PR DESCRIPTION
Given that no code changes were needed, I could change the version requirement to `>=0.5.2, <=0.8`. This allows a range of versions of the dependency. 

I could provide CI jobs to verify that the minimal specified requirement keeps working. 

Please let me know if you want me to do either of these.