### PR TITLE
Add PROPTEST_RNG_SEED to take initial TestRunner seed from environment

### DIFF
--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -37,6 +37,7 @@ pub fn contextualize_config(mut result: Config) -> Config {
     const TIMEOUT: &str = "PROPTEST_TIMEOUT";
     const VERBOSE: &str = "PROPTEST_VERBOSE";
     const RNG_ALGORITHM: &str = "PROPTEST_RNG_ALGORITHM";
+    const RNG_SEED: &str = "PROPTEST_RNG_SEED";
     const DISABLE_FAILURE_PERSISTENCE: &str =
         "PROPTEST_DISABLE_FAILURE_PERSISTENCE";
 
@@ -135,6 +136,13 @@ pub fn contextualize_config(mut result: Config) -> Config {
                 "RngAlgorithm",
                 RNG_ALGORITHM,
             );
+        } else if var == RNG_SEED {
+            parse_or_warn(
+                &value,
+                &mut result.rng_seed,
+                "u64",
+                RNG_SEED,
+            );
         } else if var == DISABLE_FAILURE_PERSISTENCE {
             result.failure_persistence = None;
         } else if var.starts_with("PROPTEST_") {
@@ -172,6 +180,7 @@ fn default_default_config() -> Config {
         #[cfg(feature = "std")]
         verbose: 0,
         rng_algorithm: RngAlgorithm::default(),
+        rng_seed: RngSeed::Random,
         _non_exhaustive: (),
     }
 }
@@ -185,6 +194,35 @@ lazy_static! {
         default_config.failure_persistence = Some(Box::new(crate::test_runner::FileFailurePersistence::default()));
         contextualize_config(default_config)
     };
+}
+
+/// The seed for the RNG, can either be random or specified as a u64.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RngSeed {
+    /// Default case, use a random value
+    Random,
+    /// Use a specific value to generate a seed
+    Fixed(u64)
+}
+
+impl std::str::FromStr for RngSeed {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "random" {
+            Ok(RngSeed::Random)
+        } else {
+            s.parse().map(RngSeed::Fixed).map_err(|_| ())
+        }
+    }
+}
+
+impl std::fmt::Display for RngSeed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RngSeed::Random => write!(f, "random"),
+            RngSeed::Fixed(n) => write!(f, "{}", n),
+        }
+    }
 }
 
 /// Configuration for how a proptest test should be run.
@@ -397,6 +435,10 @@ pub struct Config {
     /// (The variable is only considered when the `std` feature is enabled,
     /// which it is by default.)
     pub rng_algorithm: RngAlgorithm,
+
+    /// Seed used for the RNG. Set by using the PROPTEST_RNG_SEED environment variable
+    /// If `random` is supplied, a random seed is generated (this is the default option).
+    pub rng_seed: RngSeed,
 
     // Needs to be public so FRU syntax can be used.
     #[doc(hidden)]

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -208,11 +208,7 @@ pub enum RngSeed {
 impl std::str::FromStr for RngSeed {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "random" {
-            Ok(RngSeed::Random)
-        } else {
-            s.parse().map(RngSeed::Fixed).map_err(|_| ())
-        }
+        s.parse::<u64>().map(RngSeed::Fixed).map_err(|_| ())
     }
 }
 
@@ -437,7 +433,7 @@ pub struct Config {
     pub rng_algorithm: RngAlgorithm,
 
     /// Seed used for the RNG. Set by using the PROPTEST_RNG_SEED environment variable
-    /// If `random` is supplied, a random seed is generated (this is the default option).
+    /// If the environment variable is undefined, a random seed is generated (this is the default option).
     pub rng_seed: RngSeed,
 
     // Needs to be public so FRU syntax can be used.

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use crate::std_facade::Box;
-use core::u32;
+use core::{fmt, str, u32};
 
 use crate::test_runner::result_cache::{noop_result_cache, ResultCache};
 use crate::test_runner::rng::RngAlgorithm;
@@ -205,15 +205,15 @@ pub enum RngSeed {
     Fixed(u64)
 }
 
-impl std::str::FromStr for RngSeed {
+impl str::FromStr for RngSeed {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse::<u64>().map(RngSeed::Fixed).map_err(|_| ())
     }
 }
 
-impl std::fmt::Display for RngSeed {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for RngSeed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RngSeed::Random => write!(f, "random"),
             RngSeed::Fixed(n) => write!(f, "{}", n),

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -314,8 +314,9 @@ impl TestRunner {
     /// hard-coded seed. This seed is not contractually guaranteed and may be
     /// changed between releases without notice.
     pub fn new(config: Config) -> Self {
+        let seed = config.rng_seed;
         let algorithm = config.rng_algorithm;
-        TestRunner::new_with_rng(config, TestRng::default_rng(algorithm))
+        TestRunner::new_with_rng(config, TestRng::default_rng(seed, algorithm))
     }
 
     /// Create a fresh `TestRunner` with the standard deterministic RNG.
@@ -1254,7 +1255,7 @@ mod test {
 
         // create value with recorder rng
         let default_config = Config::default();
-        let recorder_rng = TestRng::default_rng(RngAlgorithm::Recorder);
+        let recorder_rng = TestRng::default_rng(RngSeed::Random, RngAlgorithm::Recorder);
         let mut runner =
             TestRunner::new_with_rng(default_config.clone(), recorder_rng);
         let random_byte_array1 = runner.rng().gen::<[u8; 16]>();


### PR DESCRIPTION
closes #548 

Ideally I wouldn't have to define the `RngSeed` type and could have just used an optional. However, the fact that `parse_or_warn` takes a `&mut T` and not a `&mut Option<T>` made it difficult to keep common parsing logic. Maybe you have another suggestion?