### PR TITLE
Rand 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ prettyplease = "0.2"
 proc-macro2 = "1.0"
 proptest-macro = { version = "0.1", path = "proptest-macro" }
 quote = "1.0"
-rand = { version = "0.8", default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
-rand_xorshift = "0.3"
+rand = { version = "0.9", default-features = false }
+rand_chacha = { version = "0.9", default-features = false }
+rand_xorshift = "0.4"
 regex = "1.0"
 regex-syntax = "0.8"
 rusty-fork = { version = "0.3.0", default-features = false }

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -29,7 +29,7 @@ attr-macro = ["proptest-macro"]
 unstable = []
 
 # Enables the use of standard-library dependent features
-std = ["rand/std", "lazy_static", "regex-syntax", "num-traits/std"]
+std = ["rand/std", "rand/os_rng", "lazy_static", "regex-syntax", "num-traits/std"]
 
 # std or libm required for mul_add.
 no_std = ["num-traits/libm"]

--- a/proptest/src/bits.rs
+++ b/proptest/src/bits.rs
@@ -205,7 +205,7 @@ impl<T: BitSetLike> Strategy for BitSetStrategy<T> {
         let mut inner = T::new_bitset(self.max);
         for bit in self.min..self.max {
             if self.mask.as_ref().map_or(true, |mask| mask.test(bit))
-                && runner.rng().gen()
+                && runner.rng().random()
             {
                 inner.set(bit);
             }

--- a/proptest/src/bool.rs
+++ b/proptest/src/bool.rs
@@ -28,7 +28,7 @@ impl Strategy for Any {
     type Value = bool;
 
     fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-        Ok(BoolValueTree::new(runner.rng().gen()))
+        Ok(BoolValueTree::new(runner.rng().random()))
     }
 }
 
@@ -50,7 +50,7 @@ impl Strategy for Weighted {
     type Value = bool;
 
     fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-        Ok(BoolValueTree::new(runner.rng().gen_bool(self.0)))
+        Ok(BoolValueTree::new(runner.rng().random_bool(self.0)))
     }
 }
 

--- a/proptest/src/char.rs
+++ b/proptest/src/char.rs
@@ -113,17 +113,17 @@ fn select_range_index(
             .map(|r| (*r.start() as u32, ch as u32 - *r.start() as u32))
     }
 
-    if !special.is_empty() && rnd.gen() {
-        let s = special[rnd.gen_range(0..special.len())];
+    if !special.is_empty() && rnd.random() {
+        let s = special[rnd.random_range(0..special.len())];
         if let Some(ret) = in_range(ranges, s) {
             return ret;
         }
     }
 
-    if !preferred.is_empty() && rnd.gen() {
-        let range = preferred[rnd.gen_range(0..preferred.len())].clone();
+    if !preferred.is_empty() && rnd.random() {
+        let range = preferred[rnd.random_range(0..preferred.len())].clone();
         if let Some(ch) = ::core::char::from_u32(
-            rnd.gen_range(*range.start() as u32..*range.end() as u32 + 1),
+            rnd.random_range(*range.start() as u32..*range.end() as u32 + 1),
         ) {
             if let Some(ret) = in_range(ranges, ch) {
                 return ret;
@@ -132,9 +132,9 @@ fn select_range_index(
     }
 
     for _ in 0..65_536 {
-        let range = ranges[rnd.gen_range(0..ranges.len())].clone();
+        let range = ranges[rnd.random_range(0..ranges.len())].clone();
         if let Some(ch) = ::core::char::from_u32(
-            rnd.gen_range(*range.start() as u32..*range.end() as u32 + 1),
+            rnd.random_range(*range.start() as u32..*range.end() as u32 + 1),
         ) {
             return (*range.start() as u32, ch as u32 - *range.start() as u32);
         }

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -15,8 +15,8 @@
 mod float_samplers;
 
 use crate::test_runner::TestRunner;
-use rand::distributions::uniform::{SampleUniform, Uniform};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::uniform::{SampleUniform, Uniform};
+use rand::distr::{Distribution, StandardUniform};
 
 /// Generate a random value of `X`, sampled uniformly from the half
 /// open range `[low, high)` (excluding `high`). Panics if `low >= high`.
@@ -25,7 +25,7 @@ pub(crate) fn sample_uniform<X: SampleUniform>(
     start: X,
     end: X,
 ) -> X {
-    Uniform::new(start, end).sample(run.rng())
+    Uniform::new(start, end).expect("not uniform").sample(run.rng())
 }
 
 /// Generate a random value of `X`, sampled uniformly from the closed
@@ -35,7 +35,7 @@ pub fn sample_uniform_incl<X: SampleUniform>(
     start: X,
     end: X,
 ) -> X {
-    Uniform::new_inclusive(start, end).sample(run.rng())
+    Uniform::new_inclusive(start, end).expect("not uniform").sample(run.rng())
 }
 
 macro_rules! int_any {
@@ -53,7 +53,7 @@ macro_rules! int_any {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-                Ok(BinarySearch::new(runner.rng().gen()))
+                Ok(BinarySearch::new(runner.rng().random()))
             }
         }
     };
@@ -418,7 +418,7 @@ impl FloatTypes {
 
 trait FloatLayout
 where
-    Standard: Distribution<Self::Bits>,
+    StandardUniform: Distribution<Self::Bits>,
 {
     type Bits: Copy;
 
@@ -675,7 +675,7 @@ macro_rules! float_any {
                     ].new_tree(runner)?.current();
 
                 let mut generated_value: <$typ as FloatLayout>::Bits =
-                    runner.rng().gen();
+                    runner.rng().random();
                 generated_value &= sign_mask | class_mask;
                 generated_value |= sign_or | class_or;
                 let exp = generated_value & $typ::EXP_MASK;

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -38,8 +38,62 @@ pub fn sample_uniform_incl<X: SampleUniform>(
     Uniform::new_inclusive(start, end).expect("not uniform").sample(run.rng())
 }
 
+macro_rules! sample_uniform {
+    ($name: ident, $incl:ident, $from:ty, $to:ty) => {
+        fn $name<X>(
+            run: &mut TestRunner,
+            start: $to,
+            end: $to,
+        ) -> $to {
+            Uniform::<$from>::new(start as $from, end as $from).expect("not uniform").sample(run.rng()) as $to
+        }
+
+        fn $incl<X>(
+            run: &mut TestRunner,
+            start: $to,
+            end: $to,
+        ) -> $to {
+            Uniform::<$from>::new_inclusive(start as $from, end as $from).expect("not uniform").sample(run.rng()) as $to
+        }        
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+sample_uniform!(usize_sample_uniform, usize_sample_uniform_incl, u64, usize);
+#[cfg(target_pointer_width = "32")]
+sample_uniform!(usize_sample_uniform, usize_sample_uniform_incl, u32, usize);
+#[cfg(target_pointer_width = "16")]
+sample_uniform!(usize_sample_uniform, usize_sample_uniform_incl, u16, usize);
+
+#[cfg(target_pointer_width = "64")]
+sample_uniform!(isize_sample_uniform, isize_sample_uniform_incl, i64, isize);
+#[cfg(target_pointer_width = "32")]
+sample_uniform!(isize_sample_uniform, isize_sample_uniform_incl, i32, isize);
+#[cfg(target_pointer_width = "16")]
+sample_uniform!(isize_sample_uniform, isize_sample_uniform_incl, i16, isize);
+
+macro_rules! supported_int_any {
+    ($runner:ident, $typ:ty) => {
+        $runner.rng().random()
+    };
+}
+
+#[cfg(target_pointer_width = "64")]
+macro_rules! unsupported_int_any {
+    ($runner:ident, $typ:ty) => {
+        $runner.rng().next_u64() as $typ
+    };
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+macro_rules! unsupported_int_any {
+    ($runner:ident, $typ:ty) => {
+        $runner.rng().next_u32() as $typ
+    };
+}
+
 macro_rules! int_any {
-    ($typ: ident) => {
+    ($typ: ident, $int_any: ident) => {
         /// Type of the `ANY` constant.
         #[derive(Clone, Copy, Debug)]
         #[must_use = "strategies do nothing unless used"]
@@ -53,7 +107,7 @@ macro_rules! int_any {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-                Ok(BinarySearch::new(runner.rng().random()))
+                Ok(BinarySearch::new($int_any!(runner, $typ)))
             }
         }
     };
@@ -64,6 +118,12 @@ macro_rules! numeric_api {
         numeric_api!($typ, $typ, $epsilon);
     };
     ($typ:ident, $sample_typ:ty, $epsilon:expr) => {
+        numeric_api!($typ, $sample_typ, $epsilon, sample_uniform, sample_uniform_incl);
+    };
+    ($typ:ident, $epsilon:expr, $uniform:ident, $incl:ident) => {
+        numeric_api!($typ, $typ, $epsilon, $uniform, $incl);
+    };
+    ($typ:ident, $sample_typ:ty, $epsilon:expr, $uniform:ident, $incl:ident) => {
         impl Strategy for ::core::ops::Range<$typ> {
             type Tree = BinarySearch;
             type Value = $typ;
@@ -78,7 +138,7 @@ macro_rules! numeric_api {
 
                 Ok(BinarySearch::new_clamped(
                     self.start,
-                    $crate::num::sample_uniform::<$sample_typ>(
+                    $crate::num::$uniform::<$sample_typ>(
                         runner,
                         self.start.into(),
                         self.end.into(),
@@ -104,7 +164,7 @@ macro_rules! numeric_api {
 
                 Ok(BinarySearch::new_clamped(
                     *self.start(),
-                    $crate::num::sample_uniform_incl::<$sample_typ>(
+                    $crate::num::$incl::<$sample_typ>(
                         runner,
                         (*self.start()).into(),
                         (*self.end()).into(),
@@ -122,7 +182,7 @@ macro_rules! numeric_api {
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 Ok(BinarySearch::new_clamped(
                     self.start,
-                    $crate::num::sample_uniform_incl::<$sample_typ>(
+                    $crate::num::$incl::<$sample_typ>(
                         runner,
                         self.start.into(),
                         ::core::$typ::MAX.into(),
@@ -140,7 +200,7 @@ macro_rules! numeric_api {
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 Ok(BinarySearch::new_clamped(
                     ::core::$typ::MIN,
-                    $crate::num::sample_uniform::<$sample_typ>(
+                    $crate::num::$uniform::<$sample_typ>(
                         runner,
                         ::core::$typ::MIN.into(),
                         self.end.into(),
@@ -158,7 +218,7 @@ macro_rules! numeric_api {
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 Ok(BinarySearch::new_clamped(
                     ::core::$typ::MIN,
-                    $crate::num::sample_uniform_incl::<$sample_typ>(
+                    $crate::num::$incl::<$sample_typ>(
                         runner,
                         ::core::$typ::MIN.into(),
                         self.end.into(),
@@ -173,14 +233,17 @@ macro_rules! numeric_api {
 
 macro_rules! signed_integer_bin_search {
     ($typ:ident) => {
+        signed_integer_bin_search!($typ, supported_int_any, sample_uniform, sample_uniform_incl);
+    };
+    ($typ:ident, $int_any: ident, $uniform: ident, $incl: ident) => {
         #[allow(missing_docs)]
         pub mod $typ {
-            use rand::Rng;
+            use rand::{Rng, RngCore};
 
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
 
-            int_any!($typ);
+            int_any!($typ, $int_any);
 
             /// Shrinks an integer towards 0, using binary search to find
             /// boundary points.
@@ -268,21 +331,24 @@ macro_rules! signed_integer_bin_search {
                 }
             }
 
-            numeric_api!($typ, 1);
+            numeric_api!($typ, 1, $uniform, $incl);
         }
     };
 }
 
 macro_rules! unsigned_integer_bin_search {
     ($typ:ident) => {
+        unsigned_integer_bin_search!($typ, supported_int_any, sample_uniform, sample_uniform_incl);
+    };
+    ($typ:ident, $int_any: ident, $uniform: ident, $incl: ident) => {
         #[allow(missing_docs)]
         pub mod $typ {
-            use rand::Rng;
+            use rand::{Rng, RngCore};
 
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
 
-            int_any!($typ);
+            int_any!($typ, $int_any);
 
             /// Shrinks an integer towards 0, using binary search to find
             /// boundary points.
@@ -356,7 +422,7 @@ macro_rules! unsigned_integer_bin_search {
                 }
             }
 
-            numeric_api!($typ, 1);
+            numeric_api!($typ, 1, $uniform, $incl);
         }
     };
 }
@@ -366,13 +432,13 @@ signed_integer_bin_search!(i16);
 signed_integer_bin_search!(i32);
 signed_integer_bin_search!(i64);
 signed_integer_bin_search!(i128);
-signed_integer_bin_search!(isize);
+signed_integer_bin_search!(isize, unsupported_int_any, isize_sample_uniform, isize_sample_uniform_incl);
 unsigned_integer_bin_search!(u8);
 unsigned_integer_bin_search!(u16);
 unsigned_integer_bin_search!(u32);
 unsigned_integer_bin_search!(u64);
 unsigned_integer_bin_search!(u128);
-unsigned_integer_bin_search!(usize);
+unsigned_integer_bin_search!(usize, unsupported_int_any, usize_sample_uniform, usize_sample_uniform_incl);
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/proptest/src/num/float_samplers.rs
+++ b/proptest/src/num/float_samplers.rs
@@ -24,7 +24,7 @@ macro_rules! float_sampler {
     ($typ: ident, $int_typ: ident, $wrapper: ident) => {
         pub mod $typ {
             use rand::prelude::*;
-            use rand::distributions::uniform::{
+            use rand::distr::uniform::{
                 SampleBorrow, SampleUniform, UniformSampler,
             };
             #[cfg(not(feature = "std"))]
@@ -79,22 +79,22 @@ macro_rules! float_sampler {
 
                 type X = $wrapper;
 
-                fn new<B1, B2>(low: B1, high: B2) -> Self
+                fn new<B1, B2>(low: B1, high: B2) -> Result<Self, rand::distr::uniform::Error>
                 where
                     B1: SampleBorrow<Self::X> + Sized,
                     B2: SampleBorrow<Self::X> + Sized,
                 {
                     let low = low.borrow().0;
                     let high = high.borrow().0;
-                    FloatUniform {
+                    Ok(FloatUniform {
                         low,
                         high,
                         intervals: split_interval([low, high]),
                         inclusive: false,
-                    }
+                    })
                 }
 
-                fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+                fn new_inclusive<B1, B2>(low: B1, high: B2) -> Result<Self, rand::distr::uniform::Error>
                 where
                     B1: SampleBorrow<Self::X> + Sized,
                     B2: SampleBorrow<Self::X> + Sized,
@@ -102,18 +102,18 @@ macro_rules! float_sampler {
                     let low = low.borrow().0;
                     let high = high.borrow().0;
 
-                    FloatUniform {
+                    Ok(FloatUniform {
                         low,
                         high,
                         intervals: split_interval([low, high]),
                         inclusive: true,
-                    }
+                    })
                 }
 
                 fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
                     let mut intervals = self.intervals;
                     while intervals.count > 1 {
-                        let new_interval = intervals.get(rng.gen_range(0..intervals.count));
+                        let new_interval = intervals.get(rng.random_range(0..intervals.count));
                         intervals = split_interval(new_interval);
                     }
                     let last = intervals.get(0);

--- a/proptest/src/num/float_samplers.rs
+++ b/proptest/src/num/float_samplers.rs
@@ -261,7 +261,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (-1., 10.);
-                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high)).expect("not uniform");
 
                     let samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -276,7 +276,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1., 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high)).expect("not uniform");
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -289,7 +289,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (-1., 10.);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).expect("not uniform");
 
                     let samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -304,7 +304,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1., 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).expect("not uniform");
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -317,7 +317,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1. - $typ::EPSILON, 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).expect("not uniform");
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -330,7 +330,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (0., MAX_PRECISE_INT as $typ);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).expect("not uniform");
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)))

--- a/proptest/src/sample.rs
+++ b/proptest/src/sample.rs
@@ -405,7 +405,7 @@ impl Selector {
         let mut rng = self.rng.clone();
 
         for item in it {
-            let score = bias.saturating_add(rng.gen());
+            let score = bias.saturating_add(rng.random());
             if best.is_none() || score < min_score {
                 best = Some(item);
                 min_score = score;

--- a/proptest/src/strategy/shuffle.rs
+++ b/proptest/src/strategy/shuffle.rs
@@ -170,7 +170,7 @@ where
             // Determine the other index to be swapped, then skip the swap if
             // it is too far. This ordering is critical, as it ensures that we
             // generate the same sequence of random numbers every time.
-            let end_index = rng.gen_range(start_index..len);
+            let end_index = rng.random_range(start_index..len);
             if end_index - start_index <= max_swap {
                 value.shuffle_swap(start_index, end_index);
             }

--- a/proptest/src/strategy/traits.rs
+++ b/proptest/src/strategy/traits.rs
@@ -127,7 +127,7 @@ pub trait Strategy: fmt::Debug {
     ///       // Note that this particular case would be better implemented as
     ///       // `(0i32..10, -10i32..10).prop_map(|(a, b)| (a, a + b))`
     ///       // but is shown here for simplicity.
-    ///       |centre, rng| (centre, centre + rng.gen_range(-10, 10))))
+    ///       |centre, rng| (centre, centre + rng.random_range(-10, 10))))
     ///   {
     ///       // Test stuff
     ///   }

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -387,14 +387,14 @@ impl TestRng {
                 rng: match algorithm {
                     RngAlgorithm::XorShift => {
                         let rng = match seed {
-                            RngSeed::Random => XorShiftRng::seed_from_u64(0),
+                            RngSeed::Random => XorShiftRng::from_os_rng(),
                             RngSeed::Fixed(seed) => XorShiftRng::seed_from_u64(seed),
                         };
                         TestRngImpl::XorShift(rng)
                     }
                     RngAlgorithm::ChaCha => {
                         let rng = match seed {
-                            RngSeed::Random => ChaChaRng::from_seed(Default::default()),
+                            RngSeed::Random => ChaChaRng::from_os_rng(),
                             RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
                         };
                         TestRngImpl::ChaCha(rng)
@@ -404,7 +404,7 @@ impl TestRng {
                     }
                     RngAlgorithm::Recorder => {
                         let rng =  match seed {
-                            RngSeed::Random => ChaChaRng::from_seed(Default::default()),
+                            RngSeed::Random => ChaChaRng::from_os_rng(),
                             RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
                         };
                         TestRngImpl::Recorder {rng, record: Vec::new()}

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -129,20 +129,14 @@ enum TestRngImpl {
 impl RngCore for TestRng {
     fn next_u32(&mut self) -> u32 {
         match &mut self.rng {
-            &mut TestRngImpl::XorShift(ref mut rng) => rng.next_u32(),
-
-            &mut TestRngImpl::ChaCha(ref mut rng) => rng.next_u32(),
-
-            &mut TestRngImpl::PassThrough { .. } => {
+            TestRngImpl::XorShift(rng) => rng.next_u32(),
+            TestRngImpl::ChaCha(rng) => rng.next_u32(),
+            TestRngImpl::PassThrough { .. } => {
                 let mut buf = [0; 4];
                 self.fill_bytes(&mut buf[..]);
                 u32::from_le_bytes(buf)
             }
-
-            &mut TestRngImpl::Recorder {
-                ref mut rng,
-                ref mut record,
-            } => {
+            TestRngImpl::Recorder { rng, record } => {
                 let read = rng.next_u32();
                 record.extend_from_slice(&read.to_le_bytes());
                 read
@@ -152,20 +146,14 @@ impl RngCore for TestRng {
 
     fn next_u64(&mut self) -> u64 {
         match &mut self.rng {
-            &mut TestRngImpl::XorShift(ref mut rng) => rng.next_u64(),
-
-            &mut TestRngImpl::ChaCha(ref mut rng) => rng.next_u64(),
-
-            &mut TestRngImpl::PassThrough { .. } => {
+            TestRngImpl::XorShift(rng) => rng.next_u64(),
+            TestRngImpl::ChaCha(rng) => rng.next_u64(),
+            TestRngImpl::PassThrough { .. } => {
                 let mut buf = [0; 8];
                 self.fill_bytes(&mut buf[..]);
                 u64::from_le_bytes(buf)
             }
-
-            &mut TestRngImpl::Recorder {
-                ref mut rng,
-                ref mut record,
-            } => {
+            TestRngImpl::Recorder { rng, record } => {
                 let read = rng.next_u64();
                 record.extend_from_slice(&read.to_le_bytes());
                 read
@@ -175,55 +163,19 @@ impl RngCore for TestRng {
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         match &mut self.rng {
-            &mut TestRngImpl::XorShift(ref mut rng) => rng.fill_bytes(dest),
-
-            &mut TestRngImpl::ChaCha(ref mut rng) => rng.fill_bytes(dest),
-
-            &mut TestRngImpl::PassThrough {
-                ref mut off,
-                end,
-                ref data,
-            } => {
-                let bytes_to_copy = dest.len().min(end - *off);
-                dest[..bytes_to_copy]
-                    .copy_from_slice(&data[*off..*off + bytes_to_copy]);
+            TestRngImpl::XorShift(rng) => rng.fill_bytes(dest),
+            TestRngImpl::ChaCha(rng) => rng.fill_bytes(dest),
+            TestRngImpl::PassThrough { off, end, data } => {
+                let bytes_to_copy = dest.len().min(*end - *off);
+                dest[.. bytes_to_copy].copy_from_slice(&data[*off .. *off + bytes_to_copy]);
                 *off += bytes_to_copy;
-                for i in bytes_to_copy..dest.len() {
+                for i in bytes_to_copy .. dest.len() {
                     dest[i] = 0;
                 }
             }
-
-            &mut TestRngImpl::Recorder {
-                ref mut rng,
-                ref mut record,
-            } => {
-                let res = rng.fill_bytes(dest);
-                record.extend_from_slice(&dest);
-                res
-            }
-        }
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        match self.rng {
-            TestRngImpl::XorShift(ref mut rng) => rng.try_fill_bytes(dest),
-
-            TestRngImpl::ChaCha(ref mut rng) => rng.try_fill_bytes(dest),
-
-            TestRngImpl::PassThrough { .. } => {
-                self.fill_bytes(dest);
-                Ok(())
-            }
-
-            TestRngImpl::Recorder {
-                ref mut rng,
-                ref mut record,
-            } => {
-                let res = rng.try_fill_bytes(dest);
-                if res.is_ok() {
-                    record.extend_from_slice(&dest);
-                }
-                res
+            TestRngImpl::Recorder { rng, record } => {
+                rng.fill_bytes(dest);
+                record.extend_from_slice(dest);
             }
         }
     }
@@ -435,14 +387,14 @@ impl TestRng {
                 rng: match algorithm {
                     RngAlgorithm::XorShift => {
                         let rng = match seed {
-                            RngSeed::Random => XorShiftRng::from_entropy(),
+                            RngSeed::Random => XorShiftRng::seed_from_u64(0),
                             RngSeed::Fixed(seed) => XorShiftRng::seed_from_u64(seed),
                         };
                         TestRngImpl::XorShift(rng)
                     }
                     RngAlgorithm::ChaCha => {
                         let rng = match seed {
-                            RngSeed::Random => ChaChaRng::from_entropy(),
+                            RngSeed::Random => ChaChaRng::from_seed(Default::default()),
                             RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
                         };
                         TestRngImpl::ChaCha(rng)
@@ -452,7 +404,7 @@ impl TestRng {
                     }
                     RngAlgorithm::Recorder => {
                         let rng =  match seed {
-                            RngSeed::Random => ChaChaRng::from_entropy(),
+                            RngSeed::Random => ChaChaRng::from_seed(Default::default()),
                             RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
                         };
                         TestRngImpl::Recorder {rng, record: Vec::new()}
@@ -586,7 +538,7 @@ impl TestRng {
     pub(crate) fn new_rng_seed(&mut self) -> Seed {
         match self.rng {
             TestRngImpl::XorShift(ref mut rng) => {
-                let mut seed = rng.gen::<[u8; 16]>();
+                let mut seed = rng.random::<[u8; 16]>();
 
                 // Directly using XorShiftRng::from_seed() at this point would
                 // result in rng and the returned value being exactly the same.
@@ -601,7 +553,7 @@ impl TestRng {
                 Seed::XorShift(seed)
             }
 
-            TestRngImpl::ChaCha(ref mut rng) => Seed::ChaCha(rng.gen()),
+            TestRngImpl::ChaCha(ref mut rng) => Seed::ChaCha(rng.random()),
 
             TestRngImpl::PassThrough {
                 ref mut off,
@@ -619,7 +571,7 @@ impl TestRng {
             }
 
             TestRngImpl::Recorder { ref mut rng, .. } => {
-                Seed::Recorder(rng.gen())
+                Seed::Recorder(rng.random())
             }
         }
     }

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -684,9 +684,9 @@ mod test {
         assert_eq!(0xDEADBEEFCAFE7856, rng.next_u64());
 
         let mut buf = [0u8; 4];
-        rng.try_fill_bytes(&mut buf[0..4]).unwrap();
+        rng.fill_bytes(&mut buf[0..4]);
         assert_eq!([1, 2, 3, 0], buf);
-        rng.try_fill_bytes(&mut buf[0..4]).unwrap();
+        rng.fill_bytes(&mut buf[0..4]);
         assert_eq!([0, 0, 0, 0], buf);
     }
 }

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -648,7 +648,7 @@ mod test {
             {
                 let mut rng1 = orig.clone();
                 let mut rng2 = rng1.gen_rng();
-                assert_ne!(rng1.gen::<Value>(), rng2.gen::<Value>());
+                assert_ne!(rng1.random::<Value>(), rng2.random::<Value>());
             }
 
             {
@@ -656,10 +656,10 @@ mod test {
                 let mut rng2 = rng1.gen_rng();
                 let mut rng3 = rng1.gen_rng();
                 let mut rng4 = rng2.gen_rng();
-                let a = rng1.gen::<Value>();
-                let b = rng2.gen::<Value>();
-                let c = rng3.gen::<Value>();
-                let d = rng4.gen::<Value>();
+                let a = rng1.random::<Value>();
+                let b = rng2.random::<Value>();
+                let c = rng3.random::<Value>();
+                let d = rng4.random::<Value>();
                 assert_ne!(a, b);
                 assert_ne!(a, c);
                 assert_ne!(a, d);

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1244,8 +1244,8 @@ mod test {
     fn new_rng_makes_separate_rng() {
         use rand::Rng;
         let mut runner = TestRunner::default();
-        let from_1 = runner.new_rng().gen::<[u8; 16]>();
-        let from_2 = runner.rng().gen::<[u8; 16]>();
+        let from_1 = runner.new_rng().random::<[u8; 16]>();
+        let from_2 = runner.rng().random::<[u8; 16]>();
         assert_ne!(from_1, from_2);
     }
 
@@ -1258,7 +1258,7 @@ mod test {
         let recorder_rng = TestRng::default_rng(RngSeed::Random, RngAlgorithm::Recorder);
         let mut runner =
             TestRunner::new_with_rng(default_config.clone(), recorder_rng);
-        let random_byte_array1 = runner.rng().gen::<[u8; 16]>();
+        let random_byte_array1 = runner.rng().random::<[u8; 16]>();
         let bytes_used = runner.bytes_used();
         assert!(bytes_used.len() >= 16); // could use more bytes for some reason
 
@@ -1267,7 +1267,7 @@ mod test {
             TestRng::from_seed(RngAlgorithm::PassThrough, &bytes_used);
         let mut runner =
             TestRunner::new_with_rng(default_config, passthrough_rng);
-        let random_byte_array2 = runner.rng().gen::<[u8; 16]>();
+        let random_byte_array2 = runner.rng().random::<[u8; 16]>();
 
         // make sure the same value was created
         assert_eq!(random_byte_array1, random_byte_array2);


### PR DESCRIPTION
This PR updates `rand` to v0.9 based off the work of #552.

There is probably a cleaner way to add the custom implementations for `usize` and `isize`, but I didn't have more time to think about it. Any ideas are welcome!

See #552.