### PR TITLE
Fix URLs in proptest-derive error messages

### DIFF
--- a/proptest-derive/CHANGELOG.md
+++ b/proptest-derive/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fixed URLs in proptest-derive error messages ([\#574](https://github.com/proptest-rs/proptest/pull/574))
+
 ## 0.5.1
 
 - Fix non-local impl nightly warning with allow(non_local_definitions)

--- a/proptest-derive/src/error.rs
+++ b/proptest-derive/src/error.rs
@@ -206,15 +206,11 @@ impl Context {
 /// to the given `$message`.
 macro_rules! mk_err_msg {
     ($code: ident, $msg: expr) => {
-        concat!(
-            "[proptest_derive, ",
+        format!(
+            "[proptest_derive, {}] during #[derive(Arbitrary)]:\n{} Please see: https://proptest-rs.github.io/proptest/proptest-derive/errors.html#{} for more information.",
             stringify!($code),
-            "]",
-            " during #[derive(Arbitrary)]:\n",
             $msg,
-            " Please see: https://PATH/TO/foo#",
-            stringify!($code),
-            " for more information."
+            (stringify!($code)).to_lowercase()
         )
     };
 }
@@ -229,7 +225,7 @@ macro_rules! fatal {
     ($error: ident ($($arg: ident: $arg_ty: ty),*), $code: ident,
      $msg: expr, $($fmt: tt)+) => {
         pub fn $error<T>(ctx: Ctx, $($arg: $arg_ty),*) -> DeriveResult<T> {
-            ctx.fatal(format!(mk_err_msg!($code, $msg), $($fmt)+))
+            ctx.fatal(mk_err_msg!($code, format!($msg, $($fmt)+)))
         }
     };
 }
@@ -244,7 +240,7 @@ macro_rules! error {
     ($error: ident ($($arg: ident: $arg_ty: ty),*), $code: ident,
      $msg: expr, $($fmt: tt)+) => {
         pub fn $error(ctx: Ctx, $($arg: $arg_ty),*) {
-            ctx.error(format!(mk_err_msg!($code, $msg), $($fmt)+))
+            ctx.error(mk_err_msg!($code, format!($msg, $($fmt)+)))
         }
     };
 }
@@ -677,3 +673,14 @@ error!(
      since `params` cannot be used in `<string>`.",
     item
 );
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_mk_err_msg_format() {
+        assert_eq!(
+            mk_err_msg!(E0001, "This is a sample error message."),
+            "[proptest_derive, E0001] during #[derive(Arbitrary)]:\nThis is a sample error message. Please see: https://proptest-rs.github.io/proptest/proptest-derive/errors.html#e0001 for more information."
+        );
+    }
+}


### PR DESCRIPTION
This PR fixes the error messages emitted by proptest-derive. Before, the URLs had the following format:

> https://PATH/TO/foo#E0001

Not only the URL doesn’t exist, but also the fragment is in uppercase characters (E0123) instead of the lowercase string (e0123) that rustdoc generates.

Now, they use the correct format instead:

> https://proptest-rs.github.io/proptest/proptest-derive/errors.html#e0001

I added a unit test to check the output format of `mk_err_msg`. Sadly it’s not possible to test the URL format in the compile-fail tests because it looks like the support from [compiletest-rs](https://github.com/Manishearth/compiletest-rs) for multi-line error messages is broken.