### PR TITLE
feat(state-machine): persist shrunk transition sequence, not just the seed

### DIFF
--- a/proptest-state-machine/CHANGELOG.md
+++ b/proptest-state-machine/CHANGELOG.md
@@ -12,7 +12,7 @@
   control diffs and merges); shrunk versions of the same failure collapse to one
   minimal case. Drive tests with `prop_state_machine_persisted!`;
   the persistence directory is overridable via the
-  `PROPTEST_STATE_MACHINE_PERSIST_DIR` environment variable, and `PROPTEST_CASES=0`
+  `PROPTEST_EXT_STATE_MACHINE_PERSIST_DIR` environment variable, and `PROPTEST_CASES=0`
   replays the regression without generating new cases. Addresses
   [\#564](https://github.com/proptest-rs/proptest/issues/564).
 

--- a/proptest-state-machine/CHANGELOG.md
+++ b/proptest-state-machine/CHANGELOG.md
@@ -2,18 +2,21 @@
 
 ### New Features
 
-- Added an optional `persistence` feature that persists the *shrunk transition
-  sequence* of a failing state-machine test to disk (as serialized
-  `(initial_state, transitions)`) instead of only the RNG seed. Mirroring how
-  proptest replays seed regressions, the persisted cases are replayed on every
-  run — before generating new cases — with no regeneration and no re-shrinking,
-  and they survive strategy changes. Distinct failures accumulate into a
-  regression file stored as JSON Lines (one case per line, for clean source-
-  control diffs and merges); shrunk versions of the same failure collapse to one
-  minimal case. Drive tests with `prop_state_machine_persisted!`;
-  the persistence directory is overridable via the
-  `PROPTEST_EXT_STATE_MACHINE_PERSIST_DIR` environment variable, and `PROPTEST_CASES=0`
-  replays the regression without generating new cases. Addresses
+- Added an optional `persistence` feature that stores the shrunk transition
+  sequence of a failing state-machine test — serialized
+  `(initial_state, transitions)` — instead of only the RNG seed, so replaying it
+  needs no regeneration and no re-shrinking. Drive tests with
+  `prop_state_machine_persisted!`: it replays every stored case before
+  generating new ones, so `PROPTEST_CASES=0` replays the regressions and
+  generates nothing. Distinct failures accumulate as JSON Lines, one case per
+  line, and shrunk versions of one failure collapse to its minimal case. A
+  stored case that no longer deserializes, or that breaks a precondition the
+  reference model has since gained, is reported with the line to delete rather
+  than replayed. `PROPTEST_EXT_STATE_MACHINE_PERSIST_DIR` overrides the
+  directory (default `proptest-regressions/state-machine` under the crate
+  root); `PROPTEST_DISABLE_FAILURE_PERSISTENCE` switches it off along with
+  proptest's own regression file. `fork` and `timeout` are rejected, because a
+  case running in its own process cannot collapse its shrink chain. Addresses
   [\#564](https://github.com/proptest-rs/proptest/issues/564).
 
 ### Breaking Changes

--- a/proptest-state-machine/CHANGELOG.md
+++ b/proptest-state-machine/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Unreleased
 
+### New Features
+
+- Added an optional `persistence` feature that persists the *shrunk transition
+  sequence* of a failing state-machine test to disk (as serialized
+  `(initial_state, transitions)`) instead of only the RNG seed. Mirroring how
+  proptest replays seed regressions, the persisted cases are replayed on every
+  run — before generating new cases — with no regeneration and no re-shrinking,
+  and they survive strategy changes. Distinct failures accumulate into a
+  regression file stored as JSON Lines (one case per line, for clean source-
+  control diffs and merges); shrunk versions of the same failure collapse to one
+  minimal case. Drive tests with `prop_state_machine_persisted!`;
+  the persistence directory is overridable via the
+  `PROPTEST_STATE_MACHINE_PERSIST_DIR` environment variable, and `PROPTEST_CASES=0`
+  replays the regression without generating new cases. Addresses
+  [\#564](https://github.com/proptest-rs/proptest/issues/564).
+
 ### Breaking Changes
 
 - The minimum supported Rust version has been increased to 1.86.0.

--- a/proptest-state-machine/Cargo.toml
+++ b/proptest-state-machine/Cargo.toml
@@ -20,12 +20,18 @@ default = ["std"]
 # Enables the use of standard-library dependent features
 std = ["proptest/std"]
 
+# Persist the shrunk transition sequence of a failing case to disk (instead of
+# only the RNG seed) and replay it without re-shrinking. Requires `std`.
+persistence = ["std", "dep:serde", "dep:serde_json"]
+
 [dependencies]
 proptest = { version = "1.11.0", path = "../proptest", default-features = true, features = [
     "fork",
     "timeout",
     "bit-set",
 ] }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 message-io = { workspace = true }

--- a/proptest-state-machine/src/lib.rs
+++ b/proptest-state-machine/src/lib.rs
@@ -14,6 +14,19 @@
 
 #[cfg(feature = "persistence")]
 pub mod persistence;
+
+/// The regression file for the named test in the calling crate and source file.
+#[cfg(feature = "persistence")]
+#[macro_export]
+macro_rules! persist_path {
+    ($test_name:expr) => {
+        $crate::persistence::persist_path(
+            ::core::env!("CARGO_MANIFEST_DIR"),
+            ::core::file!(),
+            $test_name,
+        )
+    };
+}
 pub mod strategy;
 pub mod test_runner;
 

--- a/proptest-state-machine/src/lib.rs
+++ b/proptest-state-machine/src/lib.rs
@@ -12,6 +12,8 @@
 //! Please refer to the Proptest Book chapter "State Machine testing" to learn
 //! when and how to use this and how it's made.
 
+#[cfg(feature = "persistence")]
+pub mod persistence;
 pub mod strategy;
 pub mod test_runner;
 

--- a/proptest-state-machine/src/persistence/mod.rs
+++ b/proptest-state-machine/src/persistence/mod.rs
@@ -1,0 +1,136 @@
+//-
+// Copyright 2026 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Persist the *shrunk transition sequence* of a failing state-machine test,
+//! and replay it on every run alongside freshly generated cases.
+//!
+//! Proptest's built-in failure persistence is seed-based: it stores the RNG
+//! seed of the failing run. Replaying a seed regenerates the case from the
+//! strategy and re-runs the shrinking process to reach the minimal counter-
+//! example, and it only reproduces the original failure while the reference
+//! model and transition strategy are unchanged — change either and the seed
+//! maps to a different case.
+//!
+//! For a state-machine test the failing case is itself a concrete, human-
+//! readable value — `(initial_state, Vec<Transition>)` — that, unlike a generic
+//! proptest `Value`, can usually implement [`serde::Serialize`]. This module
+//! persists that value directly. Replaying it needs no regeneration and no
+//! re-shrinking, and it keeps reproducing the same scenario across strategy
+//! changes (as long as the transition type can still be deserialized).
+//!
+//! # Model
+//!
+//! This mirrors how proptest treats seed regressions: the persisted case is
+//! **replayed on every run**, and freshly generated cases run on top to keep
+//! discovering new failures. Concretely, [`crate::prop_state_machine_persisted`]
+//! expands to a test that first calls
+//! [`StateMachineTest::replay_persisted_regressions`] and then runs the normal
+//! generation loop, capturing and persisting any new shrunk failure.
+//!
+//! On failure the shrunk case is written under [`store::PERSIST_DIR_ENV`]
+//! (default `proptest-regressions/state-machine`). Set `PROPTEST_CASES=0` to
+//! replay the persisted regressions without generating anything new.
+//!
+//! # Accumulating distinct regressions
+//!
+//! The persisted file holds a *set* of cases as JSON Lines (one case per line,
+//! under a `#` comment header), like proptest's line-oriented seed-regression
+//! file — so it diffs and merges cleanly in source control and distinct failures
+//! accumulate instead of overwriting each other:
+//!
+//! - Within one failing run, proptest re-runs the body for every shrink
+//!   candidate. Those are shrunk versions of the *same* failure, so they collapse
+//!   to the single minimal case (each write replaces this run's previous one).
+//! - Across runs, a newly discovered minimal case is appended. Because every run
+//!   replays the whole set *before* generating, a new case can only appear once
+//!   all known regressions pass — i.e. it is a genuinely distinct failure, not a
+//!   re-shrink of one already stored. Exact duplicates are de-duplicated.
+//!
+//! Delete a line (or the whole file) to stop replaying that case.
+//!
+//! # Large or not-directly-serializable states
+//!
+//! Persistence requires the reference `State` (and `Transition`) to implement
+//! [`serde::Serialize`] + [`serde::de::DeserializeOwned`]. If your `State` is
+//! large, derived, or holds values that don't serialize as-is, you don't have
+//! to serialize it verbatim: implement serde for it in terms of a small,
+//! reconstructible payload with `#[serde(into = "…", from = "…")]`. Only that
+//! payload is stored, and `From<Payload>` rebuilds the state on replay:
+//!
+//! ```rust,ignore
+//! #[derive(Clone, Serialize, Deserialize)]
+//! #[serde(into = "InitSeed", from = "InitSeed")]
+//! struct State { /* … large / not directly serializable … */ }
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct InitSeed { /* just what's needed to reconstruct the initial state */ }
+//!
+//! impl From<State> for InitSeed { /* capture */ }
+//! impl From<InitSeed> for State { /* rebuild */ }
+//! ```
+//!
+//! `Transition` is handled the same way. This keeps persistence a single,
+//! uniform `serde` requirement rather than a bespoke per-type mechanism.
+//!
+//! # Reusing the store
+//!
+//! The on-disk machinery — JSON Lines I/O, the accumulate/de-dup merge, the
+//! per-run marker, and the panic [`CaptureGuard`](store::CaptureGuard) — lives
+//! in the [`store`] submodule and is generic over any
+//! `Serialize + DeserializeOwned` case type. It does not depend on
+//! `StateMachineTest`, so a project with a richer fixture type can drive it
+//! directly while keeping its own harness. The items here ([`PersistedCase`],
+//! [`load_set`], [`default_persist_path`]) are the thin
+//! `StateMachineTest`-specific layer on top.
+//!
+//! [`StateMachineTest::replay_persisted_regressions`]:
+//!     crate::test_runner::StateMachineTest::replay_persisted_regressions
+
+pub mod store;
+
+use std::path::{Path, PathBuf};
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+pub use store::{reset_run_marker, PERSIST_DIR_ENV};
+
+/// A failing state-machine case, captured as the values that reproduce it.
+///
+/// This is the on-disk case shape (one JSON object per line in the regression
+/// file). `initial_state` and `transitions` are exactly what
+/// [`StateMachineTest::test_sequential`] consumes, so replay is a direct call
+/// with no strategy involvement.
+///
+/// [`StateMachineTest::test_sequential`]:
+///     crate::test_runner::StateMachineTest::test_sequential
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedCase<S, T> {
+    /// The reference model's initial state for the failing run.
+    pub initial_state: S,
+    /// The minimal (shrunk) transition sequence that still fails.
+    pub transitions: Vec<T>,
+}
+
+/// Resolve the default persistence file for a test type `T` (typically the
+/// `StateMachineTest` impl), with a filename derived from its fully-qualified
+/// name. See [`store::default_path`] / [`store::PERSIST_DIR_ENV`].
+pub fn default_persist_path<T: ?Sized>() -> PathBuf {
+    store::default_path(&store::slug(std::any::type_name::<T>()))
+}
+
+/// Load the persisted regression set at `path` as typed cases. Returns an empty
+/// vec if the file does not exist. Used by replay.
+pub fn load_set<S, T>(path: &Path) -> std::io::Result<Vec<PersistedCase<S, T>>>
+where
+    S: Serialize + DeserializeOwned,
+    T: Serialize + DeserializeOwned,
+{
+    store::load(path)
+}

--- a/proptest-state-machine/src/persistence/mod.rs
+++ b/proptest-state-machine/src/persistence/mod.rs
@@ -7,90 +7,41 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Persist the *shrunk transition sequence* of a failing state-machine test,
-//! and replay it on every run alongside freshly generated cases.
+//! Persist the shrunk transition sequence of a failing state-machine test and
+//! replay it on later runs.
 //!
-//! Proptest's built-in failure persistence is seed-based: it stores the RNG
-//! seed of the failing run. Replaying a seed regenerates the case from the
-//! strategy and re-runs the shrinking process to reach the minimal counter-
-//! example, and it only reproduces the original failure while the reference
-//! model and transition strategy are unchanged — change either and the seed
-//! maps to a different case.
+//! The failing case of a state-machine test is a concrete value —
+//! `(initial_state, Vec<Transition>)` — so it can be stored as itself rather
+//! than as the RNG seed proptest persists. Replaying it needs no regeneration
+//! and no re-shrinking.
 //!
-//! For a state-machine test the failing case is itself a concrete, human-
-//! readable value — `(initial_state, Vec<Transition>)` — that, unlike a generic
-//! proptest `Value`, can usually implement [`serde::Serialize`]. This module
-//! persists that value directly. Replaying it needs no regeneration and no
-//! re-shrinking, and it keeps reproducing the same scenario across strategy
-//! changes (as long as the transition type can still be deserialized).
-//!
-//! # Model
-//!
-//! This mirrors how proptest treats seed regressions: the persisted case is
-//! **replayed on every run**, and freshly generated cases run on top to keep
-//! discovering new failures. Concretely, [`crate::prop_state_machine_persisted`]
-//! expands to a test that first calls
-//! [`StateMachineTest::replay_persisted_regressions`] and then runs the normal
-//! generation loop, capturing and persisting any new shrunk failure.
-//!
-//! On failure the shrunk case is written under [`store::PERSIST_DIR_ENV`]
-//! (default `proptest-regressions/state-machine`). Set `PROPTEST_CASES=0` to
-//! replay the persisted regressions without generating anything new.
-//!
-//! # Accumulating distinct regressions
-//!
-//! The persisted file holds a *set* of cases as JSON Lines (one case per line,
-//! under a `#` comment header), like proptest's line-oriented seed-regression
-//! file — so it diffs and merges cleanly in source control and distinct failures
-//! accumulate instead of overwriting each other:
-//!
-//! - Within one failing run, proptest re-runs the body for every shrink
-//!   candidate. Those are shrunk versions of the *same* failure, so they collapse
-//!   to the single minimal case (each write replaces this run's previous one).
-//! - Across runs, a newly discovered minimal case is appended. Because every run
-//!   replays the whole set *before* generating, a new case can only appear once
-//!   all known regressions pass — i.e. it is a genuinely distinct failure, not a
-//!   re-shrink of one already stored. Exact duplicates are de-duplicated.
-//!
-//! Delete a line (or the whole file) to stop replaying that case.
+//! [`crate::prop_state_machine_persisted`] expands to a test that replays every
+//! stored case before generating new ones, and persists any new shrunk failure.
+//! Cases accumulate as JSON Lines under [`store::PERSIST_DIR_ENV`] (default
+//! `proptest-regressions/state-machine`); delete a line to stop replaying it.
+//! `PROPTEST_CASES=0` replays the stored cases and generates nothing.
 //!
 //! # Large or not-directly-serializable states
 //!
-//! Persistence requires the reference `State` (and `Transition`) to implement
-//! [`serde::Serialize`] + [`serde::de::DeserializeOwned`]. If your `State` is
-//! large, derived, or holds values that don't serialize as-is, you don't have
-//! to serialize it verbatim: implement serde for it in terms of a small,
-//! reconstructible payload with `#[serde(into = "…", from = "…")]`. Only that
-//! payload is stored, and `From<Payload>` rebuilds the state on replay:
+//! `State` and `Transition` must implement [`serde::Serialize`] +
+//! [`serde::de::DeserializeOwned`]. A `State` that does not serialize as-is can
+//! store a reconstructible payload instead, which is all that reaches the file:
 //!
 //! ```rust,ignore
 //! #[derive(Clone, Serialize, Deserialize)]
 //! #[serde(into = "InitSeed", from = "InitSeed")]
-//! struct State { /* … large / not directly serializable … */ }
+//! struct State { /* … */ }
 //!
 //! #[derive(Serialize, Deserialize)]
-//! struct InitSeed { /* just what's needed to reconstruct the initial state */ }
+//! struct InitSeed { /* enough to rebuild the initial state */ }
 //!
 //! impl From<State> for InitSeed { /* capture */ }
 //! impl From<InitSeed> for State { /* rebuild */ }
 //! ```
 //!
-//! `Transition` is handled the same way. This keeps persistence a single,
-//! uniform `serde` requirement rather than a bespoke per-type mechanism.
-//!
-//! # Reusing the store
-//!
-//! The on-disk machinery — JSON Lines I/O, the accumulate/de-dup merge, the
-//! per-run marker, and the panic [`CaptureGuard`](store::CaptureGuard) — lives
-//! in the [`store`] submodule and is generic over any
-//! `Serialize + DeserializeOwned` case type. It does not depend on
-//! `StateMachineTest`, so a project with a richer fixture type can drive it
-//! directly while keeping its own harness. The items here ([`PersistedCase`],
-//! [`load_set`], [`default_persist_path`]) are the thin
-//! `StateMachineTest`-specific layer on top.
-//!
-//! [`StateMachineTest::replay_persisted_regressions`]:
-//!     crate::test_runner::StateMachineTest::replay_persisted_regressions
+//! [`store`] holds the same machinery generic over any
+//! `Serialize + DeserializeOwned` case type, for harnesses with a richer
+//! fixture than [`PersistedCase`].
 
 pub mod store;
 

--- a/proptest-state-machine/src/persistence/mod.rs
+++ b/proptest-state-machine/src/persistence/mod.rs
@@ -147,3 +147,30 @@ pub fn assert_same_process(config: &Config) {
          minimal one"
     );
 }
+
+/// Check that `transitions` are still legal under the current reference model,
+/// walking them from `initial_state` exactly as the test will.
+///
+/// A persisted case outlives the model it was recorded against. One that still
+/// deserializes but violates a precondition would otherwise be applied anyway
+/// and report a failure the system under test never had.
+pub fn assert_still_valid<R: crate::strategy::ReferenceStateMachine>(
+    initial_state: &R::State,
+    transitions: &[R::Transition],
+    path: &Path,
+) {
+    let mut state = initial_state.clone();
+    for (ix, transition) in transitions.iter().enumerate() {
+        assert!(
+            R::preconditions(&state, transition),
+            "persisted regression in {} is no longer valid under the current \
+             reference model: transition {} of {} ({:?}) fails its \
+             precondition. Delete it to stop replaying it.",
+            path.display(),
+            ix + 1,
+            transitions.len(),
+            transition
+        );
+        state = R::apply(state, transition);
+    }
+}

--- a/proptest-state-machine/src/persistence/mod.rs
+++ b/proptest-state-machine/src/persistence/mod.rs
@@ -96,6 +96,7 @@ pub mod store;
 
 use std::path::{Path, PathBuf};
 
+use proptest::test_runner::Config;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
@@ -133,4 +134,16 @@ where
     T: Serialize + DeserializeOwned,
 {
     store::load(path)
+}
+
+/// A run's shrink chain collapses to one entry through a process-local marker,
+/// so every case of a run must execute in the same process.
+pub fn assert_same_process(config: &Config) {
+    assert!(
+        !config.fork(),
+        "state-machine persistence supports neither `fork` nor `timeout`: each \
+         case would run in its own process, so every failing shrink candidate \
+         would be stored as a separate regression instead of collapsing to the \
+         minimal one"
+    );
 }

--- a/proptest-state-machine/src/persistence/mod.rs
+++ b/proptest-state-machine/src/persistence/mod.rs
@@ -119,11 +119,15 @@ pub struct PersistedCase<S, T> {
     pub transitions: Vec<T>,
 }
 
-/// Resolve the default persistence file for a test type `T` (typically the
-/// `StateMachineTest` impl), with a filename derived from its fully-qualified
-/// name. See [`store::default_path`] / [`store::PERSIST_DIR_ENV`].
-pub fn default_persist_path<T: ?Sized>() -> PathBuf {
-    store::default_path(&store::slug(std::any::type_name::<T>()))
+/// Resolve the regression file for a test, from the crate's manifest directory,
+/// the source file it is written in, and its name. Use
+/// [`persist_path!`](crate::persist_path) rather than calling this directly.
+pub fn persist_path(
+    manifest_dir: &str,
+    source_file: &str,
+    test_name: &str,
+) -> PathBuf {
+    store::path_for(manifest_dir, source_file, test_name)
 }
 
 /// Load the persisted regression set at `path` as typed cases. Returns an empty

--- a/proptest-state-machine/src/persistence/store.rs
+++ b/proptest-state-machine/src/persistence/store.rs
@@ -45,7 +45,7 @@ use serde_json::Value;
 
 /// Environment variable naming the directory under which regression files are
 /// written. Defaults to `proptest-regressions/state-machine`.
-pub const PERSIST_DIR_ENV: &str = "PROPTEST_STATE_MACHINE_PERSIST_DIR";
+pub const PERSIST_DIR_ENV: &str = "PROPTEST_EXT_STATE_MACHINE_PERSIST_DIR";
 
 /// Resolve the regression file for the test named `test_name` in `source_file`,
 /// under `manifest_dir` (or [`PERSIST_DIR_ENV`] when it is set).

--- a/proptest-state-machine/src/persistence/store.rs
+++ b/proptest-state-machine/src/persistence/store.rs
@@ -1,0 +1,284 @@
+//-
+// Copyright 2026 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A reusable, `StateMachineTest`-agnostic store for proptest regression cases.
+//!
+//! This is the persistence machinery behind
+//! [`prop_state_machine_persisted`](crate::prop_state_machine_persisted),
+//! factored out so it can be driven on its own — e.g. by a project with a
+//! richer case type than [`PersistedCase`](super::PersistedCase). It
+//! accumulates distinct serde-serializable cases as JSON Lines, collapses the
+//! within-run shrink chain to a single minimal case, and captures on panic.
+//! Nothing here refers to `StateMachineTest` or `ReferenceStateMachine`; the
+//! case type is any `C: Serialize + DeserializeOwned`.
+//!
+//! Used like:
+//!
+//! ```rust,ignore
+//! let path = store::default_path(&store::slug(std::any::type_name::<MyTest>()));
+//! store::reset_run_marker(&path);                 // once per run, before generation
+//! for case in store::load::<MyCase>(&path)? { /* replay */ }
+//! let guard = store::CaptureGuard::arm(path, &my_case);
+//! // … run the case; on panic the guard merges `my_case` into the set …
+//! guard.disarm();                                 // call on success
+//! ```
+//!
+//! This layer is `pub` so it can be reused; upstream may choose to narrow its
+//! visibility — it is not part of the `prop_state_machine_persisted!` contract.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+
+/// Environment variable naming the directory under which regression files are
+/// written. Defaults to `proptest-regressions/state-machine`.
+pub const PERSIST_DIR_ENV: &str = "PROPTEST_STATE_MACHINE_PERSIST_DIR";
+
+/// Turn a Rust type path into a filesystem-safe slug
+/// (`foo::Bar<baz::Qux>` -> `foo__Bar_baz__Qux_`).
+pub fn slug(type_name: &str) -> String {
+    type_name
+        .chars()
+        .map(|c| match c {
+            ':' => '_',
+            c if c.is_alphanumeric() || c == '_' || c == '-' => c,
+            _ => '_',
+        })
+        .collect()
+}
+
+/// Resolve the regression file for `slug`. Uses [`PERSIST_DIR_ENV`] if set, else
+/// `proptest-regressions/state-machine`, with a `.jsonl` extension.
+pub fn default_path(slug: &str) -> PathBuf {
+    let dir = env::var_os(PERSIST_DIR_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("proptest-regressions").join("state-machine"));
+    dir.join(format!("{slug}.jsonl"))
+}
+
+/// Header written at the top of a regression file (comment lines, ignored on
+/// read) so the format is self-documenting in source control.
+const FILE_HEADER: &str = "\
+# proptest-state-machine regressions — one JSON case per line (JSON Lines).
+# These cases are replayed before any generated cases on every run. Delete a
+# line (or the whole file) to stop replaying that case. It is recommended to
+# commit this file so everyone running the test benefits from the saved cases.
+";
+
+/// Read the case lines of a regression file as JSON values, skipping blank and
+/// `#`-comment lines. Missing file → empty. A malformed case line is a hard
+/// error (a corrupt regression file should be surfaced, not silently dropped).
+fn read_case_values(path: &Path) -> std::io::Result<Vec<Value>> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| {
+            serde_json::from_str(line).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("malformed regression line in {}: {e}", path.display()),
+                )
+            })
+        })
+        .collect()
+}
+
+/// Write a regression set to `path` as JSON Lines (header + one compact case per
+/// line), creating parent directories as needed.
+fn write_case_values(path: &Path, set: &[Value]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut out = String::from(FILE_HEADER);
+    for case in set {
+        out.push_str(
+            &serde_json::to_string(case)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?,
+        );
+        out.push('\n');
+    }
+    fs::write(path, out)
+}
+
+/// Load the regression set at `path` as typed cases `C`. Empty if the file is
+/// missing; a malformed line is a hard error.
+pub fn load<C: DeserializeOwned>(path: &Path) -> std::io::Result<Vec<C>> {
+    read_case_values(path)?
+        .into_iter()
+        .map(|value| {
+            serde_json::from_value(value)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        })
+        .collect()
+}
+
+thread_local! {
+    /// Per-(test, thread) marker of the case this run last wrote, so successive
+    /// shrink writes replace it rather than accumulate. Cleared at the start of
+    /// each run by [`reset_run_marker`]. Keyed by the persistence file path.
+    static RUN_MARKER: RefCell<HashMap<PathBuf, Value>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Clear this run's "last written case" marker for `path`. Call once per run,
+/// before replaying/generating, so the next failure starts a fresh accumulation
+/// rather than replacing a previous run's case.
+pub fn reset_run_marker(path: &Path) {
+    RUN_MARKER.with(|m| {
+        m.borrow_mut().remove(path);
+    });
+}
+
+/// Merge a newly observed minimal case into a regression set.
+///
+/// `prev_this_run` is the case this run last contributed (if any): it is removed
+/// first, so the within-run shrink chain collapses to a single entry. `new` is
+/// then appended unless an equal case is already present. Pure; the I/O wrapper
+/// is [`record_minimal`].
+fn merge_minimal(
+    mut set: Vec<Value>,
+    prev_this_run: Option<&Value>,
+    new: Value,
+) -> Vec<Value> {
+    if let Some(prev) = prev_this_run {
+        if let Some(ix) = set.iter().position(|c| c == prev) {
+            set.remove(ix);
+        }
+    }
+    if !set.iter().any(|c| *c == new) {
+        set.push(new);
+    }
+    set
+}
+
+/// Load the set at `path`, merge `case` (this run's current minimal) into it,
+/// and write it back. Tracks this run's previous contribution in [`RUN_MARKER`]
+/// so repeated shrink writes collapse to one entry.
+fn record_minimal(path: &Path, case: Value) {
+    let set = match read_case_values(path) {
+        Ok(set) => set,
+        Err(e) => {
+            eprintln!(
+                "[state-machine persistence] could not read existing regressions \
+                 at {} ({e}); not overwriting",
+                path.display()
+            );
+            return;
+        }
+    };
+    let merged = RUN_MARKER.with(|m| {
+        let mut markers = m.borrow_mut();
+        let prev = markers.get(path).cloned();
+        let merged = merge_minimal(set, prev.as_ref(), case.clone());
+        markers.insert(path.to_path_buf(), case);
+        merged
+    });
+    match write_case_values(path, &merged) {
+        Ok(()) => eprintln!(
+            "[state-machine persistence] persisted regression set now holds \
+             {} case(s) at {}",
+            merged.len(),
+            path.display()
+        ),
+        Err(e) => eprintln!(
+            "[state-machine persistence] failed to write {}: {e}",
+            path.display()
+        ),
+    }
+}
+
+/// RAII guard that, if the current test panics while it is alive, merges the
+/// case it holds into the regression set at `path`. Because proptest re-runs the
+/// test body for every candidate during shrinking — ending with the minimal
+/// failing case — successive writes within a run collapse to that minimal,
+/// while distinct failures from earlier runs are preserved.
+///
+/// The case is serialized eagerly when the guard is armed (cheap relative to
+/// running a transition sequence), so the unwind path carries no `Serialize`
+/// bound. On a passing case [`CaptureGuard::disarm`] is called and nothing is
+/// written.
+pub struct CaptureGuard {
+    path: PathBuf,
+    case: Option<Value>,
+}
+
+impl CaptureGuard {
+    /// Arm a guard that merges `case` into the regression set at `path` if the
+    /// test unwinds before [`disarm`](Self::disarm) is called.
+    pub fn arm<C: Serialize>(path: PathBuf, case: &C) -> Self {
+        let value = match serde_json::to_value(case) {
+            Ok(value) => Some(value),
+            Err(e) => {
+                eprintln!(
+                    "[state-machine persistence] case is not serializable, \
+                     will not be persisted on failure: {e}"
+                );
+                None
+            }
+        };
+        Self { path, case: value }
+    }
+
+    /// Mark the case as passing: the guard will not write on drop.
+    pub fn disarm(mut self) {
+        self.case = None;
+    }
+}
+
+impl Drop for CaptureGuard {
+    fn drop(&mut self) {
+        if !std::thread::panicking() {
+            return;
+        }
+        let Some(case) = self.case.take() else {
+            return;
+        };
+        record_minimal(&self.path, case);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Simulate a run's shrink chain: successive writes (prev -> new) collapse to
+    /// the run's single minimal, while a distinct second run accumulates and an
+    /// exact-duplicate third run adds nothing.
+    #[test]
+    fn merge_collapses_within_run_and_accumulates_across_runs() {
+        let a_big = json!({ "transitions": ["A", "A", "A"] });
+        let a_min = json!({ "transitions": ["A"] });
+        let b_min = json!({ "transitions": ["B"] });
+
+        // Run 1: shrink A_big -> A_min (prev removed, not accumulated).
+        let mut set = merge_minimal(Vec::new(), None, a_big.clone());
+        set = merge_minimal(set, Some(&a_big), a_min.clone());
+        assert_eq!(set, vec![a_min.clone()]);
+
+        // Run 2 (fresh marker): a distinct failure B is appended.
+        set = merge_minimal(set, None, b_min.clone());
+        assert_eq!(set, vec![a_min.clone(), b_min.clone()]);
+
+        // Run 3 (fresh marker): re-discovering A_min must not duplicate it.
+        set = merge_minimal(set, None, a_min.clone());
+        assert_eq!(set, vec![a_min, b_min]);
+    }
+}

--- a/proptest-state-machine/src/persistence/store.rs
+++ b/proptest-state-machine/src/persistence/store.rs
@@ -223,17 +223,17 @@ impl CaptureGuard {
     /// Arm a guard that merges `case` into the regression set at `path` if the
     /// test unwinds before [`disarm`](Self::disarm) is called.
     pub fn arm<C: Serialize>(path: PathBuf, case: &C) -> Self {
-        let value = match serde_json::to_value(case) {
-            Ok(value) => Some(value),
-            Err(e) => {
-                eprintln!(
-                    "[state-machine persistence] case is not serializable, \
-                     will not be persisted on failure: {e}"
-                );
-                None
-            }
-        };
-        Self { path, case: value }
+        let value = serde_json::to_value(case).unwrap_or_else(|e| {
+            panic!(
+                "state-machine case cannot be serialized, so it could never \
+                 be persisted to {}: {e}",
+                path.display()
+            )
+        });
+        Self {
+            path,
+            case: Some(value),
+        }
     }
 
     /// Mark the case as passing: the guard will not write on drop.

--- a/proptest-state-machine/src/persistence/store.rs
+++ b/proptest-state-machine/src/persistence/store.rs
@@ -21,7 +21,7 @@
 //! Used like:
 //!
 //! ```rust,ignore
-//! let path = store::default_path(&store::slug(std::any::type_name::<MyTest>()));
+//! let path = store::path_for(env!("CARGO_MANIFEST_DIR"), file!(), "my_test");
 //! store::reset_run_marker(&path);                 // once per run, before generation
 //! for case in store::load::<MyCase>(&path)? { /* replay */ }
 //! let guard = store::CaptureGuard::arm(path, &my_case);
@@ -47,26 +47,32 @@ use serde_json::Value;
 /// written. Defaults to `proptest-regressions/state-machine`.
 pub const PERSIST_DIR_ENV: &str = "PROPTEST_STATE_MACHINE_PERSIST_DIR";
 
-/// Turn a Rust type path into a filesystem-safe slug
-/// (`foo::Bar<baz::Qux>` -> `foo__Bar_baz__Qux_`).
-pub fn slug(type_name: &str) -> String {
-    type_name
-        .chars()
-        .map(|c| match c {
-            ':' => '_',
-            c if c.is_alphanumeric() || c == '_' || c == '-' => c,
-            _ => '_',
-        })
-        .collect()
-}
-
-/// Resolve the regression file for `slug`. Uses [`PERSIST_DIR_ENV`] if set, else
-/// `proptest-regressions/state-machine`, with a `.jsonl` extension.
-pub fn default_path(slug: &str) -> PathBuf {
-    let dir = env::var_os(PERSIST_DIR_ENV)
+/// Resolve the regression file for the test named `test_name` in `source_file`,
+/// under `manifest_dir` (or [`PERSIST_DIR_ENV`] when it is set).
+///
+/// The source path and the test name are the key, so the file keeps its
+/// identity across compilers and stays distinct between test binaries.
+/// Anchoring on the manifest directory keeps the location independent of the
+/// working directory the test binary happens to be started in.
+pub fn path_for(
+    manifest_dir: &str,
+    source_file: &str,
+    test_name: &str,
+) -> PathBuf {
+    let mut path = env::var_os(PERSIST_DIR_ENV)
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("proptest-regressions").join("state-machine"));
-    dir.join(format!("{slug}.jsonl"))
+        .unwrap_or_else(|| {
+            Path::new(manifest_dir)
+                .join("proptest-regressions")
+                .join("state-machine")
+        });
+    let source = Path::new(source_file).with_extension("");
+    path.extend(
+        source
+            .components()
+            .filter(|c| matches!(c, std::path::Component::Normal(_))),
+    );
+    path.join(format!("{test_name}.jsonl"))
 }
 
 /// Header written at the top of a regression file (comment lines, ignored on
@@ -293,6 +299,18 @@ impl Drop for CaptureGuard {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn path_keeps_the_source_layout_and_test_name() {
+        let path = path_for("/crate", "tests/persistence.rs", "my_test");
+        let tail: Vec<_> = path
+            .components()
+            .rev()
+            .take(3)
+            .map(|c| c.as_os_str().to_owned())
+            .collect();
+        assert_eq!(tail, ["my_test.jsonl", "persistence", "tests"]);
+    }
 
     /// Simulate a run's shrink chain: successive writes (prev -> new) collapse to
     /// the run's single minimal, while a distinct second run accumulates and an

--- a/proptest-state-machine/src/persistence/store.rs
+++ b/proptest-state-machine/src/persistence/store.rs
@@ -37,6 +37,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -101,7 +102,8 @@ fn read_case_values(path: &Path) -> std::io::Result<Vec<Value>> {
 }
 
 /// Write a regression set to `path` as JSON Lines (header + one compact case per
-/// line), creating parent directories as needed.
+/// line), creating parent directories as needed. The file is replaced by a
+/// rename, so a concurrent reader never observes a half-written set.
 fn write_case_values(path: &Path, set: &[Value]) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -114,7 +116,11 @@ fn write_case_values(path: &Path, set: &[Value]) -> std::io::Result<()> {
         );
         out.push('\n');
     }
-    fs::write(path, out)
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(format!(".tmp.{}", std::process::id()));
+    let tmp = PathBuf::from(tmp);
+    fs::write(&tmp, out)?;
+    fs::rename(&tmp, path)
 }
 
 /// Load the regression set at `path` as typed cases `C`. Empty if the file is
@@ -168,10 +174,16 @@ fn merge_minimal(
     set
 }
 
+/// Serializes the read-merge-write cycle of [`record_minimal`]. Several test
+/// functions can share one regression file, and libtest runs them on parallel
+/// threads.
+static WRITE_LOCK: Mutex<()> = Mutex::new(());
+
 /// Load the set at `path`, merge `case` (this run's current minimal) into it,
 /// and write it back. Tracks this run's previous contribution in [`RUN_MARKER`]
 /// so repeated shrink writes collapse to one entry.
 fn record_minimal(path: &Path, case: Value) {
+    let _guard = WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let set = match read_case_values(path) {
         Ok(set) => set,
         Err(e) => {

--- a/proptest-state-machine/src/persistence/store.rs
+++ b/proptest-state-machine/src/persistence/store.rs
@@ -78,27 +78,50 @@ const FILE_HEADER: &str = "\
 # commit this file so everyone running the test benefits from the saved cases.
 ";
 
-/// Read the case lines of a regression file as JSON values, skipping blank and
-/// `#`-comment lines. Missing file → empty. A malformed case line is a hard
-/// error (a corrupt regression file should be surfaced, not silently dropped).
-fn read_case_values(path: &Path) -> std::io::Result<Vec<Value>> {
+/// Read the case lines of a regression file as JSON values paired with their
+/// 1-based line number, skipping blank and `#`-comment lines. Missing file →
+/// empty. A malformed case line is a hard error (a corrupt regression file
+/// should be surfaced, not silently dropped).
+fn read_case_lines(path: &Path) -> std::io::Result<Vec<(usize, Value)>> {
     let text = match fs::read_to_string(path) {
         Ok(text) => text,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => return Err(e),
     };
     text.lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with('#'))
-        .map(|line| {
-            serde_json::from_str(line).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("malformed regression line in {}: {e}", path.display()),
-                )
-            })
+        .enumerate()
+        .map(|(ix, line)| (ix + 1, line.trim()))
+        .filter(|(_, line)| !line.is_empty() && !line.starts_with('#'))
+        .map(|(no, line)| {
+            serde_json::from_str(line)
+                .map(|value| (no, value))
+                .map_err(|e| corrupt(path, no, &e.to_string()))
         })
         .collect()
+}
+
+/// Error for a regression line that cannot be turned back into a case. Names
+/// the line and how to get rid of it, because the file is committed and every
+/// run of the test hits this until someone acts on it.
+fn corrupt(path: &Path, line_no: usize, cause: &str) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        format!(
+            "{}:{line_no}: {cause}\n\
+             This regression no longer matches the current model. Delete line \
+             {line_no} to stop replaying it.\n\
+             (A state holding a non-finite float is stored as `null` and reads \
+             back as a type error.)",
+            path.display()
+        ),
+    )
+}
+
+fn read_case_values(path: &Path) -> std::io::Result<Vec<Value>> {
+    Ok(read_case_lines(path)?
+        .into_iter()
+        .map(|(_, value)| value)
+        .collect())
 }
 
 /// Write a regression set to `path` as JSON Lines (header + one compact case per
@@ -126,11 +149,11 @@ fn write_case_values(path: &Path, set: &[Value]) -> std::io::Result<()> {
 /// Load the regression set at `path` as typed cases `C`. Empty if the file is
 /// missing; a malformed line is a hard error.
 pub fn load<C: DeserializeOwned>(path: &Path) -> std::io::Result<Vec<C>> {
-    read_case_values(path)?
+    read_case_lines(path)?
         .into_iter()
-        .map(|value| {
+        .map(|(no, value)| {
             serde_json::from_value(value)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+                .map_err(|e| corrupt(path, no, &e.to_string()))
         })
         .collect()
 }

--- a/proptest-state-machine/src/persistence/store.rs
+++ b/proptest-state-machine/src/persistence/store.rs
@@ -7,18 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! A reusable, `StateMachineTest`-agnostic store for proptest regression cases.
+//! Regression-case store, generic over any `C: Serialize + DeserializeOwned`.
 //!
-//! This is the persistence machinery behind
-//! [`prop_state_machine_persisted`](crate::prop_state_machine_persisted),
-//! factored out so it can be driven on its own — e.g. by a project with a
-//! richer case type than [`PersistedCase`](super::PersistedCase). It
-//! accumulates distinct serde-serializable cases as JSON Lines, collapses the
-//! within-run shrink chain to a single minimal case, and captures on panic.
-//! Nothing here refers to `StateMachineTest` or `ReferenceStateMachine`; the
-//! case type is any `C: Serialize + DeserializeOwned`.
-//!
-//! Used like:
+//! Nothing here refers to `StateMachineTest` or `ReferenceStateMachine`, so a
+//! harness with its own case type can drive it directly:
 //!
 //! ```rust,ignore
 //! let path = store::path_for(env!("CARGO_MANIFEST_DIR"), file!(), "my_test");
@@ -28,9 +20,6 @@
 //! // … run the case; on panic the guard merges `my_case` into the set …
 //! guard.disarm();                                 // call on success
 //! ```
-//!
-//! This layer is `pub` so it can be reused; upstream may choose to narrow its
-//! visibility — it is not part of the `prop_state_machine_persisted!` contract.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -91,7 +80,9 @@ const FILE_HEADER: &str = "\
 fn read_case_lines(path: &Path) -> std::io::Result<Vec<(usize, Value)>> {
     let text = match fs::read_to_string(path) {
         Ok(text) => text,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Vec::new())
+        }
         Err(e) => return Err(e),
     };
     text.lines()
@@ -139,10 +130,9 @@ fn write_case_values(path: &Path, set: &[Value]) -> std::io::Result<()> {
     }
     let mut out = String::from(FILE_HEADER);
     for case in set {
-        out.push_str(
-            &serde_json::to_string(case)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?,
-        );
+        out.push_str(&serde_json::to_string(case).map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+        })?);
         out.push('\n');
     }
     let mut tmp = path.as_os_str().to_owned();
@@ -246,15 +236,14 @@ fn record_minimal(path: &Path, case: Value) {
 }
 
 /// RAII guard that, if the current test panics while it is alive, merges the
-/// case it holds into the regression set at `path`. Because proptest re-runs the
-/// test body for every candidate during shrinking — ending with the minimal
-/// failing case — successive writes within a run collapse to that minimal,
-/// while distinct failures from earlier runs are preserved.
+/// case it holds into the regression set at `path`. Proptest re-runs the test
+/// body for every shrink candidate, so successive writes within a run collapse
+/// to the minimal failing case, while distinct failures from earlier runs are
+/// preserved.
 ///
-/// The case is serialized eagerly when the guard is armed (cheap relative to
-/// running a transition sequence), so the unwind path carries no `Serialize`
-/// bound. On a passing case [`CaptureGuard::disarm`] is called and nothing is
-/// written.
+/// The case is serialized when the guard is armed rather than on drop, so an
+/// unserializable case is a panic on the ordinary path instead of a second
+/// panic during unwind.
 pub struct CaptureGuard {
     path: PathBuf,
     case: Option<Value>,

--- a/proptest-state-machine/src/test_runner.rs
+++ b/proptest-state-machine/src/test_runner.rs
@@ -135,24 +135,14 @@ pub trait StateMachineTest {
         Self::teardown(concrete_state, ref_state)
     }
 
-    /// Like [`test_sequential`](Self::test_sequential), but on failure persists
-    /// the (shrunk) `(initial_state, transitions)` to disk so it can be
-    /// replayed later without regenerating from a seed or re-running the
-    /// shrinking process. See the [`persistence`](crate::persistence) module.
-    ///
-    /// If the case fails, the *last* failing case seen during shrinking — i.e.
-    /// the minimal one — is written to [`persistence::default_persist_path`]
-    /// (the directory is overridable via [`persistence::PERSIST_DIR_ENV`]). A
-    /// passing case writes nothing. The persisted case is replayed by
-    /// [`replay_persisted_regressions`](Self::replay_persisted_regressions);
-    /// [`prop_state_machine_persisted`](crate::prop_state_machine_persisted)
-    /// wires both together.
+    /// Like [`test_sequential`](Self::test_sequential), but a failing case is
+    /// merged into the regression set at `path` — build it with
+    /// [`persist_path!`](crate::persist_path). The minimal shrunk case is the
+    /// one that survives; a passing case writes nothing.
     ///
     /// Requires the reference `State` and `Transition` to implement
-    /// [`serde::Serialize`] + [`serde::de::DeserializeOwned`].
-    ///
-    /// [`persistence::PERSIST_DIR_ENV`]: crate::persistence::PERSIST_DIR_ENV
-    /// [`persistence::default_persist_path`]: crate::persistence::default_persist_path
+    /// [`serde::Serialize`] + [`serde::de::DeserializeOwned`]. Does nothing
+    /// beyond `test_sequential` when failure persistence is disabled.
     #[cfg(feature = "persistence")]
     fn test_sequential_persisted(
         config: Config,
@@ -173,31 +163,22 @@ pub trait StateMachineTest {
             return;
         }
         crate::persistence::assert_same_process(&config);
-        // Arm a guard that merges the case on unwind. proptest re-runs this body
-        // for every shrink candidate, so the final (minimal) failing case is
-        // the last write within the run and wins.
         let case = crate::persistence::PersistedCase {
             initial_state: ref_state.clone(),
             transitions: transitions.clone(),
         };
-        let guard =
-            crate::persistence::store::CaptureGuard::arm(path, &case);
+        let guard = crate::persistence::store::CaptureGuard::arm(path, &case);
         Self::test_sequential(config, ref_state, transitions, seen_counter);
-        // Passing case: do not persist.
         guard.disarm();
     }
 
-    /// Replay every persisted regression for this test, in order, by running
-    /// each through [`test_sequential`](Self::test_sequential). Returns the
-    /// number of cases replayed.
+    /// Replay every regression stored at `path`, in order, through
+    /// [`test_sequential`](Self::test_sequential). Returns how many ran.
     ///
-    /// This is meant to run on *every* test invocation — before generating new
-    /// cases — mirroring how proptest replays its seed regressions. A persisted
-    /// case that still fails panics here, with the failure attributed to the
-    /// stored regression rather than to a freshly generated case.
-    /// [`prop_state_machine_persisted`](crate::prop_state_machine_persisted)
-    /// calls this for you. It also resets the per-run accumulation marker, so a
-    /// failure generated afterwards starts a fresh entry in the regression set.
+    /// Call this before generating new cases; a stored case that still fails
+    /// panics here, so the failure is reported as the regression it is. Also
+    /// resets the per-run accumulation marker, so a failure generated
+    /// afterwards starts a fresh entry in the set.
     ///
     /// Requires the reference `State` and `Transition` to implement
     /// [`serde::Serialize`] + [`serde::de::DeserializeOwned`].

--- a/proptest-state-machine/src/test_runner.rs
+++ b/proptest-state-machine/src/test_runner.rs
@@ -134,6 +134,109 @@ pub trait StateMachineTest {
 
         Self::teardown(concrete_state, ref_state)
     }
+
+    /// Like [`test_sequential`](Self::test_sequential), but on failure persists
+    /// the (shrunk) `(initial_state, transitions)` to disk so it can be
+    /// replayed later without regenerating from a seed or re-running the
+    /// shrinking process. See the [`persistence`](crate::persistence) module.
+    ///
+    /// If the case fails, the *last* failing case seen during shrinking — i.e.
+    /// the minimal one — is written to [`persistence::default_persist_path`]
+    /// (the directory is overridable via [`persistence::PERSIST_DIR_ENV`]). A
+    /// passing case writes nothing. The persisted case is replayed by
+    /// [`replay_persisted_regressions`](Self::replay_persisted_regressions);
+    /// [`prop_state_machine_persisted`](crate::prop_state_machine_persisted)
+    /// wires both together.
+    ///
+    /// Requires the reference `State` and `Transition` to implement
+    /// [`serde::Serialize`] + [`serde::de::DeserializeOwned`].
+    ///
+    /// [`persistence::PERSIST_DIR_ENV`]: crate::persistence::PERSIST_DIR_ENV
+    /// [`persistence::default_persist_path`]: crate::persistence::default_persist_path
+    #[cfg(feature = "persistence")]
+    fn test_sequential_persisted(
+        config: Config,
+        ref_state: <Self::Reference as ReferenceStateMachine>::State,
+        transitions: Vec<
+            <Self::Reference as ReferenceStateMachine>::Transition,
+        >,
+        seen_counter: Option<Arc<AtomicUsize>>,
+    ) where
+        <Self::Reference as ReferenceStateMachine>::State:
+            serde::Serialize + serde::de::DeserializeOwned,
+        <Self::Reference as ReferenceStateMachine>::Transition:
+            serde::Serialize + serde::de::DeserializeOwned,
+    {
+        // Arm a guard that merges the case on unwind. proptest re-runs this body
+        // for every shrink candidate, so the final (minimal) failing case is
+        // the last write within the run and wins.
+        let case = crate::persistence::PersistedCase {
+            initial_state: ref_state.clone(),
+            transitions: transitions.clone(),
+        };
+        let guard = crate::persistence::store::CaptureGuard::arm(
+            crate::persistence::default_persist_path::<Self>(),
+            &case,
+        );
+        Self::test_sequential(config, ref_state, transitions, seen_counter);
+        // Passing case: do not persist.
+        guard.disarm();
+    }
+
+    /// Replay every persisted regression for this test, in order, by running
+    /// each through [`test_sequential`](Self::test_sequential). Returns the
+    /// number of cases replayed.
+    ///
+    /// This is meant to run on *every* test invocation — before generating new
+    /// cases — mirroring how proptest replays its seed regressions. A persisted
+    /// case that still fails panics here, with the failure attributed to the
+    /// stored regression rather than to a freshly generated case.
+    /// [`prop_state_machine_persisted`](crate::prop_state_machine_persisted)
+    /// calls this for you. It also resets the per-run accumulation marker, so a
+    /// failure generated afterwards starts a fresh entry in the regression set.
+    ///
+    /// Requires the reference `State` and `Transition` to implement
+    /// [`serde::Serialize`] + [`serde::de::DeserializeOwned`].
+    #[cfg(feature = "persistence")]
+    fn replay_persisted_regressions(config: Config) -> usize
+    where
+        <Self::Reference as ReferenceStateMachine>::State:
+            serde::Serialize + serde::de::DeserializeOwned,
+        <Self::Reference as ReferenceStateMachine>::Transition:
+            serde::Serialize + serde::de::DeserializeOwned,
+    {
+        let path = crate::persistence::default_persist_path::<Self>();
+        crate::persistence::reset_run_marker(&path);
+        let set: Vec<
+            crate::persistence::PersistedCase<
+                <Self::Reference as ReferenceStateMachine>::State,
+                <Self::Reference as ReferenceStateMachine>::Transition,
+            >,
+        > = crate::persistence::load_set(&path).unwrap_or_else(|e| {
+            panic!(
+                "failed to load persisted state-machine regressions from {}: {e}",
+                path.display()
+            )
+        });
+        for (ix, case) in set.iter().enumerate() {
+            #[cfg(feature = "std")]
+            eprintln!(
+                "[state-machine persistence] replaying persisted regression \
+                 {}/{} ({} transitions) from {}",
+                ix + 1,
+                set.len(),
+                case.transitions.len(),
+                path.display()
+            );
+            Self::test_sequential(
+                config.clone(),
+                case.initial_state.clone(),
+                case.transitions.clone(),
+                None,
+            );
+        }
+        set.len()
+    }
 }
 
 /// This macro helps to turn a state machine test implementation into a runnable
@@ -213,6 +316,81 @@ macro_rules! prop_state_machine {
             }
         )*
     };
+}
+
+/// Like [`prop_state_machine`], but drives each test through
+/// [`StateMachineTest::test_sequential_persisted`], so a failing case is
+/// persisted to disk and accumulated into a regression set instead of only its
+/// seed. Requires the `persistence` feature and that the reference
+/// `State` / `Transition` implement [`serde::Serialize`] +
+/// [`serde::de::DeserializeOwned`].
+///
+/// Each generated test additionally replays the persisted regression (if any)
+/// once per run, before generating new cases — see
+/// [`StateMachineTest::replay_persisted_regressions`]. Run with
+/// `PROPTEST_CASES=0` to replay the regression without generating anything new.
+#[cfg(feature = "persistence")]
+#[macro_export]
+macro_rules! prop_state_machine_persisted {
+    // With proptest config annotation
+    (#![proptest_config($config:expr)]
+    $(
+        $(#[$meta:meta])*
+        fn $test_name:ident(sequential $size:expr => $test:ident $(< $( $ty_param:tt ),+ >)?);
+    )*) => {
+        $(
+            ::proptest::proptest! {
+                #![proptest_config($config)]
+                $(#[$meta])*
+                fn $test_name(
+                    (initial_state, transitions, seen_counter) in <<$test $(< $( $ty_param ),+ >)? as $crate::StateMachineTest>::Reference as $crate::ReferenceStateMachine>::sequential_strategy($size)
+                ) {
+                    let config = $config.__sugar_to_owned();
+                    $crate::__replay_persisted_once!($test $(< $( $ty_param ),+ >)?, config);
+                    <$test $(::< $( $ty_param ),+ >)? as $crate::StateMachineTest>::test_sequential_persisted(config, initial_state, transitions, seen_counter)
+                }
+            }
+        )*
+    };
+
+    // Without proptest config annotation
+    ($(
+        $(#[$meta:meta])*
+        fn $test_name:ident(sequential $size:expr => $test:ident $(< $( $ty_param:tt ),+ >)?);
+    )*) => {
+        $(
+            ::proptest::proptest! {
+                $(#[$meta])*
+                fn $test_name(
+                    (initial_state, transitions, seen_counter) in <<$test $(< $( $ty_param ),+ >)? as $crate::StateMachineTest>::Reference as $crate::ReferenceStateMachine>::sequential_strategy($size)
+                ) {
+                    let config = ::proptest::test_runner::Config::default();
+                    $crate::__replay_persisted_once!($test $(< $( $ty_param ),+ >)?, config);
+                    <$test $(::< $( $ty_param ),+ >)? as $crate::StateMachineTest>::test_sequential_persisted(
+                        config, initial_state, transitions, seen_counter)
+                }
+            }
+        )*
+    };
+}
+
+/// Replay the persisted regression for a test exactly once per process run.
+///
+/// The flag is set *before* the replay runs, so a regression that still fails
+/// (and panics) never poisons the flag and never re-runs while proptest shrinks
+/// the surrounding generated case. Internal helper for
+/// [`prop_state_machine_persisted`]; not part of the public API.
+#[cfg(feature = "persistence")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __replay_persisted_once {
+    ($test:ident $(< $( $ty_param:tt ),+ >)?, $config:ident) => {{
+        static REPLAYED: ::std::sync::atomic::AtomicBool =
+            ::std::sync::atomic::AtomicBool::new(false);
+        if !REPLAYED.swap(true, ::std::sync::atomic::Ordering::SeqCst) {
+            <$test $(::< $( $ty_param ),+ >)? as $crate::StateMachineTest>::replay_persisted_regressions($config.clone());
+        }
+    }};
 }
 
 #[cfg(test)]

--- a/proptest-state-machine/src/test_runner.rs
+++ b/proptest-state-machine/src/test_runner.rs
@@ -219,7 +219,6 @@ pub trait StateMachineTest {
             )
         });
         for (ix, case) in set.iter().enumerate() {
-            #[cfg(feature = "std")]
             eprintln!(
                 "[state-machine persistence] replaying persisted regression \
                  {}/{} ({} transitions) from {}",

--- a/proptest-state-machine/src/test_runner.rs
+++ b/proptest-state-machine/src/test_runner.rs
@@ -338,10 +338,10 @@ macro_rules! prop_state_machine {
 /// `State` / `Transition` implement [`serde::Serialize`] +
 /// [`serde::de::DeserializeOwned`].
 ///
-/// Each generated test additionally replays the persisted regression (if any)
-/// once per run, before generating new cases — see
-/// [`StateMachineTest::replay_persisted_regressions`]. Run with
-/// `PROPTEST_CASES=0` to replay the regression without generating anything new.
+/// Each generated test replays the stored regressions once, before proptest
+/// generates anything — see
+/// [`StateMachineTest::replay_persisted_regressions`]. `PROPTEST_CASES=0`
+/// therefore replays the regressions and generates nothing new.
 #[cfg(feature = "persistence")]
 #[macro_export]
 macro_rules! prop_state_machine_persisted {
@@ -352,16 +352,10 @@ macro_rules! prop_state_machine_persisted {
         fn $test_name:ident(sequential $size:expr => $test:ident $(< $( $ty_param:tt ),+ >)?);
     )*) => {
         $(
-            ::proptest::proptest! {
-                #![proptest_config($config)]
-                $(#[$meta])*
-                fn $test_name(
-                    (initial_state, transitions, seen_counter) in <<$test $(< $( $ty_param ),+ >)? as $crate::StateMachineTest>::Reference as $crate::ReferenceStateMachine>::sequential_strategy($size)
-                ) {
-                    let config = $config.__sugar_to_owned();
-                    $crate::__replay_persisted_once!($test $(< $( $ty_param ),+ >)?, config);
-                    <$test $(::< $( $ty_param ),+ >)? as $crate::StateMachineTest>::test_sequential_persisted(config, initial_state, transitions, seen_counter)
-                }
+            $(#[$meta])*
+            fn $test_name() {
+                $crate::__run_persisted!(
+                    $config, $test $(< $( $ty_param ),+ >)?, $size, $test_name);
             }
         )*
     };
@@ -372,37 +366,40 @@ macro_rules! prop_state_machine_persisted {
         fn $test_name:ident(sequential $size:expr => $test:ident $(< $( $ty_param:tt ),+ >)?);
     )*) => {
         $(
-            ::proptest::proptest! {
-                $(#[$meta])*
-                fn $test_name(
-                    (initial_state, transitions, seen_counter) in <<$test $(< $( $ty_param ),+ >)? as $crate::StateMachineTest>::Reference as $crate::ReferenceStateMachine>::sequential_strategy($size)
-                ) {
-                    let config = ::proptest::test_runner::Config::default();
-                    $crate::__replay_persisted_once!($test $(< $( $ty_param ),+ >)?, config);
-                    <$test $(::< $( $ty_param ),+ >)? as $crate::StateMachineTest>::test_sequential_persisted(
-                        config, initial_state, transitions, seen_counter)
-                }
+            $(#[$meta])*
+            fn $test_name() {
+                $crate::__run_persisted!(
+                    ::proptest::test_runner::Config::default(),
+                    $test $(< $( $ty_param ),+ >)?, $size, $test_name);
             }
         )*
     };
 }
 
-/// Replay the persisted regression for a test exactly once per process run.
+/// Replay the stored regressions, then run the generation loop.
 ///
-/// The flag is set *before* the replay runs, so a regression that still fails
-/// (and panics) never poisons the flag and never re-runs while proptest shrinks
-/// the surrounding generated case. Internal helper for
+/// Replay sits outside the generated-case closure: a regression that still
+/// fails is reported as itself, and proptest never sees a case that fails once
+/// and then passes every time it is shrunk. Internal helper for
 /// [`prop_state_machine_persisted`]; not part of the public API.
 #[cfg(feature = "persistence")]
 #[macro_export]
 #[doc(hidden)]
-macro_rules! __replay_persisted_once {
-    ($test:ident $(< $( $ty_param:tt ),+ >)?, $config:ident) => {{
-        static REPLAYED: ::std::sync::atomic::AtomicBool =
-            ::std::sync::atomic::AtomicBool::new(false);
-        if !REPLAYED.swap(true, ::std::sync::atomic::Ordering::SeqCst) {
-            <$test $(::< $( $ty_param ),+ >)? as $crate::StateMachineTest>::replay_persisted_regressions($config.clone());
-        }
+macro_rules! __run_persisted {
+    ($config:expr, $test:ident $(< $( $ty_param:tt ),+ >)?, $size:expr, $test_name:ident) => {{
+        let mut config = $config.__sugar_to_owned();
+        config.test_name = ::core::option::Option::Some(::core::concat!(
+            ::core::module_path!(), "::", ::core::stringify!($test_name)));
+        <$test $(::< $( $ty_param ),+ >)? as $crate::StateMachineTest>::replay_persisted_regressions(
+            config.clone());
+        ::proptest::proptest!(config.clone(), |(
+            (initial_state, transitions, seen_counter) in
+                <<$test $(< $( $ty_param ),+ >)? as $crate::StateMachineTest>::Reference
+                    as $crate::ReferenceStateMachine>::sequential_strategy($size)
+        )| {
+            <$test $(::< $( $ty_param ),+ >)? as $crate::StateMachineTest>::test_sequential_persisted(
+                config.clone(), initial_state, transitions, seen_counter)
+        });
     }};
 }
 

--- a/proptest-state-machine/src/test_runner.rs
+++ b/proptest-state-machine/src/test_runner.rs
@@ -171,6 +171,7 @@ pub trait StateMachineTest {
             Self::test_sequential(config, ref_state, transitions, seen_counter);
             return;
         }
+        crate::persistence::assert_same_process(&config);
         // Arm a guard that merges the case on unwind. proptest re-runs this body
         // for every shrink candidate, so the final (minimal) failing case is
         // the last write within the run and wins.
@@ -212,6 +213,7 @@ pub trait StateMachineTest {
         if config.failure_persistence.is_none() {
             return 0;
         }
+        crate::persistence::assert_same_process(&config);
         let path = crate::persistence::default_persist_path::<Self>();
         crate::persistence::reset_run_marker(&path);
         let set: Vec<

--- a/proptest-state-machine/src/test_runner.rs
+++ b/proptest-state-machine/src/test_runner.rs
@@ -167,6 +167,10 @@ pub trait StateMachineTest {
         <Self::Reference as ReferenceStateMachine>::Transition:
             serde::Serialize + serde::de::DeserializeOwned,
     {
+        if config.failure_persistence.is_none() {
+            Self::test_sequential(config, ref_state, transitions, seen_counter);
+            return;
+        }
         // Arm a guard that merges the case on unwind. proptest re-runs this body
         // for every shrink candidate, so the final (minimal) failing case is
         // the last write within the run and wins.
@@ -205,6 +209,9 @@ pub trait StateMachineTest {
         <Self::Reference as ReferenceStateMachine>::Transition:
             serde::Serialize + serde::de::DeserializeOwned,
     {
+        if config.failure_persistence.is_none() {
+            return 0;
+        }
         let path = crate::persistence::default_persist_path::<Self>();
         crate::persistence::reset_run_marker(&path);
         let set: Vec<

--- a/proptest-state-machine/src/test_runner.rs
+++ b/proptest-state-machine/src/test_runner.rs
@@ -156,6 +156,7 @@ pub trait StateMachineTest {
     #[cfg(feature = "persistence")]
     fn test_sequential_persisted(
         config: Config,
+        path: std::path::PathBuf,
         ref_state: <Self::Reference as ReferenceStateMachine>::State,
         transitions: Vec<
             <Self::Reference as ReferenceStateMachine>::Transition,
@@ -179,10 +180,8 @@ pub trait StateMachineTest {
             initial_state: ref_state.clone(),
             transitions: transitions.clone(),
         };
-        let guard = crate::persistence::store::CaptureGuard::arm(
-            crate::persistence::default_persist_path::<Self>(),
-            &case,
-        );
+        let guard =
+            crate::persistence::store::CaptureGuard::arm(path, &case);
         Self::test_sequential(config, ref_state, transitions, seen_counter);
         // Passing case: do not persist.
         guard.disarm();
@@ -203,7 +202,10 @@ pub trait StateMachineTest {
     /// Requires the reference `State` and `Transition` to implement
     /// [`serde::Serialize`] + [`serde::de::DeserializeOwned`].
     #[cfg(feature = "persistence")]
-    fn replay_persisted_regressions(config: Config) -> usize
+    fn replay_persisted_regressions(
+        config: Config,
+        path: &std::path::Path,
+    ) -> usize
     where
         <Self::Reference as ReferenceStateMachine>::State:
             serde::Serialize + serde::de::DeserializeOwned,
@@ -214,14 +216,13 @@ pub trait StateMachineTest {
             return 0;
         }
         crate::persistence::assert_same_process(&config);
-        let path = crate::persistence::default_persist_path::<Self>();
-        crate::persistence::reset_run_marker(&path);
+        crate::persistence::reset_run_marker(path);
         let set: Vec<
             crate::persistence::PersistedCase<
                 <Self::Reference as ReferenceStateMachine>::State,
                 <Self::Reference as ReferenceStateMachine>::Transition,
             >,
-        > = crate::persistence::load_set(&path).unwrap_or_else(|e| {
+        > = crate::persistence::load_set(path).unwrap_or_else(|e| {
             panic!(
                 "failed to load persisted state-machine regressions from {}: {e}",
                 path.display()
@@ -239,7 +240,7 @@ pub trait StateMachineTest {
             crate::persistence::assert_still_valid::<Self::Reference>(
                 &case.initial_state,
                 &case.transitions,
-                &path,
+                path,
             );
             Self::test_sequential(
                 config.clone(),
@@ -390,15 +391,16 @@ macro_rules! __run_persisted {
         let mut config = $config.__sugar_to_owned();
         config.test_name = ::core::option::Option::Some(::core::concat!(
             ::core::module_path!(), "::", ::core::stringify!($test_name)));
+        let path = $crate::persist_path!(::core::stringify!($test_name));
         <$test $(::< $( $ty_param ),+ >)? as $crate::StateMachineTest>::replay_persisted_regressions(
-            config.clone());
+            config.clone(), &path);
         ::proptest::proptest!(config.clone(), |(
             (initial_state, transitions, seen_counter) in
                 <<$test $(< $( $ty_param ),+ >)? as $crate::StateMachineTest>::Reference
                     as $crate::ReferenceStateMachine>::sequential_strategy($size)
         )| {
             <$test $(::< $( $ty_param ),+ >)? as $crate::StateMachineTest>::test_sequential_persisted(
-                config.clone(), initial_state, transitions, seen_counter)
+                config.clone(), path.clone(), initial_state, transitions, seen_counter)
         });
     }};
 }

--- a/proptest-state-machine/src/test_runner.rs
+++ b/proptest-state-machine/src/test_runner.rs
@@ -236,6 +236,11 @@ pub trait StateMachineTest {
                 case.transitions.len(),
                 path.display()
             );
+            crate::persistence::assert_still_valid::<Self::Reference>(
+                &case.initial_state,
+                &case.transitions,
+                &path,
+            );
             Self::test_sequential(
                 config.clone(),
                 case.initial_state.clone(),

--- a/proptest-state-machine/tests/persistence.rs
+++ b/proptest-state-machine/tests/persistence.rs
@@ -112,8 +112,14 @@ fn persists_shrunk_case_and_replays_it() {
     // SAFETY: single test, no other test touches these vars; std edition 2021.
     std::env::set_var(PERSIST_DIR_ENV, &tmp);
 
-    let config = Config {
+    // The runner config keeps proptest's own seed file out of the way; the
+    // config handed to the persisted runs governs state-machine persistence.
+    let runner_config = Config {
         failure_persistence: None,
+        cases: 256,
+        ..Config::default()
+    };
+    let config = Config {
         cases: 256,
         ..Config::default()
     };
@@ -121,7 +127,7 @@ fn persists_shrunk_case_and_replays_it() {
 
     // --- Phase 1: capture ---------------------------------------------------
     let result = quiet_panic(|| {
-        let mut runner = TestRunner::new(config.clone());
+        let mut runner = TestRunner::new(runner_config.clone());
         runner.run(
             &RefCounter::sequential_strategy(1..20usize),
             |(init, transitions, counter)| {
@@ -326,8 +332,12 @@ fn accumulates_distinct_regressions() {
     ));
     std::env::set_var(PERSIST_DIR_ENV, &tmp);
     let path = default_persist_path::<TwoBugs>();
-    let config = Config {
+    let runner_config = Config {
         failure_persistence: None,
+        cases: 512,
+        ..Config::default()
+    };
+    let config = Config {
         cases: 512,
         ..Config::default()
     };
@@ -338,7 +348,7 @@ fn accumulates_distinct_regressions() {
         proptest_state_machine::persistence::reset_run_marker(&path);
         BUG_MODE.with(|m| m.set(mode));
         let _ = quiet_panic(|| {
-            let mut runner = TestRunner::new(config.clone());
+            let mut runner = TestRunner::new(runner_config.clone());
             runner.run(
                 &AbRef::sequential_strategy(1..20usize),
                 |(init, transitions, counter)| {
@@ -402,4 +412,50 @@ fn corrupt_regression_line_names_itself() {
 
     assert!(err.contains(":3:"), "error must name the offending line: {err}");
     assert!(err.contains("Delete line 3"), "error must say how to clear it: {err}");
+}
+
+/// `failure_persistence: None` — what `PROPTEST_DISABLE_FAILURE_PERSISTENCE`
+/// sets — suppresses the state-machine regression file too.
+#[test]
+fn disabled_failure_persistence_writes_nothing() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = std::env::temp_dir().join(format!(
+        "psm-persistence-off-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::env::set_var(PERSIST_DIR_ENV, &tmp);
+    let path = default_persist_path::<BuggyCounter>();
+
+    let config = Config {
+        failure_persistence: None,
+        cases: 256,
+        ..Config::default()
+    };
+    let result = quiet_panic(|| {
+        let mut runner = TestRunner::new(config.clone());
+        runner.run(
+            &RefCounter::sequential_strategy(1..20usize),
+            |(init, transitions, counter)| {
+                BuggyCounter::test_sequential_persisted(
+                    config.clone(),
+                    init,
+                    transitions,
+                    counter,
+                );
+                Ok(())
+            },
+        )
+    });
+    let replayed = BuggyCounter::replay_persisted_regressions(config.clone());
+    std::env::remove_var(PERSIST_DIR_ENV);
+    let exists = path.exists();
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(matches!(result, Err(TestError::Fail(..))), "the machine still fails");
+    assert!(!exists, "no regression file when failure persistence is off");
+    assert_eq!(replayed, 0, "nothing is replayed when failure persistence is off");
 }

--- a/proptest-state-machine/tests/persistence.rs
+++ b/proptest-state-machine/tests/persistence.rs
@@ -459,3 +459,13 @@ fn disabled_failure_persistence_writes_nothing() {
     assert!(!exists, "no regression file when failure persistence is off");
     assert_eq!(replayed, 0, "nothing is replayed when failure persistence is off");
 }
+
+#[test]
+#[should_panic(expected = "neither `fork` nor `timeout`")]
+fn fork_is_rejected() {
+    let config = Config {
+        fork: true,
+        ..Config::default()
+    };
+    BuggyCounter::replay_persisted_regressions(config);
+}

--- a/proptest-state-machine/tests/persistence.rs
+++ b/proptest-state-machine/tests/persistence.rs
@@ -7,10 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! End-to-end test for the `persistence` feature: a deliberately buggy state
-//! machine must (1) persist its shrunk failing transition sequence on failure,
-//! and (2) reproduce the failure when that file is replayed — without
-//! regeneration or re-shrinking.
+//! End-to-end tests for the `persistence` feature.
 
 #![cfg(feature = "persistence")]
 
@@ -25,21 +22,19 @@ static ENV_LOCK: Mutex<()> = Mutex::new(());
 use proptest::prelude::*;
 use proptest::strategy::{Just, ValueTree};
 use proptest::test_runner::{Config, TestError, TestRunner};
+use proptest_state_machine::persist_path;
 use proptest_state_machine::persistence::{
     load_set, PersistedCase, PERSIST_DIR_ENV,
 };
-use proptest_state_machine::persist_path;
 use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
 
 use serde::{Deserialize, Serialize};
 
-/// The only transition: increment the counter.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 enum Op {
     Inc,
 }
 
-/// Reference model: an honest counter.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct RefCounter {
     value: u32,
@@ -57,15 +52,17 @@ impl ReferenceStateMachine for RefCounter {
         Just(Op::Inc).boxed()
     }
 
-    fn apply(mut state: Self::State, _transition: &Self::Transition) -> Self::State {
+    fn apply(
+        mut state: Self::State,
+        _transition: &Self::Transition,
+    ) -> Self::State {
         state.value += 1;
         state
     }
 }
 
-/// SUT with a bug: the concrete counter saturates at 3, so once the reference
-/// reaches 4 the post-condition `sut == ref` fails. The minimal failing case is
-/// therefore exactly four `Inc`s.
+/// The concrete counter saturates at 3, so the minimal failing case is four
+/// `Inc`s.
 struct BuggyCounter;
 
 impl StateMachineTest for BuggyCounter {
@@ -77,7 +74,6 @@ impl StateMachineTest for BuggyCounter {
     }
 
     fn apply(state: u32, _ref_state: &RefCounter, _transition: Op) -> u32 {
-        // BUG: caps at 3 instead of counting forever.
         (state + 1).min(3)
     }
 
@@ -100,8 +96,6 @@ fn quiet_panic<R>(f: impl FnOnce() -> R) -> R {
 #[test]
 fn persists_shrunk_case_and_replays_it() {
     let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    // Isolate persistence to a unique temp dir and keep proptest's own seed
-    // regression file out of the picture.
     let tmp = std::env::temp_dir().join(format!(
         "psm-persistence-{}-{}",
         std::process::id(),
@@ -110,7 +104,6 @@ fn persists_shrunk_case_and_replays_it() {
             .unwrap()
             .as_nanos()
     ));
-    // SAFETY: single test, no other test touches these vars; std edition 2021.
     std::env::set_var(PERSIST_DIR_ENV, &tmp);
 
     // The runner config keeps proptest's own seed file out of the way; the
@@ -126,7 +119,6 @@ fn persists_shrunk_case_and_replays_it() {
     };
     let path: PathBuf = persist_path!("persists_shrunk_case_and_replays_it");
 
-    // --- Phase 1: capture ---------------------------------------------------
     let result = quiet_panic(|| {
         let mut runner = TestRunner::new(runner_config.clone());
         runner.run(
@@ -158,9 +150,11 @@ fn persists_shrunk_case_and_replays_it() {
     );
     assert_eq!(set[0].initial_state.value, 0);
 
-    // On-disk format is JSON Lines: a `#` header plus exactly one case line.
     let raw = std::fs::read_to_string(&path).unwrap();
-    assert!(raw.starts_with('#'), "file should begin with a comment header");
+    assert!(
+        raw.starts_with('#'),
+        "file should begin with a comment header"
+    );
     let case_lines: Vec<&str> = raw
         .lines()
         .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with('#'))
@@ -169,10 +163,6 @@ fn persists_shrunk_case_and_replays_it() {
     serde_json::from_str::<serde_json::Value>(case_lines[0])
         .expect("each case line is standalone JSON");
 
-    // --- Phase 2: replay ----------------------------------------------------
-    // `replay_persisted_regressions` loads the file written above and re-runs
-    // it; since the bug is still present it must reproduce the failure. This is
-    // the call `prop_state_machine_persisted!` makes once per run.
     let replayed = quiet_panic(|| {
         panic::catch_unwind(panic::AssertUnwindSafe(|| {
             BuggyCounter::replay_persisted_regressions(config.clone(), &path)
@@ -187,7 +177,6 @@ fn persists_shrunk_case_and_replays_it() {
     );
 }
 
-/// A passing machine must not write a persistence file.
 #[test]
 fn passing_case_writes_nothing() {
     let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -217,7 +206,6 @@ fn passing_case_writes_nothing() {
     std::env::set_var(PERSIST_DIR_ENV, &tmp);
     let path = persist_path!("passing_case_writes_nothing");
 
-    // Drive a single case directly through the value tree (no proptest! macro).
     let mut runner = TestRunner::new(Config {
         failure_persistence: None,
         ..Config::default()
@@ -239,9 +227,6 @@ fn passing_case_writes_nothing() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
-/// A correct machine driven through the `prop_state_machine_persisted!` macro:
-/// it expands, the once-per-run regression replay no-ops (no persisted file),
-/// generation runs, and the test passes. Exercises the macro end to end.
 struct GoodMachine;
 impl StateMachineTest for GoodMachine {
     type SystemUnderTest = u32;
@@ -262,13 +247,11 @@ proptest_state_machine::prop_state_machine_persisted! {
     fn macro_drives_good_machine(sequential 1..10 => GoodMachine);
 }
 
-// --- Accumulation of distinct regressions -----------------------------------
-
 use std::cell::Cell;
 
 thread_local! {
-    /// Selects which invariant `TwoBugs` violates, so a single test type can
-    /// exhibit two *distinct* minimal failures across runs.
+    /// Selects which invariant `TwoBugs` violates, so one test type can
+    /// exhibit two distinct minimal failures.
     static BUG_MODE: Cell<u8> = const { Cell::new(0) };
 }
 
@@ -293,7 +276,10 @@ impl ReferenceStateMachine for AbRef {
     fn transitions(_s: &Self::State) -> BoxedStrategy<Self::Transition> {
         prop_oneof![Just(Ab::A), Just(Ab::B)].boxed()
     }
-    fn apply(mut state: Self::State, transition: &Self::Transition) -> Self::State {
+    fn apply(
+        mut state: Self::State,
+        transition: &Self::Transition,
+    ) -> Self::State {
         match transition {
             Ab::A => state.a += 1,
             Ab::B => state.b += 1,
@@ -319,9 +305,6 @@ impl StateMachineTest for TwoBugs {
     }
 }
 
-/// Distinct failures (not shrunk versions of each other) accumulate into the
-/// regression set across runs, while re-discovering one already stored does not
-/// duplicate it.
 #[test]
 fn accumulates_distinct_regressions() {
     let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -345,8 +328,8 @@ fn accumulates_distinct_regressions() {
         ..Config::default()
     };
 
-    // Each `run_once` is a fresh logical run: reset the accumulation marker,
-    // then let proptest find and shrink one failure.
+    // A fresh logical run: reset the accumulation marker, then let proptest
+    // find and shrink one failure.
     let run_once = |mode: u8| {
         proptest_state_machine::persistence::reset_run_marker(&path);
         BUG_MODE.with(|m| m.set(mode));
@@ -414,12 +397,18 @@ fn corrupt_regression_line_names_itself() {
     std::env::remove_var(PERSIST_DIR_ENV);
     let _ = std::fs::remove_dir_all(&tmp);
 
-    assert!(err.contains(":3:"), "error must name the offending line: {err}");
-    assert!(err.contains("Delete line 3"), "error must say how to clear it: {err}");
+    assert!(
+        err.contains(":3:"),
+        "error must name the offending line: {err}"
+    );
+    assert!(
+        err.contains("Delete line 3"),
+        "error must say how to clear it: {err}"
+    );
 }
 
-/// `failure_persistence: None` — what `PROPTEST_DISABLE_FAILURE_PERSISTENCE`
-/// sets — suppresses the state-machine regression file too.
+/// `failure_persistence: None` is what `PROPTEST_DISABLE_FAILURE_PERSISTENCE`
+/// sets.
 #[test]
 fn disabled_failure_persistence_writes_nothing() {
     let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -455,14 +444,24 @@ fn disabled_failure_persistence_writes_nothing() {
             },
         )
     });
-    let replayed = BuggyCounter::replay_persisted_regressions(config.clone(), &path);
+    let replayed =
+        BuggyCounter::replay_persisted_regressions(config.clone(), &path);
     std::env::remove_var(PERSIST_DIR_ENV);
     let exists = path.exists();
     let _ = std::fs::remove_dir_all(&tmp);
 
-    assert!(matches!(result, Err(TestError::Fail(..))), "the machine still fails");
-    assert!(!exists, "no regression file when failure persistence is off");
-    assert_eq!(replayed, 0, "nothing is replayed when failure persistence is off");
+    assert!(
+        matches!(result, Err(TestError::Fail(..))),
+        "the machine still fails"
+    );
+    assert!(
+        !exists,
+        "no regression file when failure persistence is off"
+    );
+    assert_eq!(
+        replayed, 0,
+        "nothing is replayed when failure persistence is off"
+    );
 }
 
 #[test]
@@ -506,14 +505,20 @@ mod stale {
             Just(Gated::Open).boxed()
         }
 
-        fn preconditions(state: &Self::State, transition: &Self::Transition) -> bool {
+        fn preconditions(
+            state: &Self::State,
+            transition: &Self::Transition,
+        ) -> bool {
             match transition {
                 Gated::Open => true,
                 Gated::Enter => state.open,
             }
         }
 
-        fn apply(mut state: Self::State, transition: &Self::Transition) -> Self::State {
+        fn apply(
+            mut state: Self::State,
+            transition: &Self::Transition,
+        ) -> Self::State {
             if let Gated::Open = transition {
                 state.open = true;
             }

--- a/proptest-state-machine/tests/persistence.rs
+++ b/proptest-state-machine/tests/persistence.rs
@@ -374,3 +374,32 @@ fn accumulates_distinct_regressions() {
     std::env::remove_var(PERSIST_DIR_ENV);
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+#[test]
+fn corrupt_regression_line_names_itself() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = std::env::temp_dir().join(format!(
+        "psm-persistence-corrupt-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::env::set_var(PERSIST_DIR_ENV, &tmp);
+    let path = default_persist_path::<BuggyCounter>();
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        "# header\n{\"initial_state\":{\"value\":0},\"transitions\":[\"Inc\"]}\n\
+         {\"initial_state\":{\"value\":0},\"transitions\":[\"Nope\"]}\n",
+    )
+    .unwrap();
+
+    let err = load_set::<RefCounter, Op>(&path).unwrap_err().to_string();
+    std::env::remove_var(PERSIST_DIR_ENV);
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(err.contains(":3:"), "error must name the offending line: {err}");
+    assert!(err.contains("Delete line 3"), "error must say how to clear it: {err}");
+}

--- a/proptest-state-machine/tests/persistence.rs
+++ b/proptest-state-machine/tests/persistence.rs
@@ -1,0 +1,376 @@
+//-
+// Copyright 2026 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! End-to-end test for the `persistence` feature: a deliberately buggy state
+//! machine must (1) persist its shrunk failing transition sequence on failure,
+//! and (2) reproduce the failure when that file is replayed — without
+//! regeneration or re-shrinking.
+
+#![cfg(feature = "persistence")]
+
+use std::panic;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// The persistence env vars are process-global; serialize the tests that set
+/// them so they don't race each other.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+use proptest::prelude::*;
+use proptest::strategy::{Just, ValueTree};
+use proptest::test_runner::{Config, TestError, TestRunner};
+use proptest_state_machine::persistence::{
+    default_persist_path, load_set, PersistedCase, PERSIST_DIR_ENV,
+};
+use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
+
+use serde::{Deserialize, Serialize};
+
+/// The only transition: increment the counter.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+enum Op {
+    Inc,
+}
+
+/// Reference model: an honest counter.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct RefCounter {
+    value: u32,
+}
+
+impl ReferenceStateMachine for RefCounter {
+    type State = RefCounter;
+    type Transition = Op;
+
+    fn init_state() -> BoxedStrategy<Self::State> {
+        Just(RefCounter { value: 0 }).boxed()
+    }
+
+    fn transitions(_state: &Self::State) -> BoxedStrategy<Self::Transition> {
+        Just(Op::Inc).boxed()
+    }
+
+    fn apply(mut state: Self::State, _transition: &Self::Transition) -> Self::State {
+        state.value += 1;
+        state
+    }
+}
+
+/// SUT with a bug: the concrete counter saturates at 3, so once the reference
+/// reaches 4 the post-condition `sut == ref` fails. The minimal failing case is
+/// therefore exactly four `Inc`s.
+struct BuggyCounter;
+
+impl StateMachineTest for BuggyCounter {
+    type SystemUnderTest = u32;
+    type Reference = RefCounter;
+
+    fn init_test(_ref_state: &RefCounter) -> u32 {
+        0
+    }
+
+    fn apply(state: u32, _ref_state: &RefCounter, _transition: Op) -> u32 {
+        // BUG: caps at 3 instead of counting forever.
+        (state + 1).min(3)
+    }
+
+    fn check_invariants(state: &u32, ref_state: &RefCounter) {
+        assert_eq!(
+            *state, ref_state.value,
+            "SUT counter diverged from reference"
+        );
+    }
+}
+
+fn quiet_panic<R>(f: impl FnOnce() -> R) -> R {
+    let prev = panic::take_hook();
+    panic::set_hook(Box::new(|_| {}));
+    let r = f();
+    panic::set_hook(prev);
+    r
+}
+
+#[test]
+fn persists_shrunk_case_and_replays_it() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // Isolate persistence to a unique temp dir and keep proptest's own seed
+    // regression file out of the picture.
+    let tmp = std::env::temp_dir().join(format!(
+        "psm-persistence-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    // SAFETY: single test, no other test touches these vars; std edition 2021.
+    std::env::set_var(PERSIST_DIR_ENV, &tmp);
+
+    let config = Config {
+        failure_persistence: None,
+        cases: 256,
+        ..Config::default()
+    };
+    let path: PathBuf = default_persist_path::<BuggyCounter>();
+
+    // --- Phase 1: capture ---------------------------------------------------
+    let result = quiet_panic(|| {
+        let mut runner = TestRunner::new(config.clone());
+        runner.run(
+            &RefCounter::sequential_strategy(1..20usize),
+            |(init, transitions, counter)| {
+                BuggyCounter::test_sequential_persisted(
+                    config.clone(),
+                    init,
+                    transitions,
+                    counter,
+                );
+                Ok(())
+            },
+        )
+    });
+    assert!(
+        matches!(result, Err(TestError::Fail(..))),
+        "the buggy machine must fail, got {result:?}"
+    );
+
+    let set: Vec<PersistedCase<RefCounter, Op>> = load_set(&path)
+        .unwrap_or_else(|e| panic!("expected persisted set at {path:?}: {e}"));
+    assert_eq!(set.len(), 1, "one distinct failure → one persisted case");
+    assert_eq!(
+        set[0].transitions,
+        vec![Op::Inc, Op::Inc, Op::Inc, Op::Inc],
+        "shrunk case must be the minimal four increments"
+    );
+    assert_eq!(set[0].initial_state.value, 0);
+
+    // On-disk format is JSON Lines: a `#` header plus exactly one case line.
+    let raw = std::fs::read_to_string(&path).unwrap();
+    assert!(raw.starts_with('#'), "file should begin with a comment header");
+    let case_lines: Vec<&str> = raw
+        .lines()
+        .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with('#'))
+        .collect();
+    assert_eq!(case_lines.len(), 1, "exactly one case line");
+    serde_json::from_str::<serde_json::Value>(case_lines[0])
+        .expect("each case line is standalone JSON");
+
+    // --- Phase 2: replay ----------------------------------------------------
+    // `replay_persisted_regressions` loads the file written above and re-runs
+    // it; since the bug is still present it must reproduce the failure. This is
+    // the call `prop_state_machine_persisted!` makes once per run.
+    let replayed = quiet_panic(|| {
+        panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            BuggyCounter::replay_persisted_regressions(config.clone())
+        }))
+    });
+    std::env::remove_var(PERSIST_DIR_ENV);
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(
+        replayed.is_err(),
+        "replaying the stored failing case must reproduce the failure"
+    );
+}
+
+/// A passing machine must not write a persistence file.
+#[test]
+fn passing_case_writes_nothing() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    struct GoodCounter;
+    impl StateMachineTest for GoodCounter {
+        type SystemUnderTest = u32;
+        type Reference = RefCounter;
+        fn init_test(_r: &RefCounter) -> u32 {
+            0
+        }
+        fn apply(state: u32, _r: &RefCounter, _t: Op) -> u32 {
+            state + 1
+        }
+        fn check_invariants(state: &u32, r: &RefCounter) {
+            assert_eq!(*state, r.value);
+        }
+    }
+
+    let tmp = std::env::temp_dir().join(format!(
+        "psm-persistence-good-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::env::set_var(PERSIST_DIR_ENV, &tmp);
+    let path = default_persist_path::<GoodCounter>();
+
+    // Drive a single case directly through the value tree (no proptest! macro).
+    let mut runner = TestRunner::new(Config {
+        failure_persistence: None,
+        ..Config::default()
+    });
+    let tree = RefCounter::sequential_strategy(1..10usize)
+        .new_tree(&mut runner)
+        .unwrap();
+    let (init, transitions, counter) = tree.current();
+    GoodCounter::test_sequential_persisted(
+        Config::default(),
+        init,
+        transitions,
+        counter,
+    );
+
+    assert!(!path.exists(), "passing case must not persist a file");
+    std::env::remove_var(PERSIST_DIR_ENV);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// A correct machine driven through the `prop_state_machine_persisted!` macro:
+/// it expands, the once-per-run regression replay no-ops (no persisted file),
+/// generation runs, and the test passes. Exercises the macro end to end.
+struct GoodMachine;
+impl StateMachineTest for GoodMachine {
+    type SystemUnderTest = u32;
+    type Reference = RefCounter;
+    fn init_test(_r: &RefCounter) -> u32 {
+        0
+    }
+    fn apply(state: u32, _r: &RefCounter, _t: Op) -> u32 {
+        state + 1
+    }
+    fn check_invariants(state: &u32, r: &RefCounter) {
+        assert_eq!(*state, r.value);
+    }
+}
+
+proptest_state_machine::prop_state_machine_persisted! {
+    #[test]
+    fn macro_drives_good_machine(sequential 1..10 => GoodMachine);
+}
+
+// --- Accumulation of distinct regressions -----------------------------------
+
+use std::cell::Cell;
+
+thread_local! {
+    /// Selects which invariant `TwoBugs` violates, so a single test type can
+    /// exhibit two *distinct* minimal failures across runs.
+    static BUG_MODE: Cell<u8> = const { Cell::new(0) };
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+enum Ab {
+    A,
+    B,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct AbRef {
+    a: u32,
+    b: u32,
+}
+
+impl ReferenceStateMachine for AbRef {
+    type State = AbRef;
+    type Transition = Ab;
+    fn init_state() -> BoxedStrategy<Self::State> {
+        Just(AbRef { a: 0, b: 0 }).boxed()
+    }
+    fn transitions(_s: &Self::State) -> BoxedStrategy<Self::Transition> {
+        prop_oneof![Just(Ab::A), Just(Ab::B)].boxed()
+    }
+    fn apply(mut state: Self::State, transition: &Self::Transition) -> Self::State {
+        match transition {
+            Ab::A => state.a += 1,
+            Ab::B => state.b += 1,
+        }
+        state
+    }
+}
+
+/// Bug 1 (mode 1): breaks after two `A`s → minimal `[A, A]`.
+/// Bug 2 (mode 2): breaks after one `B` → minimal `[B]`.
+struct TwoBugs;
+impl StateMachineTest for TwoBugs {
+    type SystemUnderTest = ();
+    type Reference = AbRef;
+    fn init_test(_r: &AbRef) {}
+    fn apply(_s: (), _r: &AbRef, _t: Ab) {}
+    fn check_invariants(_s: &(), r: &AbRef) {
+        match BUG_MODE.with(Cell::get) {
+            1 => assert!(r.a < 2, "mode 1: two A transitions"),
+            2 => assert!(r.b < 1, "mode 2: a B transition"),
+            _ => {}
+        }
+    }
+}
+
+/// Distinct failures (not shrunk versions of each other) accumulate into the
+/// regression set across runs, while re-discovering one already stored does not
+/// duplicate it.
+#[test]
+fn accumulates_distinct_regressions() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = std::env::temp_dir().join(format!(
+        "psm-persistence-accum-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::env::set_var(PERSIST_DIR_ENV, &tmp);
+    let path = default_persist_path::<TwoBugs>();
+    let config = Config {
+        failure_persistence: None,
+        cases: 512,
+        ..Config::default()
+    };
+
+    // Each `run_once` is a fresh logical run: reset the accumulation marker,
+    // then let proptest find and shrink one failure.
+    let run_once = |mode: u8| {
+        proptest_state_machine::persistence::reset_run_marker(&path);
+        BUG_MODE.with(|m| m.set(mode));
+        let _ = quiet_panic(|| {
+            let mut runner = TestRunner::new(config.clone());
+            runner.run(
+                &AbRef::sequential_strategy(1..20usize),
+                |(init, transitions, counter)| {
+                    TwoBugs::test_sequential_persisted(
+                        config.clone(),
+                        init,
+                        transitions,
+                        counter,
+                    );
+                    Ok(())
+                },
+            )
+        });
+    };
+
+    run_once(1);
+    let set1: Vec<PersistedCase<AbRef, Ab>> = load_set(&path).unwrap();
+    assert_eq!(set1.len(), 1, "first failure stored");
+    assert_eq!(set1[0].transitions, vec![Ab::A, Ab::A]);
+
+    run_once(2);
+    let set2: Vec<PersistedCase<AbRef, Ab>> = load_set(&path).unwrap();
+    let seqs: Vec<_> = set2.iter().map(|c| c.transitions.clone()).collect();
+    assert_eq!(set2.len(), 2, "distinct second failure accumulated");
+    assert!(seqs.contains(&vec![Ab::A, Ab::A]));
+    assert!(seqs.contains(&vec![Ab::B]));
+
+    // Re-discover bug 1: must not duplicate the existing [A, A] entry.
+    run_once(1);
+    let set3: Vec<PersistedCase<AbRef, Ab>> = load_set(&path).unwrap();
+    assert_eq!(set3.len(), 2, "re-discovered failure must not duplicate");
+
+    std::env::remove_var(PERSIST_DIR_ENV);
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/proptest-state-machine/tests/persistence.rs
+++ b/proptest-state-machine/tests/persistence.rs
@@ -469,3 +469,85 @@ fn fork_is_rejected() {
     };
     BuggyCounter::replay_persisted_regressions(config);
 }
+
+/// A stored case that still deserializes but breaks a precondition the model
+/// has since gained must be reported as stale, not applied anyway.
+mod stale {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+    pub enum Gated {
+        Open,
+        Enter,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct Gate {
+        pub open: bool,
+    }
+
+    impl ReferenceStateMachine for Gate {
+        type State = Gate;
+        type Transition = Gated;
+
+        fn init_state() -> BoxedStrategy<Self::State> {
+            Just(Gate { open: false }).boxed()
+        }
+
+        fn transitions(_s: &Self::State) -> BoxedStrategy<Self::Transition> {
+            Just(Gated::Open).boxed()
+        }
+
+        fn preconditions(state: &Self::State, transition: &Self::Transition) -> bool {
+            match transition {
+                Gated::Open => true,
+                Gated::Enter => state.open,
+            }
+        }
+
+        fn apply(mut state: Self::State, transition: &Self::Transition) -> Self::State {
+            if let Gated::Open = transition {
+                state.open = true;
+            }
+            state
+        }
+    }
+
+    pub struct GateTest;
+    impl StateMachineTest for GateTest {
+        type SystemUnderTest = ();
+        type Reference = Gate;
+        fn init_test(_r: &Gate) {}
+        fn apply(_s: (), _r: &Gate, _t: Gated) {}
+    }
+}
+
+#[test]
+#[should_panic(expected = "no longer valid under the current reference model")]
+fn stale_regression_is_reported_not_applied() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = std::env::temp_dir().join(format!(
+        "psm-persistence-stale-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::env::set_var(PERSIST_DIR_ENV, &tmp);
+    let path = default_persist_path::<stale::GateTest>();
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    // Entering before opening: legal when recorded, rejected by the gate now.
+    std::fs::write(
+        &path,
+        "{\"initial_state\":{\"open\":false},\"transitions\":[\"Enter\"]}\n",
+    )
+    .unwrap();
+
+    let result = panic::catch_unwind(|| {
+        stale::GateTest::replay_persisted_regressions(Config::default())
+    });
+    std::env::remove_var(PERSIST_DIR_ENV);
+    let _ = std::fs::remove_dir_all(&tmp);
+    panic::resume_unwind(result.unwrap_err());
+}

--- a/proptest-state-machine/tests/persistence.rs
+++ b/proptest-state-machine/tests/persistence.rs
@@ -26,8 +26,9 @@ use proptest::prelude::*;
 use proptest::strategy::{Just, ValueTree};
 use proptest::test_runner::{Config, TestError, TestRunner};
 use proptest_state_machine::persistence::{
-    default_persist_path, load_set, PersistedCase, PERSIST_DIR_ENV,
+    load_set, PersistedCase, PERSIST_DIR_ENV,
 };
+use proptest_state_machine::persist_path;
 use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
 
 use serde::{Deserialize, Serialize};
@@ -123,7 +124,7 @@ fn persists_shrunk_case_and_replays_it() {
         cases: 256,
         ..Config::default()
     };
-    let path: PathBuf = default_persist_path::<BuggyCounter>();
+    let path: PathBuf = persist_path!("persists_shrunk_case_and_replays_it");
 
     // --- Phase 1: capture ---------------------------------------------------
     let result = quiet_panic(|| {
@@ -133,6 +134,7 @@ fn persists_shrunk_case_and_replays_it() {
             |(init, transitions, counter)| {
                 BuggyCounter::test_sequential_persisted(
                     config.clone(),
+                    path.clone(),
                     init,
                     transitions,
                     counter,
@@ -173,7 +175,7 @@ fn persists_shrunk_case_and_replays_it() {
     // the call `prop_state_machine_persisted!` makes once per run.
     let replayed = quiet_panic(|| {
         panic::catch_unwind(panic::AssertUnwindSafe(|| {
-            BuggyCounter::replay_persisted_regressions(config.clone())
+            BuggyCounter::replay_persisted_regressions(config.clone(), &path)
         }))
     });
     std::env::remove_var(PERSIST_DIR_ENV);
@@ -213,7 +215,7 @@ fn passing_case_writes_nothing() {
             .as_nanos()
     ));
     std::env::set_var(PERSIST_DIR_ENV, &tmp);
-    let path = default_persist_path::<GoodCounter>();
+    let path = persist_path!("passing_case_writes_nothing");
 
     // Drive a single case directly through the value tree (no proptest! macro).
     let mut runner = TestRunner::new(Config {
@@ -226,6 +228,7 @@ fn passing_case_writes_nothing() {
     let (init, transitions, counter) = tree.current();
     GoodCounter::test_sequential_persisted(
         Config::default(),
+        path.clone(),
         init,
         transitions,
         counter,
@@ -331,7 +334,7 @@ fn accumulates_distinct_regressions() {
             .as_nanos()
     ));
     std::env::set_var(PERSIST_DIR_ENV, &tmp);
-    let path = default_persist_path::<TwoBugs>();
+    let path = persist_path!("accumulates_distinct_regressions");
     let runner_config = Config {
         failure_persistence: None,
         cases: 512,
@@ -354,6 +357,7 @@ fn accumulates_distinct_regressions() {
                 |(init, transitions, counter)| {
                     TwoBugs::test_sequential_persisted(
                         config.clone(),
+                        path.clone(),
                         init,
                         transitions,
                         counter,
@@ -397,7 +401,7 @@ fn corrupt_regression_line_names_itself() {
             .as_nanos()
     ));
     std::env::set_var(PERSIST_DIR_ENV, &tmp);
-    let path = default_persist_path::<BuggyCounter>();
+    let path = persist_path!("corrupt_regression_line_names_itself");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     std::fs::write(
         &path,
@@ -428,7 +432,7 @@ fn disabled_failure_persistence_writes_nothing() {
             .as_nanos()
     ));
     std::env::set_var(PERSIST_DIR_ENV, &tmp);
-    let path = default_persist_path::<BuggyCounter>();
+    let path = persist_path!("disabled_failure_persistence_writes_nothing");
 
     let config = Config {
         failure_persistence: None,
@@ -442,6 +446,7 @@ fn disabled_failure_persistence_writes_nothing() {
             |(init, transitions, counter)| {
                 BuggyCounter::test_sequential_persisted(
                     config.clone(),
+                    path.clone(),
                     init,
                     transitions,
                     counter,
@@ -450,7 +455,7 @@ fn disabled_failure_persistence_writes_nothing() {
             },
         )
     });
-    let replayed = BuggyCounter::replay_persisted_regressions(config.clone());
+    let replayed = BuggyCounter::replay_persisted_regressions(config.clone(), &path);
     std::env::remove_var(PERSIST_DIR_ENV);
     let exists = path.exists();
     let _ = std::fs::remove_dir_all(&tmp);
@@ -467,7 +472,10 @@ fn fork_is_rejected() {
         fork: true,
         ..Config::default()
     };
-    BuggyCounter::replay_persisted_regressions(config);
+    BuggyCounter::replay_persisted_regressions(
+        config,
+        &persist_path!("fork_is_rejected"),
+    );
 }
 
 /// A stored case that still deserializes but breaks a precondition the model
@@ -535,7 +543,7 @@ fn stale_regression_is_reported_not_applied() {
             .as_nanos()
     ));
     std::env::set_var(PERSIST_DIR_ENV, &tmp);
-    let path = default_persist_path::<stale::GateTest>();
+    let path = persist_path!("stale_regression_is_reported_not_applied");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     // Entering before opening: legal when recorded, rejected by the gate now.
     std::fs::write(
@@ -545,7 +553,7 @@ fn stale_regression_is_reported_not_applied() {
     .unwrap();
 
     let result = panic::catch_unwind(|| {
-        stale::GateTest::replay_persisted_regressions(Config::default())
+        stale::GateTest::replay_persisted_regressions(Config::default(), &path)
     });
     std::env::remove_var(PERSIST_DIR_ENV);
     let _ = std::fs::remove_dir_all(&tmp);

--- a/proptest-state-machine/tests/persistence_cases_zero.rs
+++ b/proptest-state-machine/tests/persistence_cases_zero.rs
@@ -44,7 +44,10 @@ impl ReferenceStateMachine for RefCounter {
         Just(Op::Inc).boxed()
     }
 
-    fn apply(mut state: Self::State, _transition: &Self::Transition) -> Self::State {
+    fn apply(
+        mut state: Self::State,
+        _transition: &Self::Transition,
+    ) -> Self::State {
         state.value += 1;
         state
     }
@@ -65,14 +68,18 @@ impl StateMachineTest for BuggyCounter {
     }
 
     fn check_invariants(state: &u32, ref_state: &RefCounter) {
-        assert_eq!(*state, ref_state.value, "SUT counter diverged from reference");
+        assert_eq!(
+            *state, ref_state.value,
+            "SUT counter diverged from reference"
+        );
     }
 }
 
 /// Evaluated before the macro replays anything, so the regression it writes is
 /// on disk by the time replay reads it.
 fn seeded_config() -> Config {
-    let dir = std::env::temp_dir().join(format!("psm-cases-zero-{}", std::process::id()));
+    let dir = std::env::temp_dir()
+        .join(format!("psm-cases-zero-{}", std::process::id()));
     std::env::set_var(PERSIST_DIR_ENV, &dir);
     let path = persist_path!("cases_zero_replays_the_regression");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();

--- a/proptest-state-machine/tests/persistence_cases_zero.rs
+++ b/proptest-state-machine/tests/persistence_cases_zero.rs
@@ -17,7 +17,8 @@
 use proptest::prelude::*;
 use proptest::strategy::Just;
 use proptest::test_runner::Config;
-use proptest_state_machine::persistence::{default_persist_path, PERSIST_DIR_ENV};
+use proptest_state_machine::persist_path;
+use proptest_state_machine::persistence::PERSIST_DIR_ENV;
 use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
 use serde::{Deserialize, Serialize};
 
@@ -73,7 +74,7 @@ impl StateMachineTest for BuggyCounter {
 fn seeded_config() -> Config {
     let dir = std::env::temp_dir().join(format!("psm-cases-zero-{}", std::process::id()));
     std::env::set_var(PERSIST_DIR_ENV, &dir);
-    let path = default_persist_path::<BuggyCounter>();
+    let path = persist_path!("cases_zero_replays_the_regression");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     std::fs::write(
         &path,

--- a/proptest-state-machine/tests/persistence_cases_zero.rs
+++ b/proptest-state-machine/tests/persistence_cases_zero.rs
@@ -1,0 +1,94 @@
+//-
+// Copyright 2026 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! `PROPTEST_CASES=0` replays the stored regressions and generates nothing.
+//!
+//! Its own binary: the persistence directory is selected by a process-global
+//! environment variable, and this test owns it for the whole run.
+
+#![cfg(feature = "persistence")]
+
+use proptest::prelude::*;
+use proptest::strategy::Just;
+use proptest::test_runner::Config;
+use proptest_state_machine::persistence::{default_persist_path, PERSIST_DIR_ENV};
+use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+enum Op {
+    Inc,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct RefCounter {
+    value: u32,
+}
+
+impl ReferenceStateMachine for RefCounter {
+    type State = RefCounter;
+    type Transition = Op;
+
+    fn init_state() -> BoxedStrategy<Self::State> {
+        Just(RefCounter { value: 0 }).boxed()
+    }
+
+    fn transitions(_state: &Self::State) -> BoxedStrategy<Self::Transition> {
+        Just(Op::Inc).boxed()
+    }
+
+    fn apply(mut state: Self::State, _transition: &Self::Transition) -> Self::State {
+        state.value += 1;
+        state
+    }
+}
+
+struct BuggyCounter;
+
+impl StateMachineTest for BuggyCounter {
+    type SystemUnderTest = u32;
+    type Reference = RefCounter;
+
+    fn init_test(_ref_state: &RefCounter) -> u32 {
+        0
+    }
+
+    fn apply(state: u32, _ref_state: &RefCounter, _transition: Op) -> u32 {
+        (state + 1).min(3)
+    }
+
+    fn check_invariants(state: &u32, ref_state: &RefCounter) {
+        assert_eq!(*state, ref_state.value, "SUT counter diverged from reference");
+    }
+}
+
+/// Evaluated before the macro replays anything, so the regression it writes is
+/// on disk by the time replay reads it.
+fn seeded_config() -> Config {
+    let dir = std::env::temp_dir().join(format!("psm-cases-zero-{}", std::process::id()));
+    std::env::set_var(PERSIST_DIR_ENV, &dir);
+    let path = default_persist_path::<BuggyCounter>();
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        "{\"initial_state\":{\"value\":0},\"transitions\":[\"Inc\",\"Inc\",\"Inc\",\"Inc\"]}\n",
+    )
+    .unwrap();
+    Config {
+        cases: 0,
+        ..Config::default()
+    }
+}
+
+proptest_state_machine::prop_state_machine_persisted! {
+    #![proptest_config(seeded_config())]
+    #[test]
+    #[should_panic(expected = "SUT counter diverged from reference")]
+    fn cases_zero_replays_the_regression(sequential 1..10 => BuggyCounter);
+}

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -41,6 +41,8 @@ pub fn contextualize_config(mut result: Config) -> Config {
     const DISABLE_FAILURE_PERSISTENCE: &str =
         "PROPTEST_DISABLE_FAILURE_PERSISTENCE";
 
+    use super::EXTENSION_PREFIX;
+
     fn parse_or_warn<T: FromStr + fmt::Display>(
         src: &OsString,
         dst: &mut T,
@@ -140,9 +142,7 @@ pub fn contextualize_config(mut result: Config) -> Config {
             parse_or_warn(&value, &mut result.rng_seed, "u64", RNG_SEED);
         } else if var == DISABLE_FAILURE_PERSISTENCE {
             result.failure_persistence = None;
-        } else if var.starts_with("PROPTEST_STATE_MACHINE_") {
-            // Reserved namespace for the `proptest-state-machine` crate (e.g.
-            // its `persistence` feature). Not consumed here; don't warn.
+        } else if var.starts_with(EXTENSION_PREFIX) {
         } else if var.starts_with("PROPTEST_") {
             eprintln!("proptest: Ignoring unknown env-var {}.", var);
         }
@@ -219,6 +219,10 @@ impl fmt::Display for RngSeed {
         }
     }
 }
+
+/// Prefix reserved for crates built on proptest, which read these variables
+/// themselves. Proptest passes over them rather than reporting them as unknown.
+pub const EXTENSION_PREFIX: &str = "PROPTEST_EXT_";
 
 /// Configuration for how a proptest test should be run.
 #[derive(Clone, Debug, PartialEq)]

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -140,6 +140,9 @@ pub fn contextualize_config(mut result: Config) -> Config {
             parse_or_warn(&value, &mut result.rng_seed, "u64", RNG_SEED);
         } else if var == DISABLE_FAILURE_PERSISTENCE {
             result.failure_persistence = None;
+        } else if var.starts_with("PROPTEST_STATE_MACHINE_") {
+            // Reserved namespace for the `proptest-state-machine` crate (e.g.
+            // its `persistence` feature). Not consumed here; don't warn.
         } else if var.starts_with("PROPTEST_") {
             eprintln!("proptest: Ignoring unknown env-var {}.", var);
         }


### PR DESCRIPTION
# Persist the shrunk transition sequence, not just the seed (proptest-state-machine)

Closes #564. Related context: #440.

## Problem

Proptest's built-in failure persistence stores the **RNG seed** of the failing
`TestRunner`. For state-machine tests that has two costs:

1. **Replay re-shrinks.** Replaying a seed regenerates the case from the
   strategy and then re-runs the whole shrinking process before the minimal
   counter-example is reached.
2. **Seeds are brittle.** As soon as the reference model or the transition
   strategy changes, the same seed no longer maps to the same case, so the
   stored regression silently stops pinning the bug it was meant to pin.

Issue #564 asks for the ability to save and load the *fully-shrunk* failing
case directly. Unlike a generic proptest `Value`, a state-machine failing case
is a concrete, human-readable value — `(initial_state, Vec<Transition>)` — that
can usually implement `serde::Serialize`. That makes the state-machine crate the
natural home for this (proptest core stays seed-based and untouched apart from a
one-line env-var namespace reservation).

## What this adds

A new **opt-in `persistence` feature** (pulls in `serde` + `serde_json`).

The model mirrors how proptest treats seed regressions: persisted cases are
**replayed on every run**, and freshly generated cases run on top to keep
finding new failures. Distinct failures **accumulate** into a regression file
stored as **JSON Lines** (one case per line, like proptest's line-oriented
seed-regression file — clean diffs and union-friendly merges in source control),
while shrunk versions of the *same* failure collapse to one minimal case.

- `prop_state_machine_persisted!` — macro counterpart of `prop_state_machine!`.
  It expands to a test that (1) calls `replay_persisted_regressions` once per
  run, then (2) runs the normal generation loop with capture-on-failure.
- `StateMachineTest::replay_persisted_regressions(config)` — loads the persisted
  case (if any) and re-runs it via `test_sequential`. A still-failing regression
  panics here, attributed to the stored case rather than to a generated one.
- `StateMachineTest::test_sequential_persisted(...)` — `test_sequential` plus
  capture-on-failure.
- `persistence::PersistedCase<S, T>` — the on-disk case shape
  (`{ initial_state, transitions }`); the file is one such object per line
  (JSON Lines) under a `#` comment header.
- `persistence::store` — the `StateMachineTest`-agnostic half: JSON Lines I/O,
  the accumulate/de-dup merge, the per-run marker, and the panic `CaptureGuard`,
  generic over any `Serialize + DeserializeOwned` case type. The trait/macro
  glue is a thin layer on top. Factored out so it's reviewable in isolation and
  reusable by projects with a richer fixture type; happy to narrow its
  visibility if you'd prefer a smaller public surface.
- `persistence::CaptureGuard` — an RAII guard that serializes the case eagerly
  and, on unwind, merges it into the regression set. Within a run, proptest
  re-runs the body for every shrink candidate; successive writes replace this
  run's previous entry (collapsing to the minimal). Across runs, a distinct
  minimal is appended; exact duplicates are de-duplicated.
- `PROPTEST_STATE_MACHINE_PERSIST_DIR` env var overrides the persistence
  directory (default `proptest-regressions/state-machine`). `PROPTEST_CASES=0`
  replays the regression without generating new cases.
- proptest core: the `PROPTEST_STATE_MACHINE_*` namespace is reserved so the
  config env scanner doesn't print `Ignoring unknown env-var`.

The reference `State` and `Transition` must implement
`serde::Serialize + serde::de::DeserializeOwned` to use the persisted path; the
base traits are unchanged, so existing tests and default builds are completely
unaffected.

## Usage

```rust
prop_state_machine_persisted! {
    #[test]
    fn my_test(sequential 1..20 => MyStateMachine);
}
```

On failure the shrunk sequence is written to
`proptest-regressions/state-machine/<type>.jsonl` and committed like a normal
regression file. Every subsequent run replays the stored cases first, then
generates new cases. To replay only the regressions (no new generation):

```sh
PROPTEST_CASES=0 cargo test my_test
```

## Tests

`proptest-state-machine/tests/persistence.rs`:

- a deliberately buggy counter machine (SUT saturates at 3) fails; the persisted
  file contains the **minimal** shrunk sequence (exactly four increments), not
  an unshrunk one;
- `replay_persisted_regressions` reproduces the failure from that file;
- a passing machine writes nothing;
- a correct machine driven through `prop_state_machine_persisted!` exercises the
  macro (replay no-op + generation) end to end;
- a machine with two selectable bugs accumulates **two distinct** minimal cases
  across runs, and re-discovering one already stored does not duplicate it
  (plus a focused unit test of the set-merge logic).

## Notes / open questions for maintainers

- **Collapsing "shrunk versions of each other".** Distinct minimals are kept by
  exact-equality de-dup, not by subsequence subsumption. Subsumption would be
  unsound here: two genuinely different bugs can be subsequence-related, so
  collapsing by subsequence could silently drop a distinct regression. Instead,
  the replay-before-generate flow already prevents accumulating two shrinks of
  the *same* live bug (its regression fails replay before generation can run),
  and within-run shrinking collapses to one minimal. If you'd still like
  same-bug-across-strategy-change collapsing, we'd need a per-failure identity
  signal (e.g. the panic message) — happy to explore.
- **Why `State: Serialize` and no bespoke abstraction?** Persistence is a single,
  uniform serde requirement on both `State` and `Transition` — no special-casing
  of one over the other. A state that is large or not directly serializable can
  persist a compact, reconstructible form via `#[serde(into = "…", from = "…")]`
  (documented in the module docs), so the serde bound isn't a hard ceiling. I
  deliberately avoided a dedicated state-codec trait: it would be asymmetric with
  `Transition` and is redundant with serde's own proxy support for any state you
  own. If foreign (orphan-rule-blocked) states create real demand later, a codec
  can be added additively.
- The capture/replay relies on the in-process unwind path; it is not wired
  through the `fork`/`timeout` out-of-process runners. Happy to gate or document
  that explicitly.
- JSON via `serde_json` was chosen for human-readability (these files are meant
  to be inspected and checked in). If you'd prefer a different format or to make
  the serializer pluggable, easy to change.
- Naming of the trait method / macro / env var is open to bikeshedding.
