### PR TITLE
Add feature `backtrace`

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - When running persisted regressions, the most recently added regression is now run first.
 - Added `handle-panics` feature which enables catching panics raised in tests and turning them into failures
+- Added `backtrace` feature which enables capturing backtraces for both test failures and panics,
+  if `handle-panics` feature is enabled
 
 ## 1.5.0
 

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New Features
 
 - When running persisted regressions, the most recently added regression is now run first.
+- Added `handle-panics` feature which enables catching panics raised in tests and turning them into failures
 
 ## 1.5.0
 

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -59,6 +59,10 @@ atomic64bit = []
 
 bit-set = [ "dep:bit-set", "dep:bit-vec" ]
 
+# Enables proper handling of panics
+# In particular, hides all intermediate panics flowing into stderr during shrink phase
+handle-panics = ["std"]
+
 [dependencies]
 bitflags = "2"
 unarray = "0.1.4"

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -63,6 +63,11 @@ bit-set = [ "dep:bit-set", "dep:bit-vec" ]
 # In particular, hides all intermediate panics flowing into stderr during shrink phase
 handle-panics = ["std"]
 
+# Enables gathering of failure backtraces
+# * when test failure is reported via `prop_assert_*` macro
+# * when normal assertion fails or panic fires, if `handle-panics` feature is enabled too
+backtrace = ["std"]
+
 [dependencies]
 bitflags = "2"
 unarray = "0.1.4"

--- a/proptest/src/sugar.rs
+++ b/proptest/src/sugar.rs
@@ -751,11 +751,9 @@ macro_rules! prop_assert {
 
     ($cond:expr, $($fmt:tt)*) => {
         if !$cond {
-            let message = format!($($fmt)*);
-            let message = format!("{} at {}:{}", message, file!(), line!());
             return ::core::result::Result::Err(
                 $crate::test_runner::TestCaseError::fail(
-                    $crate::test_runner::Reason::with_backtrace(message)
+                    $crate::test_runner::Reason::with_location_and_backtrace(format!($($fmt)*))
                 )
             );
         }

--- a/proptest/src/sugar.rs
+++ b/proptest/src/sugar.rs
@@ -754,7 +754,10 @@ macro_rules! prop_assert {
             let message = format!($($fmt)*);
             let message = format!("{} at {}:{}", message, file!(), line!());
             return ::core::result::Result::Err(
-                $crate::test_runner::TestCaseError::fail(message));
+                $crate::test_runner::TestCaseError::fail(
+                    $crate::test_runner::Reason::with_backtrace(message)
+                )
+            );
         }
     };
 }

--- a/proptest/src/test_runner/backtrace.rs
+++ b/proptest/src/test_runner/backtrace.rs
@@ -1,0 +1,135 @@
+//-
+// Copyright 2024
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core::fmt;
+/// Holds test failure backtrace, if captured
+///
+/// If feature `backtrace` is disabled, it's a zero-sized struct with no logic
+///
+/// If `backtrace` is enabled, attempts to capture backtrace using `std::backtrace::Backtrace` -
+/// if requested
+#[derive(Clone, Default)]
+pub struct Backtrace(internal::Backtrace);
+
+impl Backtrace {
+    /// Creates empty backtrace object
+    ///
+    /// Used when client code doesn't care
+    pub fn empty() -> Self {
+        Self(internal::Backtrace::empty())
+    }
+    /// Tells whether there's backtrace captured
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    /// Attempts to capture backtrace - but only if `backtrace` feature is enabled
+    #[inline(always)]
+    pub fn capture() -> Self {
+        Self(internal::Backtrace::capture())
+    }
+}
+
+impl fmt::Debug for Backtrace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for Backtrace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+#[cfg(feature = "backtrace")]
+mod internal {
+    use core::fmt;
+    use std::backtrace as bt;
+    use std::sync::Arc;
+
+    // `std::backtrace::Backtrace` isn't `Clone`, so we have
+    // to use `Arc` to also maintain `Send + Sync`
+    #[derive(Clone, Default)]
+    pub struct Backtrace(Option<Arc<bt::Backtrace>>);
+
+    impl Backtrace {
+        pub fn empty() -> Self {
+            Self(None)
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.0.is_none()
+        }
+
+        #[inline(always)]
+        pub fn capture() -> Self {
+            let bt = bt::Backtrace::capture();
+            // Store only if we have backtrace
+            if bt.status() == bt::BacktraceStatus::Captured {
+                Self(Some(Arc::new(bt)))
+            } else {
+                Self(None)
+            }
+        }
+    }
+
+    impl fmt::Debug for Backtrace {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            if let Some(ref arc) = self.0 {
+                fmt::Debug::fmt(arc.as_ref(), f)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl fmt::Display for Backtrace {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            if let Some(ref arc) = self.0 {
+                fmt::Display::fmt(arc.as_ref(), f)
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "backtrace"))]
+mod internal {
+    use core::fmt;
+
+    #[derive(Clone, Default)]
+    pub struct Backtrace;
+
+    impl Backtrace {
+        pub fn empty() -> Self {
+            Self
+        }
+
+        pub fn is_empty(&self) -> bool {
+            true
+        }
+
+        pub fn capture() -> Self {
+            Self
+        }
+    }
+
+    impl fmt::Debug for Backtrace {
+        fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+            Ok(())
+        }
+    }
+
+    impl fmt::Display for Backtrace {
+        fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+            Ok(())
+        }
+    }
+}

--- a/proptest/src/test_runner/errors.rs
+++ b/proptest/src/test_runner/errors.rs
@@ -86,7 +86,7 @@ impl fmt::Display for TestCaseError {
             TestCaseError::Reject(ref whence) => {
                 write!(f, "Input rejected at {}", whence)
             }
-            TestCaseError::Fail(ref why) => write!(f, "Case failed: {}", why),
+            TestCaseError::Fail(ref why) => write!(f, "Case failed: {}", why.display_detailed()),
         }
     }
 }
@@ -115,7 +115,7 @@ impl<T: fmt::Debug> fmt::Display for TestError<T> {
         match *self {
             TestError::Abort(ref why) => write!(f, "Test aborted: {}", why),
             TestError::Fail(ref why, ref what) => {
-                writeln!(f, "Test failed: {}.", why)?;
+                writeln!(f, "Test failed: {}", why.display_detailed())?;
                 write!(f, "minimal failing input: {:#?}", what)
             }
         }

--- a/proptest/src/test_runner/mod.rs
+++ b/proptest/src/test_runner/mod.rs
@@ -22,6 +22,7 @@ mod result_cache;
 mod rng;
 mod runner;
 mod scoped_panic_hook;
+mod backtrace;
 
 pub use self::config::*;
 pub use self::errors::*;

--- a/proptest/src/test_runner/mod.rs
+++ b/proptest/src/test_runner/mod.rs
@@ -21,6 +21,7 @@ mod replay;
 mod result_cache;
 mod rng;
 mod runner;
+mod scoped_panic_hook;
 
 pub use self::config::*;
 pub use self::errors::*;

--- a/proptest/src/test_runner/reason.rs
+++ b/proptest/src/test_runner/reason.rs
@@ -151,7 +151,7 @@ impl<'a> fmt::Display for DisplayReason<'a> {
         if bt.is_empty() {
             write!(f, "{msg}")
         } else {
-            write!(f, "{msg}\n{bt}")
+            write!(f, "{msg}\nstack backtrace:\n{bt}")
         }
     }
 }

--- a/proptest/src/test_runner/reason.rs
+++ b/proptest/src/test_runner/reason.rs
@@ -7,8 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::std_facade::{fmt, Box, Cow, String};
 use super::backtrace::Backtrace;
+use crate::std_facade::{fmt, Box, Cow, String};
 
 /// The reason for why something, such as a generated value, was rejected.
 ///
@@ -23,23 +23,23 @@ pub struct Reason(Cow<'static, str>, Backtrace);
 
 impl Reason {
     /// Creates reason from provided message
-    /// 
+    ///
     /// # Parameters
     /// * `message` - anything convertible to message
-    /// 
+    ///
     /// # Returns
     /// Reason object
     pub fn new(message: impl Into<Cow<'static, str>>) -> Self {
         Self(message.into(), Backtrace::empty())
     }
     /// Creates reason from provided message and captures backtrace at callsite
-    /// 
+    ///
     /// NOTE: Backtrace is actually captured only if `backtrace` feature is enabled,
     /// otherwise it'll be empty
-    /// 
+    ///
     /// # Parameters
     /// * `message` - anything convertible to message
-    /// 
+    ///
     /// # Returns
     /// Reason object with provided message and captured backtrace
     #[inline(always)]
@@ -92,6 +92,12 @@ impl From<(&'static str, Backtrace)> for Reason {
     }
 }
 
+impl From<(Cow<'static, str>, Backtrace)> for Reason {
+    fn from((msg, bt): (Cow<'static, str>, Backtrace)) -> Self {
+        Self(msg, bt)
+    }
+}
+
 impl From<(String, Backtrace)> for Reason {
     fn from((s, b): (String, Backtrace)) -> Self {
         Self(s.into(), b)
@@ -124,7 +130,10 @@ impl From<Box<str>> for Reason {
 
 impl fmt::Debug for Reason {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Reason").field(&self.0).field(&"Backtrace(...)").finish()
+        f.debug_tuple("Reason")
+            .field(&self.0)
+            .field(&"Backtrace(...)")
+            .finish()
     }
 }
 

--- a/proptest/src/test_runner/reason.rs
+++ b/proptest/src/test_runner/reason.rs
@@ -8,18 +8,44 @@
 // except according to those terms.
 
 use crate::std_facade::{fmt, Box, Cow, String};
+use super::backtrace::Backtrace;
 
 /// The reason for why something, such as a generated value, was rejected.
 ///
-/// Currently this is merely a wrapper around a message, but more properties
-/// may be added in the future.
+/// Contains message which describes reason and optionally backtrace
+/// (depending on several factors like features `backtrace` and
+/// `handle-panics`, and actual spot where reason was created).
 ///
 /// This is constructed via `.into()` on a `String`, `&'static str`, or
 /// `Box<str>`.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Reason(Cow<'static, str>);
+#[derive(Clone)]
+pub struct Reason(Cow<'static, str>, Backtrace);
 
 impl Reason {
+    /// Creates reason from provided message
+    /// 
+    /// # Parameters
+    /// * `message` - anything convertible to message
+    /// 
+    /// # Returns
+    /// Reason object
+    pub fn new(message: impl Into<Cow<'static, str>>) -> Self {
+        Self(message.into(), Backtrace::empty())
+    }
+    /// Creates reason from provided message and captures backtrace at callsite
+    /// 
+    /// NOTE: Backtrace is actually captured only if `backtrace` feature is enabled,
+    /// otherwise it'll be empty
+    /// 
+    /// # Parameters
+    /// * `message` - anything convertible to message
+    /// 
+    /// # Returns
+    /// Reason object with provided message and captured backtrace
+    #[inline(always)]
+    pub fn with_backtrace(message: impl Into<Cow<'static, str>>) -> Self {
+        Self(message.into(), Backtrace::capture())
+    }
     /// Return the message for this `Reason`.
     ///
     /// The message is intended for human consumption, and is not guaranteed to
@@ -27,28 +53,96 @@ impl Reason {
     pub fn message(&self) -> &str {
         &*self.0
     }
+    /// Produces displayable value which displays all data stored in Reason,
+    /// unlike normal `Display` implementation which shows only message
+    pub fn display_detailed(&self) -> impl fmt::Display + '_ {
+        DisplayReason(self)
+    }
+}
+
+impl core::cmp::PartialEq for Reason {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl core::cmp::Eq for Reason {}
+
+impl core::cmp::PartialOrd for Reason {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl core::cmp::Ord for Reason {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl core::hash::Hash for Reason {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl From<(&'static str, Backtrace)> for Reason {
+    fn from((s, b): (&'static str, Backtrace)) -> Self {
+        Self(s.into(), b)
+    }
+}
+
+impl From<(String, Backtrace)> for Reason {
+    fn from((s, b): (String, Backtrace)) -> Self {
+        Self(s.into(), b)
+    }
+}
+
+impl From<(Box<str>, Backtrace)> for Reason {
+    fn from((s, b): (Box<str>, Backtrace)) -> Self {
+        Self(String::from(s).into(), b)
+    }
 }
 
 impl From<&'static str> for Reason {
     fn from(s: &'static str) -> Self {
-        Reason(s.into())
+        (s, Backtrace::empty()).into()
     }
 }
 
 impl From<String> for Reason {
     fn from(s: String) -> Self {
-        Reason(s.into())
+        (s, Backtrace::empty()).into()
     }
 }
 
 impl From<Box<str>> for Reason {
     fn from(s: Box<str>) -> Self {
-        Reason(String::from(s).into())
+        (s, Backtrace::empty()).into()
+    }
+}
+
+impl fmt::Debug for Reason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Reason").field(&self.0).field(&"Backtrace(...)").finish()
     }
 }
 
 impl fmt::Display for Reason {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self.message(), f)
+        write!(f, "{}", self.message())
+    }
+}
+
+struct DisplayReason<'a>(&'a Reason);
+
+impl<'a> fmt::Display for DisplayReason<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let Self(Reason(msg, bt)) = self;
+        if bt.is_empty() {
+            write!(f, "{msg}")
+        } else {
+            write!(f, "{msg}\n{bt}")
+        }
     }
 }

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1,5 +1,5 @@
 //-
-// Copyright 2017, 2018, 2019 The proptest developers
+// Copyright 2017, 2018, 2019, 2024 The proptest developers
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -253,7 +253,10 @@ where
     let time_start = time::Instant::now();
 
     let mut result = unwrap_or!(
-        panic::catch_unwind(AssertUnwindSafe(|| test(case))),
+        super::scoped_panic_hook::with_hook(
+            |_| { /* Silence out panic backtrace */ },
+            || panic::catch_unwind(AssertUnwindSafe(|| test(case)))
+        ),
         what => Err(TestCaseError::Fail(
             what.downcast::<&'static str>().map(|s| (*s).into())
                 .or_else(|what| what.downcast::<String>().map(|b| (*b).into()))

--- a/proptest/src/test_runner/scoped_panic_hook.rs
+++ b/proptest/src/test_runner/scoped_panic_hook.rs
@@ -1,3 +1,12 @@
+//-
+// Copyright 2024 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 #[cfg(feature = "handle-panics")]
 mod internal {
     //! Implementation of scoped panic hooks

--- a/proptest/src/test_runner/scoped_panic_hook.rs
+++ b/proptest/src/test_runner/scoped_panic_hook.rs
@@ -1,0 +1,123 @@
+#[cfg(feature = "handle-panics")]
+mod panicky {
+    //! Implementation of scoped panic hooks
+    //!
+    //! 1. `with_hook` serves as entry point, it executes body closure with panic hook closure
+    //!     installed as scoped panic hook
+    //! 2. Upon first execution, current panic hook is replaced with `scoped_hook_dispatcher`
+    //!     in a thread-safe manner, and original hook is stored for later use
+    //! 3. When panic occurs, `scoped_hook_dispatcher` either delegates execution to scoped
+    //!     panic hook, if one is installed, or back to original hook stored earlier.
+    //!     This preserves original behavior when scoped hook isn't used
+    //! 4. When `with_hook` is used, it replaces stored scoped hook pointer with pointer to
+    //!     hook closure passed as parameter. Old hook pointer is set to be restored unconditionally
+    //!     via drop guard. Then, normal body closure is executed.
+    use std::boxed::Box;
+    use std::cell::Cell;
+    use std::panic::{set_hook, take_hook, PanicInfo};
+    use std::sync::Once;
+    use std::{mem, ptr};
+
+    thread_local! {
+        /// Pointer to currently installed scoped panic hook, if any
+        ///
+        /// NB: pointers to arbitrary fn's are fat, and Rust doesn't allow crafting null pointers
+        /// to fat objects. So we just store const pointer to tuple with whatever data we need
+        static SCOPED_HOOK_PTR: Cell<*const (*mut dyn FnMut(&PanicInfo<'_>),)> = Cell::new(ptr::null());
+    }
+
+    static INIT_ONCE: Once = Once::new();
+    /// Default panic hook, the one which was present before installing scoped one
+    ///
+    /// NB: no need for external sync, value is mutated only once, when init is performed
+    static mut DEFAULT_HOOK: Option<Box<dyn Fn(&PanicInfo<'_>) + Send + Sync>> =
+        None;
+    /// Replaces currently installed panic hook with `scoped_hook_dispatcher` once,
+    /// in a thread-safe manner
+    fn init() {
+        INIT_ONCE.call_once(|| {
+            let old_handler = take_hook();
+            set_hook(Box::new(scoped_hook_dispatcher));
+            unsafe {
+                DEFAULT_HOOK = Some(old_handler);
+            }
+        });
+    }
+    /// Panic hook which delegates execution to scoped hook,
+    /// if one installed, or to default hook
+    fn scoped_hook_dispatcher(info: &PanicInfo<'_>) {
+        let handler = SCOPED_HOOK_PTR.get();
+        if !handler.is_null() {
+            // It's assumed that if container's ptr is not null, ptr to `FnMut` is non-null too.
+            // Correctness **must** be ensured by hook switch code in `with_hook`
+            let hook = unsafe { &mut *(*handler).0 };
+            (hook)(info);
+            return;
+        }
+
+        if let Some(hook) = unsafe { DEFAULT_HOOK.as_ref() } {
+            (hook)(info);
+        }
+    }
+    /// Executes stored closure when dropped
+    struct Finally<F: FnOnce()>(Option<F>);
+
+    impl<F: FnOnce()> Finally<F> {
+        fn new(body: F) -> Self {
+            Self(Some(body))
+        }
+    }
+
+    impl<F: FnOnce()> Drop for Finally<F> {
+        fn drop(&mut self) {
+            if let Some(body) = self.0.take() {
+                body();
+            }
+        }
+    }
+    /// Executes main closure `body` while installing `guard` as scoped panic hook,
+    /// for execution duration.
+    ///
+    /// Any panics which happen during execution of `body` are passed to `guard` hook
+    /// to collect any info necessary, although unwind process is **NOT** interrupted.
+    /// See module documentation for details
+    ///
+    /// # Parameters
+    /// * `panic_hook` - scoped panic hook, functions for the duration of `body` execution
+    /// * `body` - actual logic covered by `panic_hook`
+    ///
+    /// # Returns
+    /// `body`'s return value
+    pub fn with_hook<R>(
+        mut panic_hook: impl FnMut(&PanicInfo<'_>),
+        body: impl FnOnce() -> R,
+    ) -> R {
+        init();
+        // Construct scoped hook pointer
+        let guard_tuple = (unsafe {
+            // `mem::transmute` is needed due to borrow checker restrictions to erase all lifetimes
+            mem::transmute(&mut panic_hook as *mut dyn FnMut(&PanicInfo<'_>))
+        },);
+        let old_tuple = SCOPED_HOOK_PTR.replace(&guard_tuple);
+        // Old scoped hook **must** be restored before leaving function scope to keep it sound
+        let _undo = Finally::new(|| {
+            SCOPED_HOOK_PTR.set(old_tuple);
+        });
+        body()
+    }
+}
+
+#[cfg(not(feature = "handle-panics"))]
+mod panicky {
+    use std::panic::PanicInfo;
+    /// Simply executes `body` and returns its execution result.
+    /// Hook parameter is ignored
+    pub fn with_hook<R>(
+        _: impl FnMut(&PanicInfo<'_>),
+        body: impl FnOnce() -> R,
+    ) -> R {
+        body()
+    }
+}
+
+pub use panicky::with_hook;

--- a/proptest/src/test_runner/scoped_panic_hook.rs
+++ b/proptest/src/test_runner/scoped_panic_hook.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "handle-panics")]
-mod panicky {
+mod internal {
     //! Implementation of scoped panic hooks
     //!
     //! 1. `with_hook` serves as entry point, it executes body closure with panic hook closure
@@ -108,7 +108,7 @@ mod panicky {
 }
 
 #[cfg(not(feature = "handle-panics"))]
-mod panicky {
+mod internal {
     use std::panic::PanicInfo;
     /// Simply executes `body` and returns its execution result.
     /// Hook parameter is ignored
@@ -120,4 +120,4 @@ mod panicky {
     }
 }
 
-pub use panicky::with_hook;
+pub use internal::with_hook;


### PR DESCRIPTION
! Merge after #525

Enables collection of full backtraces:
* when panic occurs inside test, but only if `handle-panics` feature is enabled
* when `prop_assert` macro or any of its derivatives is used
