### PR TITLE
adds support for re-exporting crate

### DIFF
--- a/proptest-derive/src/ast.rs
+++ b/proptest-derive/src/ast.rs
@@ -116,7 +116,7 @@ impl Impl {
             #[allow(non_upper_case_globals)]
             #[allow(clippy::arc_with_non_send_sync)]
             const _: () = {
-            extern crate proptest as _proptest;
+            use proptest as _proptest;
 
             impl #impl_generics _proptest::arbitrary::Arbitrary
             for #typ #ty_generics #where_clause {


### PR DESCRIPTION
Hiya! Big fan of `proptest`, it's been fantastic for testing my code, and the commit-friendly regressions file is such a lovely touch.

This is tiny little change to `proptest-derive` that helps things work when `proptest` is not a **direct** dependency, such as when it has been re-exported from another crate.

As far as I'm aware, this is a safe change that shouldn't break anything for anyone currently using it, but if I'm wrong about that, please let me know.

If there's any changes you'd like me to make, I'd be glad to do so.

Thanks again, crates like this are valuable parts of the testing ecosystem. ❤️ 