### PR TITLE
add no_std to alloc contexts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
         run: cd proptest && cargo build --lib --no-default-features --features std
       - name: Build rng no-default-features
         if: ${{ matrix.build == 'nightly' }}
-        run: cd proptest && cargo build --no-default-features --features "alloc unstable hardware-rng"
+        run: cd proptest && cargo build --no-default-features --features "no_std alloc unstable hardware-rng"
       - name: Run persistence tests
         if: ${{ matrix.build == 'nightly' }}
         run: cd proptest/test-persistence-location && ./run-tests.sh

--- a/book/src/proptest/no-std.md
+++ b/book/src/proptest/no-std.md
@@ -15,7 +15,7 @@ default-features = false
 # alloc: Use the `alloc` crate directly. Proptest has a hard requirement on
 # memory allocation, so either this or `std` is needed.
 # unstable: Enable use of nightly-only compiler features.
-features = ["alloc", "unstable"]
+features = ["no_std", "alloc", "unstable"]
 ```
 
 Some APIs are not available in the `no_std` build. This includes functionality

--- a/prerelease-checks.sh
+++ b/prerelease-checks.sh
@@ -10,7 +10,7 @@ set -eux
     cd proptest
     cargo clean
     cargo +nightly build --target thumbv7em-none-eabihf \
-          --no-default-features --features 'alloc unstable'
+          --no-default-features --features 'no_std alloc unstable'
     cargo clean
     cargo +nightly build --target wasm32-unknown-emscripten \
           --no-default-features --features std

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -29,8 +29,7 @@ attr-macro = ["proptest-macro"]
 unstable = []
 
 # Enables the use of standard-library dependent features
-std = ["rand/std", "lazy_static",
-       "regex-syntax", "num-traits/std"]
+std = ["rand/std", "lazy_static", "regex-syntax", "num-traits/std"]
 
 # std or libm required for mul_add.
 no_std = ["num-traits/libm"]
@@ -57,7 +56,7 @@ timeout = ["fork", "rusty-fork/timeout"]
 # need it excluded, however.
 atomic64bit = []
 
-bit-set = [ "dep:bit-set", "dep:bit-vec" ]
+bit-set = ["dep:bit-set", "dep:bit-vec"]
 
 [dependencies]
 bitflags = "2"

--- a/proptest/gen-docs.sh
+++ b/proptest/gen-docs.sh
@@ -10,7 +10,7 @@ set -eux
 if test "$1" = "nostd"; then
     crate=proptest-nostd
     cargo='cargo +nightly'
-    cargoflags='--no-default-features --features=alloc,unstable'
+    cargoflags='--no-default-features --features=no_std,alloc,unstable'
 else
     crate=proptest
     cargo=cargo


### PR DESCRIPTION
commit 69c25f00aed0e58f6cd8b9a141ab2861f889dc72 made it so libm no longer included in std features and is moved to an explicit no_std feature, however this broke the build and is confusing for no_std docs. no_std docs force using "alloc", relatedly everywhere we use "alloc" we should also use "no_std".