### PR TITLE
fix for 32 bit processors

### DIFF
--- a/proptest/src/arbitrary/_alloc/alloc.rs
+++ b/proptest/src/arbitrary/_alloc/alloc.rs
@@ -31,7 +31,7 @@ arbitrary!(self::alloc::Layout, SFnPtrMap<(Range<u8>, StrategyFor<usize>), Self>
         let align = 1usize << align_power;
         // TODO: This may only work on 64 bit processors, but previously it was broken
         // even on 64 bit so still an improvement. 63 -> uint size - 1.
-        let max_size = (1usize << 63) - (1 << usize::from(align_power));
+        let max_size = (1usize << (usize::BITS - 1)) - (1 << usize::from(align_power));
         // Not quite a uniform distribution due to clamping,
         // but probably good enough
         self::alloc::Layout::from_size_align(cmp::min(max_size, size), align).unwrap()


### PR DESCRIPTION
based on: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/proptest/debian/patches/fix-arithmetic-overflow.patch?ref_type=heads