### PR TITLE
chore: assert collection in `sample::select` is not empty

### DIFF
--- a/proptest/src/sample.rs
+++ b/proptest/src/sample.rs
@@ -158,6 +158,8 @@ pub fn select<T: Clone + fmt::Debug + 'static>(
 ) -> Select<T> {
     let cow = values.into();
 
+    assert!(!cow.is_empty(), "Cannot select from empty collection");
+
     Select(statics::Map::new(0..cow.len(), SelectMapFn(Arc::new(cow))))
 }
 


### PR DESCRIPTION
This will already fail further down the call-chain but asserting it here gives much better stracktraces, allowing users to debug much faster, where in their potentially very large and composed strategy the problem is.