### PR TITLE
fix attr-macro eating mutability modifiers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,8 @@ jobs:
         run: cd proptest && cargo test --verbose
       - name: Run macro tests
         run: cd proptest-macro && cargo test --verbose
+      - name: Run macro integration tests
+        run: cargo test --verbose --test attr_macro --features attr-macro
       - name: Build coverage no-default-features
         if: ${{ matrix.build == 'stable' }}
         env:

--- a/proptest-macro/src/property_test/codegen/test_body.rs
+++ b/proptest-macro/src/property_test/codegen/test_body.rs
@@ -30,7 +30,14 @@ pub(super) fn body(
         // shorthand struct initialization.
 
         match pat {
-            Pat::Ident(_) => quote!(#field_name,),
+            // We need to make sure to handle any mutability modifiers here, i.e. if the user wrote
+            // `mut x: i32`, we have to generate `mut x`, not `x: mut x`
+            //
+            // See https://github.com/proptest-rs/proptest/issues/601
+            Pat::Ident(i) => match i.mutability {
+                Some(mutability) => quote!(#mutability #field_name,),
+                None => quote!(#field_name,),
+            },
             _ => quote!(#field_name: #pat,),
         }
     });

--- a/proptest-macro/src/property_test/utils.rs
+++ b/proptest-macro/src/property_test/utils.rs
@@ -1,9 +1,4 @@
-use core::mem::replace;
-
-use syn::{
-    punctuated::Punctuated, AttrStyle, Attribute, Expr, FnArg, ItemFn, Meta,
-    PatType,
-};
+use syn::{AttrStyle, Attribute, Expr, FnArg, ItemFn, Meta, PatType};
 
 /// A parsed argument, with an optional custom strategy
 pub struct Argument {
@@ -15,7 +10,7 @@ pub struct Argument {
 ///
 /// Panics on any invalid function
 pub fn strip_args(mut f: ItemFn) -> (ItemFn, Vec<Argument>) {
-    let args = replace(&mut f.sig.inputs, Punctuated::new());
+    let args = std::mem::take(&mut f.sig.inputs);
     let args = args
         .into_iter()
         .map(|arg| match arg {

--- a/proptest/tests/attr_macro.rs
+++ b/proptest/tests/attr_macro.rs
@@ -1,0 +1,11 @@
+/// Regression for https://github.com/proptest-rs/proptest/issues/601
+#[cfg(feature = "attr-macro")]
+#[proptest::property_test]
+fn attr_macro_does_not_clobber_mutability(mut x: i32, (mut y, _z): (i32, i32)) {
+    let _suppress_unused_warning = x == y;
+
+    x = 0;
+    y = 0;
+    assert_eq!(x, y);
+}
+


### PR DESCRIPTION
Closes #601

Also adds a small regression test, which should also be a good place to put
more rigorous testing for the attr macro.