### PR TITLE
Make runtime errors when someone forgets a direct failure persistence file

### DIFF
--- a/proptest/src/test_runner/failure_persistence/file.rs
+++ b/proptest/src/test_runner/failure_persistence/file.rs
@@ -393,8 +393,15 @@ impl FileFailurePersistence {
                 }
             },
 
-            Direct(path) => Some(Path::new(path).to_owned()),
-
+            Direct(path) => {
+                // assert that path exits
+                let path_owned: PathBuf = Path::new(path).to_owned();
+                assert!(
+                    path_owned.exists(),
+                    "FileFailurePersistence::Direct set, but file does not exist. Please provide: \n{}", path_owned.display()
+                );
+                Some(path_owned)
+            }
             _NonExhaustive => {
                 panic!("FailurePersistence set to _NonExhaustive")
             }


### PR DESCRIPTION
This gives the user a runtime error when they want the test to use a `Direct` failure persistence file.  Here is a code example:

```
 proptest! {
#![proptest_config(Config {
            // set failure persistance
            failure_persistence: Some(
                Box::new(FileFailurePersistence::Direct("past_failures_that_I_want_to_test.txt"))
            ),
            ..Default::default()
        })]
        
  #[test]
  fn  test_that_should_run_old_failures()....
 ```
 
 Will give the correct behavior of:
 ```
 ---- <crate>::tests::proptest_test_that_should_run_old_failures stdout ----
thread <crate>::tests::proptest_test_that_should_run_old_failures' panicked at proptest-1.6.0/src/test_runner/failure_persistence/file.rs:399:17:
FileFailurePersistence::Direct set, but file does not exist. Please provide:
past_failures_that_I_want_to_test.txt
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```



Without this change if the user moves that file- this unit test will not raise an error. The intent by writing that statement is run this past failures before trying new random inputs.  There should be a hard error to tell the user that something has gone wrong.

@matthew-russo @cameron1024. This is my first time contributing so please let me know anything I can do to make this PR easier to review.