### PR TITLE
Upgrade `rand` to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,10 @@ prettyplease = "0.2"
 proc-macro2 = "1.0"
 proptest-macro = { version = "0.1", path = "proptest-macro" }
 quote = "1.0"
-rand = { version = "0.8", default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
-rand_xorshift = "0.3"
+rand = { version = "0.9.1", default-features = false, features = ["os_rng"] }
+rand_core = { version = "0.9.3", default-features = false }
+rand_chacha = { version = "0.9.0", default-features = false }
+rand_xorshift = "0.4.0"
 regex = "1.0"
 regex-syntax = "0.8"
 rusty-fork = { version = "0.3.0", default-features = false }

--- a/proptest/Cargo.toml
+++ b/proptest/Cargo.toml
@@ -72,6 +72,7 @@ regex-syntax = { workspace = true, optional = true }
 bit-set = { workspace = true, optional = true }
 bit-vec = { workspace = true, optional = true }
 rand = { workspace = true, features = ["alloc"] }
+rand_core = { workspace = true }
 rand_xorshift = { workspace = true }
 rand_chacha = { workspace = true }
 rusty-fork = { workspace = true, optional = true }

--- a/proptest/src/bits.rs
+++ b/proptest/src/bits.rs
@@ -205,7 +205,7 @@ impl<T: BitSetLike> Strategy for BitSetStrategy<T> {
         let mut inner = T::new_bitset(self.max);
         for bit in self.min..self.max {
             if self.mask.as_ref().map_or(true, |mask| mask.test(bit))
-                && runner.rng().gen()
+                && runner.rng().random()
             {
                 inner.set(bit);
             }

--- a/proptest/src/bool.rs
+++ b/proptest/src/bool.rs
@@ -28,7 +28,7 @@ impl Strategy for Any {
     type Value = bool;
 
     fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-        Ok(BoolValueTree::new(runner.rng().gen()))
+        Ok(BoolValueTree::new(runner.rng().random()))
     }
 }
 
@@ -50,7 +50,7 @@ impl Strategy for Weighted {
     type Value = bool;
 
     fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-        Ok(BoolValueTree::new(runner.rng().gen_bool(self.0)))
+        Ok(BoolValueTree::new(runner.rng().random_bool(self.0)))
     }
 }
 

--- a/proptest/src/char.rs
+++ b/proptest/src/char.rs
@@ -113,17 +113,17 @@ fn select_range_index(
             .map(|r| (*r.start() as u32, ch as u32 - *r.start() as u32))
     }
 
-    if !special.is_empty() && rnd.gen() {
-        let s = special[rnd.gen_range(0..special.len())];
+    if !special.is_empty() && rnd.random() {
+        let s = special[rnd.random_range(0..special.len())];
         if let Some(ret) = in_range(ranges, s) {
             return ret;
         }
     }
 
-    if !preferred.is_empty() && rnd.gen() {
-        let range = preferred[rnd.gen_range(0..preferred.len())].clone();
+    if !preferred.is_empty() && rnd.random() {
+        let range = preferred[rnd.random_range(0..preferred.len())].clone();
         if let Some(ch) = ::core::char::from_u32(
-            rnd.gen_range(*range.start() as u32..*range.end() as u32 + 1),
+            rnd.random_range(*range.start() as u32..*range.end() as u32 + 1),
         ) {
             if let Some(ret) = in_range(ranges, ch) {
                 return ret;
@@ -132,9 +132,9 @@ fn select_range_index(
     }
 
     for _ in 0..65_536 {
-        let range = ranges[rnd.gen_range(0..ranges.len())].clone();
+        let range = ranges[rnd.random_range(0..ranges.len())].clone();
         if let Some(ch) = ::core::char::from_u32(
-            rnd.gen_range(*range.start() as u32..*range.end() as u32 + 1),
+            rnd.random_range(*range.start() as u32..*range.end() as u32 + 1),
         ) {
             return (*range.start() as u32, ch as u32 - *range.start() as u32);
         }

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -873,7 +873,7 @@ macro_rules! float_any {
                     ].new_tree(runner)?.current();
 
                 let mut generated_value: <$typ as FloatLayout>::Bits =
-                    runner.rng().gen();
+                    runner.rng().random();
                 generated_value &= sign_mask | class_mask;
                 generated_value |= sign_or | class_or;
                 let exp = generated_value & $typ::EXP_MASK;

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -80,6 +80,7 @@ macro_rules! int_any {
 
     // 3) Everything else: fall back to `.random()`
     ($typ:ident) => {
+        use rand::Rng;
         #[derive(Clone, Copy, Debug)]
         #[must_use = "strategies do nothing unless used"]
         pub struct Any(());
@@ -373,8 +374,6 @@ macro_rules! signed_integer_bin_search {
     ($typ:ident) => {
         #[allow(missing_docs)]
         pub mod $typ {
-            use rand::Rng;
-
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
 
@@ -475,8 +474,6 @@ macro_rules! unsigned_integer_bin_search {
     ($typ:ident) => {
         #[allow(missing_docs)]
         pub mod $typ {
-            use rand::Rng;
-
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
 

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -15,8 +15,8 @@
 mod float_samplers;
 
 use crate::test_runner::TestRunner;
-use rand::distributions::uniform::{SampleUniform, Uniform};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::uniform::{SampleUniform, Uniform};
+use rand::distr::{Distribution, StandardUniform};
 
 /// Generate a random value of `X`, sampled uniformly from the half
 /// open range `[low, high)` (excluding `high`). Panics if `low >= high`.
@@ -25,7 +25,9 @@ pub(crate) fn sample_uniform<X: SampleUniform>(
     start: X,
     end: X,
 ) -> X {
-    Uniform::new(start, end).sample(run.rng())
+    Uniform::new(start, end)
+        .expect("Invalid range for Uniform")
+        .sample(run.rng())
 }
 
 /// Generate a random value of `X`, sampled uniformly from the closed
@@ -35,7 +37,9 @@ pub fn sample_uniform_incl<X: SampleUniform>(
     start: X,
     end: X,
 ) -> X {
-    Uniform::new_inclusive(start, end).sample(run.rng())
+    Uniform::new_inclusive(start, end)
+        .expect("Invalid range for Uniform")
+        .sample(run.rng())
 }
 
 macro_rules! int_any {
@@ -418,7 +422,7 @@ impl FloatTypes {
 
 trait FloatLayout
 where
-    Standard: Distribution<Self::Bits>,
+    StandardUniform: Distribution<Self::Bits>,
 {
     type Bits: Copy;
 

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -15,8 +15,7 @@
 mod float_samplers;
 
 use crate::test_runner::TestRunner;
-use rand::distr::uniform::{SampleUniform, Uniform};
-use rand::distr::{Distribution, StandardUniform};
+use rand::distr::{Distribution, StandardUniform, uniform::{SampleUniform, Uniform}};
 
 /// Generate a random value of `X`, sampled uniformly from the half
 /// open range `[low, high)` (excluding `high`). Panics if `low >= high`.
@@ -57,7 +56,7 @@ macro_rules! int_any {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-                Ok(BinarySearch::new(runner.rng().gen()))
+                Ok(BinarySearch::new(runner.rng().random()))
             }
         }
     };
@@ -370,13 +369,11 @@ signed_integer_bin_search!(i16);
 signed_integer_bin_search!(i32);
 signed_integer_bin_search!(i64);
 signed_integer_bin_search!(i128);
-signed_integer_bin_search!(isize);
 unsigned_integer_bin_search!(u8);
 unsigned_integer_bin_search!(u16);
 unsigned_integer_bin_search!(u32);
 unsigned_integer_bin_search!(u64);
 unsigned_integer_bin_search!(u128);
-unsigned_integer_bin_search!(usize);
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -679,7 +676,7 @@ macro_rules! float_any {
                     ].new_tree(runner)?.current();
 
                 let mut generated_value: <$typ as FloatLayout>::Bits =
-                    runner.rng().gen();
+                    runner.rng().random();
                 generated_value &= sign_mask | class_mask;
                 generated_value |= sign_or | class_or;
                 let exp = generated_value & $typ::EXP_MASK;
@@ -1114,8 +1111,6 @@ mod test {
         contract_sanity!(i32);
         contract_sanity!(u64);
         contract_sanity!(i64);
-        contract_sanity!(usize);
-        contract_sanity!(isize);
         contract_sanity!(f32);
         contract_sanity!(f64);
     }
@@ -1464,8 +1459,6 @@ mod test {
         panic_on_empty!(i32);
         panic_on_empty!(u64);
         panic_on_empty!(i64);
-        panic_on_empty!(usize);
-        panic_on_empty!(isize);
         panic_on_empty!(f32);
         panic_on_empty!(f64);
     }

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -15,7 +15,8 @@
 mod float_samplers;
 
 use crate::test_runner::TestRunner;
-use rand::distr::{Distribution, StandardUniform, uniform::{SampleUniform, Uniform}};
+use rand::distr::uniform::{SampleUniform, Uniform};
+use rand::distr::{Distribution, StandardUniform};
 
 /// Generate a random value of `X`, sampled uniformly from the half
 /// open range `[low, high)` (excluding `high`). Panics if `low >= high`.
@@ -56,7 +57,7 @@ macro_rules! int_any {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-                Ok(BinarySearch::new(runner.rng().random()))
+                Ok(BinarySearch::new(runner.rng().gen()))
             }
         }
     };
@@ -369,11 +370,13 @@ signed_integer_bin_search!(i16);
 signed_integer_bin_search!(i32);
 signed_integer_bin_search!(i64);
 signed_integer_bin_search!(i128);
+signed_integer_bin_search!(isize);
 unsigned_integer_bin_search!(u8);
 unsigned_integer_bin_search!(u16);
 unsigned_integer_bin_search!(u32);
 unsigned_integer_bin_search!(u64);
 unsigned_integer_bin_search!(u128);
+unsigned_integer_bin_search!(usize);
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -676,7 +679,7 @@ macro_rules! float_any {
                     ].new_tree(runner)?.current();
 
                 let mut generated_value: <$typ as FloatLayout>::Bits =
-                    runner.rng().random();
+                    runner.rng().gen();
                 generated_value &= sign_mask | class_mask;
                 generated_value |= sign_or | class_or;
                 let exp = generated_value & $typ::EXP_MASK;
@@ -1111,6 +1114,8 @@ mod test {
         contract_sanity!(i32);
         contract_sanity!(u64);
         contract_sanity!(i64);
+        contract_sanity!(usize);
+        contract_sanity!(isize);
         contract_sanity!(f32);
         contract_sanity!(f64);
     }
@@ -1459,6 +1464,8 @@ mod test {
         panic_on_empty!(i32);
         panic_on_empty!(u64);
         panic_on_empty!(i64);
+        panic_on_empty!(usize);
+        panic_on_empty!(isize);
         panic_on_empty!(f32);
         panic_on_empty!(f64);
     }

--- a/proptest/src/num/float_samplers.rs
+++ b/proptest/src/num/float_samplers.rs
@@ -264,7 +264,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (-1., 10.);
-                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high)).unwrap();
 
                     let samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -279,7 +279,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1., 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high)).unwrap();
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -292,7 +292,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (-1., 10.);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).unwrap();
 
                     let samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -307,7 +307,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1., 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).unwrap();
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -320,7 +320,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1. - $typ::EPSILON, 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).unwrap();
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -333,7 +333,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (0., MAX_PRECISE_INT as $typ);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).unwrap();
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)))

--- a/proptest/src/num/float_samplers.rs
+++ b/proptest/src/num/float_samplers.rs
@@ -264,7 +264,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (-1., 10.);
-                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high)).expect("Invalid range for FloatUniform");
 
                     let samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -279,7 +279,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1., 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high)).expect("Invalid range for FloatUniform");
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -292,7 +292,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (-1., 10.);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).expect("Invalid range for FloatUniform");
 
                     let samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -307,7 +307,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1., 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).expect("Invalid range for FloatUniform");
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -320,7 +320,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1. - $typ::EPSILON, 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).expect("Invalid range for FloatUniform");
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -333,7 +333,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (0., MAX_PRECISE_INT as $typ);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).expect("Invalid range for FloatUniform");
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)))

--- a/proptest/src/num/float_samplers.rs
+++ b/proptest/src/num/float_samplers.rs
@@ -24,9 +24,7 @@ macro_rules! float_sampler {
     ($typ: ident, $int_typ: ident, $wrapper: ident) => {
         pub mod $typ {
             use rand::prelude::*;
-            use rand::distributions::uniform::{
-                SampleBorrow, SampleUniform, UniformSampler,
-            };
+            use rand::distr::uniform::{SampleBorrow, SampleUniform, UniformSampler};
             #[cfg(not(feature = "std"))]
             use num_traits::float::Float;
 
@@ -79,41 +77,46 @@ macro_rules! float_sampler {
 
                 type X = $wrapper;
 
-                fn new<B1, B2>(low: B1, high: B2) -> Self
+                fn new<B1, B2>(low: B1, high: B2) -> Result<Self, rand::distr::uniform::Error>
                 where
                     B1: SampleBorrow<Self::X> + Sized,
                     B2: SampleBorrow<Self::X> + Sized,
                 {
                     let low = low.borrow().0;
                     let high = high.borrow().0;
-                    FloatUniform {
+                    if !(low < high) {
+                        return Err(rand::distr::uniform::Error::EmptyRange);
+                    }
+                    Ok(FloatUniform {
                         low,
                         high,
                         intervals: split_interval([low, high]),
                         inclusive: false,
-                    }
+                    })
                 }
 
-                fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+                fn new_inclusive<B1, B2>(low: B1, high: B2) -> Result<Self, rand::distr::uniform::Error>
                 where
                     B1: SampleBorrow<Self::X> + Sized,
                     B2: SampleBorrow<Self::X> + Sized,
                 {
                     let low = low.borrow().0;
                     let high = high.borrow().0;
-
-                    FloatUniform {
+                    if !(low <= high) {
+                        return Err(rand::distr::uniform::Error::EmptyRange);
+                    }
+                    Ok(FloatUniform {
                         low,
                         high,
                         intervals: split_interval([low, high]),
                         inclusive: true,
-                    }
+                    })
                 }
 
                 fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
                     let mut intervals = self.intervals;
                     while intervals.count > 1 {
-                        let new_interval = intervals.get(rng.gen_range(0..intervals.count));
+                        let new_interval = intervals.get(rng.random_range(0..intervals.count));
                         intervals = split_interval(new_interval);
                     }
                     let last = intervals.get(0);

--- a/proptest/src/num/float_samplers.rs
+++ b/proptest/src/num/float_samplers.rs
@@ -264,7 +264,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (-1., 10.);
-                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high)).unwrap();
+                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high));
 
                     let samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -279,7 +279,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1., 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high)).unwrap();
+                    let uniform = FloatUniform::new($wrapper(low), $wrapper(high));
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -292,7 +292,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (-1., 10.);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).unwrap();
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
 
                     let samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -307,7 +307,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1., 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).unwrap();
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -320,7 +320,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (1. - $typ::EPSILON, 1. + $typ::EPSILON);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).unwrap();
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)));
@@ -333,7 +333,7 @@ macro_rules! float_sampler {
 
                     let mut test_rng = TestRng::deterministic_rng(RngAlgorithm::default());
                     let (low, high) = (0., MAX_PRECISE_INT as $typ);
-                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high)).unwrap();
+                    let uniform = FloatUniform::new_inclusive($wrapper(low), $wrapper(high));
 
                     let mut samples = (0..100)
                         .map(|_| $typ::from(uniform.sample(&mut test_rng)))

--- a/proptest/src/sample.rs
+++ b/proptest/src/sample.rs
@@ -405,7 +405,7 @@ impl Selector {
         let mut rng = self.rng.clone();
 
         for item in it {
-            let score = bias.saturating_add(rng.gen());
+            let score = bias.saturating_add(rng.random());
             if best.is_none() || score < min_score {
                 best = Some(item);
                 min_score = score;

--- a/proptest/src/strategy/shuffle.rs
+++ b/proptest/src/strategy/shuffle.rs
@@ -170,7 +170,7 @@ where
             // Determine the other index to be swapped, then skip the swap if
             // it is too far. This ordering is critical, as it ensures that we
             // generate the same sequence of random numbers every time.
-            let end_index = rng.gen_range(start_index..len);
+            let end_index = rng.random_range(start_index..len);
             if end_index - start_index <= max_swap {
                 value.shuffle_swap(start_index, end_index);
             }

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -630,6 +630,24 @@ impl TestRng {
             },
         }
     }
+
+    /// Generate a full-width random `usize`.
+    pub fn next_usize(&mut self) -> usize {
+        // On 64-bit targets, use next_u64(); on 32-bit, use next_u32().
+        #[cfg(target_pointer_width = "64")]
+        {
+            self.next_u64() as usize
+        }
+        #[cfg(target_pointer_width = "32")]
+        {
+            self.next_u32() as usize
+        }
+    }
+
+    /// Generate a full-width random `isize`.
+    pub fn next_isize(&mut self) -> isize {
+        self.next_usize() as isize
+    }    
 }
 
 #[cfg(test)]

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1244,8 +1244,8 @@ mod test {
     fn new_rng_makes_separate_rng() {
         use rand::Rng;
         let mut runner = TestRunner::default();
-        let from_1 = runner.new_rng().gen::<[u8; 16]>();
-        let from_2 = runner.rng().gen::<[u8; 16]>();
+        let from_1 = runner.new_rng().random::<[u8; 16]>();
+        let from_2 = runner.rng().random::<[u8; 16]>();
         assert_ne!(from_1, from_2);
     }
 
@@ -1258,7 +1258,7 @@ mod test {
         let recorder_rng = TestRng::default_rng(RngSeed::Random, RngAlgorithm::Recorder);
         let mut runner =
             TestRunner::new_with_rng(default_config.clone(), recorder_rng);
-        let random_byte_array1 = runner.rng().gen::<[u8; 16]>();
+        let random_byte_array1 = runner.rng().random::<[u8; 16]>();
         let bytes_used = runner.bytes_used();
         assert!(bytes_used.len() >= 16); // could use more bytes for some reason
 
@@ -1267,7 +1267,7 @@ mod test {
             TestRng::from_seed(RngAlgorithm::PassThrough, &bytes_used);
         let mut runner =
             TestRunner::new_with_rng(default_config, passthrough_rng);
-        let random_byte_array2 = runner.rng().gen::<[u8; 16]>();
+        let random_byte_array2 = runner.rng().random::<[u8; 16]>();
 
         // make sure the same value was created
         assert_eq!(random_byte_array1, random_byte_array2);


### PR DESCRIPTION
I took a crack at upgrading the `rand` dependency to 0.9.1 (latest). I also upgraded `rand_*` and added a `rand_core` dependency. I went through the [updating notes](https://rust-random.github.io/book/update-0.9.html) and made the appropriate changes.

My motivation for this PR is that `slatedb` uses `ulid`, `uuid`, and `proptest`. While updating `slatedb` to support seedable and portable RNGs for deterministic simulation testing, I discovered that the recent versions of `uuid` and `ulid` all use `^0.9.0`. This caused a lot of issues; ultimately, I had to drop all library versions way down to maintain compatibility with proptest, which requires ^0.8.0. Cargo seems to enforce compatibility across pre 1.0 minor versions, so it was really throwing a fit.

The upgrade was fairly straightforward except for the changes to `isize` and `usize`. As described in #553, `rand` dropped those because they're not portable. It does not seem they're likely to add them back (https://github.com/rust-random/rand/pull/1598).

I'm assuming that `proptest` wants to keep support for `isize` and `usize` distributions and random numbers. I tried several strategies to maintain these features without the underlying support in `rand`. Ultimately, I settled on adding `next_isize` and `next_usize` to `TestRunner`. I subsequently updated the macros in `num.rs` to call `next_isize` and `next_usize` when `$typ` is an `isize` or `usize`. This required implementing strategies. The results are a little clunky, but I feel they strike the best balance between maintainability and ease of implementation.

If others believe there's a better approach, I'm happy to listen.

Fixes #553