### PR TITLE
Remove Display of minimal failing input in TestError

### DIFF
--- a/proptest/src/test_runner/errors.rs
+++ b/proptest/src/test_runner/errors.rs
@@ -114,10 +114,7 @@ impl<T: fmt::Debug> fmt::Display for TestError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TestError::Abort(ref why) => write!(f, "Test aborted: {}", why),
-            TestError::Fail(ref why, ref what) => {
-                writeln!(f, "Test failed: {}.", why)?;
-                write!(f, "minimal failing input: {:#?}", what)
-            }
+            TestError::Fail(ref why, ref _what) => write!(f, "Test failed: {}.", why),
         }
     }
 }


### PR DESCRIPTION
When an error is encountered, the current behavior is to panic and print the error, including the non-minimized, minimal failing input. This input can be quite large, which may pose a challenge when running on environments with limited resources. However, detailed information about the minimal failing input is still accessible through the persistence logic.