### PR TITLE
Allow prop_assert! with trailing comma

### DIFF
--- a/proptest/src/sugar.rs
+++ b/proptest/src/sugar.rs
@@ -745,7 +745,7 @@ macro_rules! prop_compose {
 /// ```
 #[macro_export]
 macro_rules! prop_assert {
-    ($cond:expr) => {
+    ($cond:expr $(,) ?) => {
         $crate::prop_assert!($cond, concat!("assertion failed: ", stringify!($cond)))
     };
 


### PR DESCRIPTION
i.e. `prop_assert!(false,)` should be valid in an analogous way to `prop_assert_eq!(1, 2,)` being valid.