### PR TITLE
Fix non-local impl nightly warning with `allow(non_local_definitions)`

### DIFF
--- a/proptest-derive/src/ast.rs
+++ b/proptest-derive/src/ast.rs
@@ -113,6 +113,7 @@ impl Impl {
         // The double-curly-braces are not strictly required, but allow the expression to be
         // annotated with an attribute.
         let q = quote! {
+            #[allow(non_local_definitions)]
             #[allow(non_upper_case_globals)]
             #[allow(clippy::arc_with_non_send_sync)]
             const _: () = {

--- a/proptest-derive/src/tests.rs
+++ b/proptest-derive/src/tests.rs
@@ -78,6 +78,7 @@ test! {
         #[derive(Debug)]
         struct MyUnitStruct;
     } expands to {
+        #[allow(non_local_definitions)]
         #[allow(non_upper_case_globals)]
         #[allow(clippy::arc_with_non_send_sync)]
         const _: () = {
@@ -99,6 +100,7 @@ test! {
         #[derive(Debug)]
         struct MyTupleUnitStruct();
     } expands to {
+        #[allow(non_local_definitions)]
         #[allow(non_upper_case_globals)]
         #[allow(clippy::arc_with_non_send_sync)]
         const _: () = {
@@ -120,6 +122,7 @@ test! {
         #[derive(Debug)]
         struct MyNamedUnitStruct {}
     } expands to {
+        #[allow(non_local_definitions)]
         #[allow(non_upper_case_globals)]
         #[allow(clippy::arc_with_non_send_sync)]
         const _: () = {


### PR DESCRIPTION
Simplest possible fix for https://github.com/proptest-rs/proptest/issues/447