### PR TITLE
Add edge bias feature to bias for testing edge cases.

### DIFF
--- a/proptest/src/arbitrary/_std/time.rs
+++ b/proptest/src/arbitrary/_std/time.rs
@@ -17,8 +17,11 @@ use crate::num;
 use crate::strategy::statics::{self, static_map};
 
 arbitrary!(Duration, SMapped<(u64, u32), Self>;
-    static_map(any::<(u64, u32)>(), |(a, b)| Duration::new(a, b))
-);
+    static_map(any::<(u64, u32)>(), |(a, b)|
+    // Duration::new panics if nanoseconds are over one billion (one second)
+    // and overflowing into the seconds would overflow the second counter.
+    Duration::new(a, b % 1_000_000_000)
+));
 
 // Instant::now() "never" returns the same Instant, so no shrinking may occur!
 arbitrary!(Instant; Self::now());

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -38,6 +38,193 @@ pub fn sample_uniform_incl<X: SampleUniform>(
     Uniform::new_inclusive(start, end).sample(run.rng())
 }
 
+trait SampleEdgeCase<T> {
+    fn sample_edge_case(runner: &mut TestRunner, epsilon: T) -> Self;
+}
+
+macro_rules! impl_sample_edge_case_signed_impl {
+    ($typ: ty) => {
+        impl SampleEdgeCase<$typ> for $typ {
+            fn sample_edge_case(
+                runner: &mut TestRunner,
+                epsilon: $typ,
+            ) -> $typ {
+                match sample_uniform(runner, 0, 7) {
+                    0 => 0,
+                    1 => epsilon,
+                    2 => -epsilon,
+                    3 => <$typ>::MIN,
+                    4 => <$typ>::MAX,
+                    5 => <$typ>::MIN + epsilon,
+                    6 => <$typ>::MAX - epsilon,
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_sample_edge_case_signed {
+    ($($typ: ty),*) => {
+        $(impl_sample_edge_case_signed_impl!($typ);)*
+    };
+}
+
+macro_rules! impl_sample_edge_case_unsigned_impl {
+    ($typ: ty) => {
+        impl SampleEdgeCase<$typ> for $typ {
+            fn sample_edge_case(
+                runner: &mut TestRunner,
+                epsilon: $typ,
+            ) -> $typ {
+                match sample_uniform(runner, 0, 4) {
+                    0 => 0,
+                    1 => epsilon,
+                    2 => <$typ>::MAX,
+                    3 => <$typ>::MAX - epsilon,
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_sample_edge_case_unsigned {
+    ($($typ: ty),*) => {
+        $(impl_sample_edge_case_unsigned_impl!($typ);)*
+    };
+}
+
+impl_sample_edge_case_signed!(i8, i16, i32, i64, i128, isize);
+impl_sample_edge_case_unsigned!(u8, u16, u32, u64, u128, usize);
+
+trait SampleEdgeCaseRangeExclusive<T> {
+    fn sample_edge_case_range_exclusive(
+        runner: &mut TestRunner,
+        start: T,
+        end: T,
+        epsilon: T,
+    ) -> Self;
+}
+
+macro_rules! impl_sample_edge_case_range_exclusive_impl {
+    ($typ: ty) => {
+        impl SampleEdgeCaseRangeExclusive<$typ> for $typ {
+            fn sample_edge_case_range_exclusive(
+                runner: &mut TestRunner,
+                start: $typ,
+                end: $typ,
+                epsilon: $typ,
+            ) -> $typ {
+                match sample_uniform(runner, 0, 4) {
+                    0 => start,
+                    1 => {
+                        num_traits::clamp(start + epsilon, start, end - epsilon)
+                    }
+                    2 => {
+                        if start < end - epsilon {
+                            end - epsilon * 2 as $typ
+                        } else {
+                            start
+                        }
+                    }
+                    3 => end - epsilon,
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_sample_edge_case_range_exclusive {
+    ($($typ: ty),*) => {
+        $(impl_sample_edge_case_range_exclusive_impl!($typ);)*
+    };
+}
+
+impl_sample_edge_case_range_exclusive!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64
+);
+
+trait SampleEdgeCaseRangeInclusive<T> {
+    fn sample_edge_case_range_inclusive(
+        runner: &mut TestRunner,
+        start: T,
+        end: T,
+        epsilon: T,
+    ) -> Self;
+}
+
+macro_rules! impl_sample_edge_case_range_inclusive_impl {
+    ($typ: ty) => {
+        impl SampleEdgeCaseRangeInclusive<$typ> for $typ {
+            fn sample_edge_case_range_inclusive(
+                runner: &mut TestRunner,
+                start: $typ,
+                end: $typ,
+                epsilon: $typ,
+            ) -> $typ {
+                match sample_uniform(runner, 0, 4) {
+                    0 => start,
+                    1 => num_traits::clamp(start + epsilon, start, end),
+                    2 => num_traits::clamp(end - epsilon, start, end),
+                    3 => end,
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_sample_edge_case_range_inclusive {
+    ($($typ: ty),*) => {
+        $(impl_sample_edge_case_range_inclusive_impl!($typ);)*
+    };
+}
+
+impl_sample_edge_case_range_inclusive!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64
+);
+
+trait SampleEdgeCaseFloat<T> {
+    fn sample_edge_case_float(runner: &mut TestRunner) -> Self;
+}
+
+macro_rules! impl_sample_edge_case_float_impl {
+    ($typ: ty) => {
+        impl SampleEdgeCaseFloat<$typ> for $typ {
+            fn sample_edge_case_float(runner: &mut TestRunner) -> $typ {
+                match sample_uniform(runner, 0, 11) {
+                    0 => 0.0,
+                    1 => -0.0,
+                    2 => 1.0,
+                    3 => -1.0,
+                    4 => <$typ>::MIN,
+                    5 => <$typ>::MAX,
+                    6 => <$typ>::MIN_POSITIVE,
+                    7 => -<$typ>::MIN_POSITIVE,
+                    8 => <$typ>::EPSILON,
+                    // One ULP from MIN and MAX
+                    9 => <$typ>::from_bits(<$typ>::MIN.to_bits() - 1),
+                    10 => <$typ>::from_bits(<$typ>::MAX.to_bits() - 1),
+                    // 11 => <$typ>::NAN,
+                    // 12 => <$typ>::NEG_INFINITY,
+                    // 13 => <$typ>::INFINITY,
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_sample_edge_case_float {
+    ($($typ: ty),*) => {
+        $(impl_sample_edge_case_float_impl!($typ);)*
+    };
+}
+
+impl_sample_edge_case_float!(f32, f64);
+
 macro_rules! int_any {
     ($typ: ident) => {
         /// Type of the `ANY` constant.
@@ -53,6 +240,14 @@ macro_rules! int_any {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                if runner.eval_edge_bias() {
+                    return Ok(BinarySearch::new(
+                        $crate::num::SampleEdgeCase::sample_edge_case(
+                            runner, 1,
+                        ),
+                    ));
+                }
+
                 Ok(BinarySearch::new(runner.rng().gen()))
             }
         }
@@ -74,6 +269,14 @@ macro_rules! numeric_api {
                         "Invalid use of empty range {}..{}.",
                         self.start, self.end
                     );
+                }
+
+                if runner.eval_edge_bias() {
+                    return Ok(BinarySearch::new(
+                        $crate::num::SampleEdgeCaseRangeExclusive::sample_edge_case_range_exclusive(
+                            runner, self.start, self.end, $epsilon,
+                        ),
+                    ));
                 }
 
                 Ok(BinarySearch::new_clamped(
@@ -102,6 +305,14 @@ macro_rules! numeric_api {
                     );
                 }
 
+                if runner.eval_edge_bias() {
+                    return Ok(BinarySearch::new(
+                        $crate::num::SampleEdgeCaseRangeInclusive::sample_edge_case_range_inclusive(
+                            runner, (*self.start()), (*self.end()), $epsilon,
+                        ),
+                    ));
+                }
+
                 Ok(BinarySearch::new_clamped(
                     *self.start(),
                     $crate::num::sample_uniform_incl::<$sample_typ>(
@@ -120,6 +331,13 @@ macro_rules! numeric_api {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                if runner.eval_edge_bias() {
+                    return Ok(BinarySearch::new(
+                        $crate::num::SampleEdgeCaseRangeInclusive::sample_edge_case_range_inclusive(
+                            runner, self.start, ::core::$typ::MAX, $epsilon,
+                        ),
+                    ));
+                }
                 Ok(BinarySearch::new_clamped(
                     self.start,
                     $crate::num::sample_uniform_incl::<$sample_typ>(
@@ -138,6 +356,13 @@ macro_rules! numeric_api {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                if runner.eval_edge_bias() {
+                    return Ok(BinarySearch::new(
+                        $crate::num::SampleEdgeCaseRangeExclusive::sample_edge_case_range_exclusive(
+                            runner, ::core::$typ::MIN, self.end, $epsilon,
+                        ),
+                    ));
+                }
                 Ok(BinarySearch::new_clamped(
                     ::core::$typ::MIN,
                     $crate::num::sample_uniform::<$sample_typ>(
@@ -156,6 +381,13 @@ macro_rules! numeric_api {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+                if runner.eval_edge_bias() {
+                    return Ok(BinarySearch::new(
+                        $crate::num::SampleEdgeCaseRangeInclusive::sample_edge_case_range_inclusive(
+                            runner, ::core::$typ::MIN, self.end, $epsilon,
+                        ),
+                    ));
+                }
                 Ok(BinarySearch::new_clamped(
                     ::core::$typ::MIN,
                     $crate::num::sample_uniform_incl::<$sample_typ>(
@@ -627,6 +859,12 @@ macro_rules! float_any {
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 let flags = self.0.normalise();
+
+                if runner.eval_edge_bias() {
+                    return Ok(BinarySearch::new_with_types(
+                        $crate::num::SampleEdgeCaseFloat::sample_edge_case_float(runner), flags))
+                }
+
                 let sign_mask = if flags.contains(FloatTypes::NEGATIVE) {
                     $typ::SIGN_MASK
                 } else {

--- a/proptest/src/num/float_samplers.rs
+++ b/proptest/src/num/float_samplers.rs
@@ -438,20 +438,29 @@ macro_rules! float_sampler {
                         let intervals = split_interval([low, high]);
                         let size = (intervals.count - 1) as usize;
 
-                        let interval = intervals.get(index.index(size) as $int_typ);
-                        let small_intervals = split_interval(interval);
+                        if size <= 0
+                        {
+                            prop_assert!((intervals.start == high && intervals.step < 0.0) ||
+                                (intervals.start == low && intervals.step > 0.0));
+                            prop_assert!(intervals.count == 1);
+                        }
+                        else
+                        {
+                            let interval = intervals.get(index.index(size) as $int_typ);
+                            let small_intervals = split_interval(interval);
 
-                        let start = small_intervals.get(0);
-                        let end = small_intervals.get(small_intervals.count - 1);
-                        let (low_interval, high_interval) = if  start[0] < end[0] {
-                            (start, end)
-                        } else {
-                            (end, start)
-                        };
+                            let start = small_intervals.get(0);
+                            let end = small_intervals.get(small_intervals.count - 1);
+                            let (low_interval, high_interval) = if  start[0] < end[0] {
+                                (start, end)
+                            } else {
+                                (end, start)
+                            };
 
-                        prop_assert!(
-                            interval[0] == low_interval[0] &&
-                            interval[1] == high_interval[1]);
+                            prop_assert!(
+                                interval[0] == low_interval[0] &&
+                                interval[1] == high_interval[1]);
+                        }
                     }
                 }
             }

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -28,6 +28,8 @@ use crate::test_runner::FileFailurePersistence;
 #[cfg(feature = "std")]
 const CASES: &str = "PROPTEST_CASES";
 #[cfg(feature = "std")]
+const EDGE_BIAS: &str = "PROPTEST_EDGE_BIAS";
+#[cfg(feature = "std")]
 const MAX_LOCAL_REJECTS: &str = "PROPTEST_MAX_LOCAL_REJECTS";
 #[cfg(feature = "std")]
 const MAX_GLOBAL_REJECTS: &str = "PROPTEST_MAX_GLOBAL_REJECTS";
@@ -85,6 +87,9 @@ pub fn contextualize_config(mut result: Config) -> Config {
     {
         match var.as_str() {
             CASES => parse_or_warn(&value, &mut result.cases, "u32", CASES),
+            EDGE_BIAS => {
+                parse_or_warn(&value, &mut result.edge_bias, "f32", EDGE_BIAS)
+            }
             MAX_LOCAL_REJECTS => parse_or_warn(
                 &value,
                 &mut result.max_local_rejects,
@@ -158,6 +163,7 @@ pub fn contextualize_config(result: Config) -> Config {
 fn default_default_config() -> Config {
     Config {
         cases: 256,
+        edge_bias: 0.25f32,
         max_local_rejects: 65_536,
         max_global_rejects: 1024,
         max_flat_map_regens: 1_000_000,
@@ -203,6 +209,30 @@ pub struct Config {
     /// `PROPTEST_CASES` environment variable. (The variable is only considered
     /// when the `std` feature is enabled, which it is by default.)
     pub cases: u32,
+
+    /// Bias towards edge cases of the input domain, meaning things like
+    /// MIN, MIN + 1, -1, 0, 1, MAX - 1, MAX. And in case of floats, NaN's and
+    /// infinity.
+    ///
+    /// This only applies to integers, floats and ranges of those.
+    ///
+    /// The number indicates the fraction of the cases on average that will be
+    /// edge cases.
+    ///
+    /// 0.0 would mean no bias towards edge cases at any point.
+    ///
+    /// 1.0 means only edge cases.
+    ///
+    /// 0.5 means that chance of edge cases reaches 50% at half-way through.
+    ///
+    /// Any non-zero value means edge cases start at 100% chance and then
+    /// smoothly decreases to 0% chance at the end. It decreases in a two-part
+    /// linear function whose area is edge_bias, so there is always a
+    /// combination of edge cases with other edge cases, edge cases with random
+    /// values, and random values with random values.
+    ///
+    /// The default is 0.25.
+    pub edge_bias: f32,
 
     /// The maximum number of individual inputs that may be rejected before the
     /// test as a whole aborts.
@@ -424,6 +454,47 @@ impl Config {
     pub fn with_cases(cases: u32) -> Self {
         Self {
             cases,
+            ..Config::default()
+        }
+    }
+
+    /// Constructs a `Config` only differing from the `default()` in the
+    /// edge_bias.
+    ///
+    /// This is simply a more concise alternative to using field-record update
+    /// syntax:
+    ///
+    /// ```
+    /// # use proptest::test_runner::Config;
+    /// assert_eq!(
+    ///     Config::with_edge_bias(0.5f32),
+    ///     Config { edge_bias: 0.5f32, .. Config::default() }
+    /// );
+    /// ```
+    pub fn with_edge_bias(edge_bias: f32) -> Self {
+        Self {
+            edge_bias,
+            ..Config::default()
+        }
+    }
+
+    /// Constructs a `Config` only differing from the `default()` in the
+    /// number of test cases and edge_bias.
+    ///
+    /// This is simply a more concise alternative to using field-record update
+    /// syntax:
+    ///
+    /// ```
+    /// # use proptest::test_runner::Config;
+    /// assert_eq!(
+    ///     Config::with_cases_and_edge_bias(1000, 0.5),
+    ///     Config { cases: 1000, edge_bias: 0.5, .. Config::default() }
+    /// );
+    /// ```
+    pub fn with_cases_and_edge_bias(cases: u32, edge_bias: f32) -> Self {
+        Self {
+            cases,
+            edge_bias,
             ..Config::default()
         }
     }

--- a/proptest/src/test_runner/failure_persistence/mod.rs
+++ b/proptest/src/test_runner/failure_persistence/mod.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::std_facade::{fmt, Box, Vec};
+use crate::std_facade::{fmt, Box, String, Vec};
 use core::any::Any;
 use core::fmt::Display;
 use core::result::Result;
@@ -31,6 +31,9 @@ use crate::test_runner::Seed;
 /// Proptest uses for its persistence file.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PersistedSeed(pub(crate) Seed);
+
+/// Floating point edge bias as bytes to be put inside BTreeMap/set.
+pub type PersistedEdgeBias = [u8; 4];
 
 impl Display for PersistedSeed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -64,10 +67,12 @@ pub trait FailurePersistence: Send + Sync + fmt::Debug {
     fn load_persisted_failures2(
         &self,
         source_file: Option<&'static str>,
-    ) -> Vec<PersistedSeed> {
+    ) -> Vec<(PersistedSeed, PersistedEdgeBias)> {
         self.load_persisted_failures(source_file)
             .into_iter()
-            .map(|seed| PersistedSeed(Seed::XorShift(seed)))
+            .map(|(seed, edge_bias)| {
+                (PersistedSeed(Seed::XorShift(seed)), edge_bias)
+            })
             .collect()
     }
 
@@ -80,7 +85,7 @@ pub trait FailurePersistence: Send + Sync + fmt::Debug {
     fn load_persisted_failures(
         &self,
         source_file: Option<&'static str>,
-    ) -> Vec<[u8; 16]> {
+    ) -> Vec<([u8; 16], PersistedEdgeBias)> {
         panic!("load_persisted_failures2 not implemented");
     }
 
@@ -93,12 +98,16 @@ pub trait FailurePersistence: Send + Sync + fmt::Debug {
         &mut self,
         source_file: Option<&'static str>,
         seed: PersistedSeed,
+        current_edge_bias: PersistedEdgeBias,
         shrunken_value: &dyn fmt::Debug,
     ) {
         match seed.0 {
-            Seed::XorShift(seed) => {
-                self.save_persisted_failure(source_file, seed, shrunken_value)
-            }
+            Seed::XorShift(seed) => self.save_persisted_failure(
+                source_file,
+                seed,
+                current_edge_bias,
+                shrunken_value,
+            ),
             _ => (),
         }
     }
@@ -113,6 +122,7 @@ pub trait FailurePersistence: Send + Sync + fmt::Debug {
         &mut self,
         source_file: Option<&'static str>,
         seed: [u8; 16],
+        current_edge_bias: PersistedEdgeBias,
         shrunken_value: &dyn fmt::Debug,
     ) {
         panic!("save_persisted_failure2 not implemented");
@@ -142,14 +152,35 @@ impl Clone for Box<dyn FailurePersistence> {
     }
 }
 
+pub(crate) fn to_base16(dst: &mut String, src: &[u8]) {
+    for byte in src {
+        dst.push_str(&format!("{:02x}", byte));
+    }
+}
+
+pub(crate) fn from_base16(dst: &mut [u8], src: &str) -> Option<()> {
+    if dst.len() * 2 != src.len() {
+        return None;
+    }
+
+    for (dst_byte, src_pair) in dst.into_iter().zip(src.as_bytes().chunks(2)) {
+        *dst_byte =
+            u8::from_str_radix(std::str::from_utf8(src_pair).ok()?, 16).ok()?;
+    }
+
+    Some(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::PersistedSeed;
+    use super::{PersistedEdgeBias, PersistedSeed};
     use crate::test_runner::rng::Seed;
 
     pub const INC_SEED: PersistedSeed = PersistedSeed(Seed::XorShift([
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     ]));
+
+    pub const INC_EDGE_BIAS: PersistedEdgeBias = [0, 0, 0, 0];
 
     pub const HI_PATH: Option<&str> = Some("hi");
     pub const UNREL_PATH: Option<&str> = Some("unrelated");

--- a/proptest/src/test_runner/failure_persistence/noop.rs
+++ b/proptest/src/test_runner/failure_persistence/noop.rs
@@ -11,7 +11,7 @@ use crate::std_facade::{fmt, Box, Vec};
 use core::any::Any;
 
 use crate::test_runner::failure_persistence::{
-    FailurePersistence, PersistedSeed,
+    FailurePersistence, PersistedEdgeBias, PersistedSeed,
 };
 
 /// Failure persistence option that loads and saves nothing at all.
@@ -22,7 +22,7 @@ impl FailurePersistence for NoopFailurePersistence {
     fn load_persisted_failures2(
         &self,
         _source_file: Option<&'static str>,
-    ) -> Vec<PersistedSeed> {
+    ) -> Vec<(PersistedSeed, PersistedEdgeBias)> {
         Vec::new()
     }
 
@@ -30,6 +30,7 @@ impl FailurePersistence for NoopFailurePersistence {
         &mut self,
         _source_file: Option<&'static str>,
         _seed: PersistedSeed,
+        _current_edge_bias: PersistedEdgeBias,
         _shrunken_value: &dyn fmt::Debug,
     ) {
     }
@@ -68,7 +69,7 @@ mod tests {
     #[test]
     fn seeds_not_recoverable() {
         let mut p = NoopFailurePersistence::default();
-        p.save_persisted_failure2(HI_PATH, INC_SEED, &"");
+        p.save_persisted_failure2(HI_PATH, INC_SEED, INC_EDGE_BIAS, &"");
         assert!(p.load_persisted_failures2(HI_PATH).is_empty());
         assert!(p.load_persisted_failures2(None).is_empty());
         assert!(p.load_persisted_failures2(UNREL_PATH).is_empty());

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -9,11 +9,13 @@
 
 use crate::std_facade::{Arc, String, ToOwned, Vec};
 use core::result::Result;
-use core::{fmt, str, u8, convert::TryInto};
+use core::{convert::TryInto, fmt, str, u8};
 
 use rand::{self, Rng, RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use rand_xorshift::XorShiftRng;
+
+use crate::test_runner::failure_persistence::to_base16;
 
 /// Identifies a particular RNG algorithm supported by proptest.
 ///
@@ -347,12 +349,6 @@ impl Seed {
     }
 
     pub(crate) fn to_persistence(&self) -> String {
-        fn to_base16(dst: &mut String, src: &[u8]) {
-            for byte in src {
-                dst.push_str(&format!("{:02x}", byte));
-            }
-        }
-
         match *self {
             Seed::XorShift(ref seed) => {
                 let dwords = [

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -14,6 +14,7 @@ use core::{fmt, iter};
 #[cfg(feature = "std")]
 use std::panic::{self, AssertUnwindSafe};
 
+use rand::Rng;
 #[cfg(feature = "fork")]
 use rusty_fork;
 #[cfg(feature = "fork")]
@@ -34,6 +35,8 @@ use crate::test_runner::reason::*;
 use crate::test_runner::replay;
 use crate::test_runner::result_cache::*;
 use crate::test_runner::rng::TestRng;
+
+use super::PersistedEdgeBias;
 
 #[cfg(feature = "fork")]
 const ENV_FORK_FILE: &'static str = "_PROPTEST_FORKFILE";
@@ -71,6 +74,7 @@ type RejectionDetail = BTreeMap<Reason, u32>;
 pub struct TestRunner {
     config: Config,
     successes: u32,
+    current_edge_bias: f32,
     local_rejects: u32,
     global_rejects: u32,
     rng: TestRng,
@@ -85,6 +89,7 @@ impl fmt::Debug for TestRunner {
         f.debug_struct("TestRunner")
             .field("config", &self.config)
             .field("successes", &self.successes)
+            .field("current_edge_bias", &self.current_edge_bias)
             .field("local_rejects", &self.local_rejects)
             .field("global_rejects", &self.global_rejects)
             .field("rng", &"<TestRng>")
@@ -340,6 +345,7 @@ impl TestRunner {
         TestRunner {
             config: config,
             successes: 0,
+            current_edge_bias: 0f32,
             local_rejects: 0,
             global_rejects: 0,
             rng: rng,
@@ -356,6 +362,7 @@ impl TestRunner {
         TestRunner {
             config: self.config.clone(),
             successes: 0,
+            current_edge_bias: 0f32,
             local_rejects: 0,
             global_rejects: 0,
             rng: self.new_rng(),
@@ -368,6 +375,19 @@ impl TestRunner {
     /// Returns the RNG for this test run.
     pub fn rng(&mut self) -> &mut TestRng {
         &mut self.rng
+    }
+
+    /// Returns the current edge bias for this test run.
+    pub fn current_edge_bias(&self) -> f32 {
+        self.current_edge_bias
+    }
+
+    /// Evaluates if we should generate edge bias case.
+    pub fn eval_edge_bias(&mut self) -> bool {
+        // We do not want to use up rng if current edge bias is 0 so we can
+        // stay backwards compatible in case current_edge_bias is not set.
+        self.current_edge_bias > 0f32
+            && self.rng.gen_range(0f32..1f32) <= self.current_edge_bias
     }
 
     /// Create a new, independent but deterministic RNG from the RNG in this
@@ -584,19 +604,20 @@ impl TestRunner {
     ) -> TestRunResult<S> {
         let old_rng = self.rng.clone();
 
-        let persisted_failure_seeds: Vec<PersistedSeed> = self
-            .config
-            .failure_persistence
-            .as_ref()
-            .map(|f| f.load_persisted_failures2(self.config.source_file))
-            .unwrap_or_default();
+        let persisted_failure_seeds: Vec<(PersistedSeed, PersistedEdgeBias)> =
+            self.config
+                .failure_persistence
+                .as_ref()
+                .map(|f| f.load_persisted_failures2(self.config.source_file))
+                .unwrap_or_default();
 
         let mut result_cache = self.new_cache();
 
-        for PersistedSeed(persisted_seed) in
+        for (PersistedSeed(persisted_seed), edge_bias_bytes) in
             persisted_failure_seeds.into_iter().rev()
         {
             self.rng.set_seed(persisted_seed);
+            self.current_edge_bias = f32::from_le_bytes(edge_bias_bytes);
             self.gen_and_run_case(
                 strategy,
                 &test,
@@ -611,6 +632,33 @@ impl TestRunner {
         while self.successes < self.config.cases {
             // Generate a new seed and make an RNG from that so that we know
             // what seed to persist if this case fails.
+
+            if self.config.edge_bias <= 0f32 {
+                self.current_edge_bias = 0f32;
+            } else if self.config.edge_bias >= 1f32 {
+                self.current_edge_bias = 1f32;
+            } else {
+                // Value from 0.0 to 1.0 representing how far we are through the
+                // tests. Infinity is OK here in case of cases == 1.
+                let x = self.successes as f32 / (self.config.cases - 1) as f32;
+                if x.is_infinite() {
+                    self.current_edge_bias = self.config.edge_bias;
+                } else {
+                    // Separate the curve into two linear parts whose total area
+                    // is p. Cases of p <= 0 and p >= 1 are handled above.
+                    let p = self.config.edge_bias;
+                    if x < p {
+                        self.current_edge_bias = 1f32 + x * (p - 1f32) / p;
+                    } else {
+                        self.current_edge_bias = (x - 1f32) * p / (p - 1f32);
+                    }
+                }
+            }
+
+            if self.current_edge_bias.is_nan() {
+                // Might happen if cases is 1 or edge_bias is 0.
+                self.current_edge_bias = self.config.edge_bias;
+            }
             let seed = self.rng.gen_get_seed();
             let result = self.gen_and_run_case(
                 strategy,
@@ -633,6 +681,7 @@ impl TestRunner {
                         failure_persistence.save_persisted_failure2(
                             *source_file,
                             PersistedSeed(seed),
+                            self.current_edge_bias.to_le_bytes(),
                             value,
                         );
                     }


### PR DESCRIPTION
* Works by randomly changing some generated values to be one of the random edge cases. The first tests are done with 100% edge cases, and then the chance goes down over the number of test cases until it's 0%.
* The average amount of edge case tests can be controlled by edge_bias configuration option. It defaults to 0.25.
* In failure the edge bias is persisted to the persistence file along with the seed, so it should be reproducible.
* Also fix time::Duration test because the edge bias system found a problem in it. (Might need more modifications.)
* Fix float_samplers test subsequent_splits_always_match_bounds.


replaces #369