### PR TITLE
fix no-std build

### DIFF
--- a/proptest/src/test_runner/scoped_panic_hook.rs
+++ b/proptest/src/test_runner/scoped_panic_hook.rs
@@ -118,7 +118,8 @@ mod internal {
 
 #[cfg(not(feature = "handle-panics"))]
 mod internal {
-    use std::panic::PanicInfo;
+    use core::panic::PanicInfo;
+
     /// Simply executes `body` and returns its execution result.
     /// Hook parameter is ignored
     pub fn with_hook<R>(


### PR DESCRIPTION
follow-up for #525 to fix no-std build (see e.g. https://github.com/proptest-rs/proptest/actions/runs/12227857268/job/34105201245)