### PR TITLE
Choice-tape shrink engine: Conjecture-style generation recording, shrinking, and persistence

### DIFF
--- a/design/choice-tape-shrinking.md
+++ b/design/choice-tape-shrinking.md
@@ -416,11 +416,10 @@ strategy:
   `ShrinkEngine` config, runner integration. Tests: round-float minimal
   examples, filter no-stall, flat_map shrink quality, unmigrated-strategy
   shrinking via raw choices, budget respect.
-  **Status: DONE — see `design/choice-tape-status.md`.**
+  **Status: DONE.**
 - **Phase 2:** spans; continuation encoding for `vec`/collections;
   `delete_spans`; `prop_oneof` branch choice.
-  **Status: DONE except adaptive deletion batching — see
-  `design/choice-tape-status.md`.**
+  **Status: DONE, including adaptive deletion batching.**
 - **Phase 3:** migrate char/string/bits/sample; state-machine crate
   evaluation.
 - **Phase 4:** cross-value passes (duplicates, redistribute, reorder).

--- a/design/choice-tape-shrinking.md
+++ b/design/choice-tape-shrinking.md
@@ -418,7 +418,9 @@ strategy:
   shrinking via raw choices, budget respect.
   **Status: DONE — see `design/choice-tape-status.md`.**
 - **Phase 2:** spans; continuation encoding for `vec`/collections;
-  `delete_spans` with adaptive batching; `prop_oneof` branch choice.
+  `delete_spans`; `prop_oneof` branch choice.
+  **Status: DONE except adaptive deletion batching — see
+  `design/choice-tape-status.md`.**
 - **Phase 3:** migrate char/string/bits/sample; state-machine crate
   evaluation.
 - **Phase 4:** cross-value passes (duplicates, redistribute, reorder).

--- a/design/choice-tape-shrinking.md
+++ b/design/choice-tape-shrinking.md
@@ -1,0 +1,428 @@
+# Design: a Conjecture-style choice tape for proptest
+
+Status: draft for review. Nothing in this document is implemented yet.
+
+## 1. Motivation
+
+Proptest is "inspired by Hypothesis", but it did not adopt Hypothesis's core
+engine idea (Conjecture): serialize *all* generation decisions into a
+replayable sequence, and implement shrinking as *edits to that sequence*
+followed by re-running the generator. Instead, proptest threads shrink state
+through every strategy as a `ValueTree` with `simplify()`/`complicate()`
+([traits.rs](../proptest/src/strategy/traits.rs)), driven by a single greedy
+loop in [runner.rs](../proptest/src/test_runner/runner.rs) (`fn shrink`).
+
+Concrete costs of the current design, observed in the code:
+
+- **Floats shrink to noise.** `f64::BinarySearch`
+  ([num.rs](../proptest/src/num.rs), `float_bin_search!`) does numeric
+  bisection toward 0 and converges to an arbitrary boundary midpoint like
+  `0.7500000000000002`. Hypothesis shrinks through a lexicographic float
+  encoding and produces round values (`2.0`, `1.5`).
+- **`prop_filter` strands the search.**
+  [filter.rs](../proptest/src/strategy/filter.rs) rejects a simplification
+  whose value fails the predicate and backtracks; shrinking stalls at locally
+  minimal values (the code has to relax the simplify/complicate contract for
+  this, see `strict_complicate_after_simplify: false`).
+- **`prop_flat_map` shrinking is regeneration-with-retry.**
+  [flatten.rs](../proptest/src/strategy/flatten.rs) admits in its comments
+  that complicating after the outer value shrinks is implemented by
+  regenerating inner values up to a retry budget.
+- **No cross-value passes.** Each `ValueTree` shrinks in isolation. We cannot
+  lower two equal values together, redistribute a numeric pair, or reorder
+  elements.
+- **Fragile persistence.** Failures persist as RNG seeds
+  (`PersistedSeed(Seed)`), which regenerate a different value as soon as the
+  strategy code (or rand) changes. A persisted choice tape survives most code
+  changes because typed values are replayed, not re-derived from entropy.
+
+Decision (2026-07-07): build a choice-tape engine. Distribution changes to
+default strategies are acceptable.
+
+## 2. Goals and non-goals
+
+Goals, in priority order:
+
+1. Shrinking quality: round floats, no filter stalls, natural flat_map
+   shrinking, collection element deletion as a generic pass, later
+   cross-value passes.
+2. Zero breakage: every existing `Strategy`/`ValueTree` implementation
+   (including third-party and proptest-state-machine) keeps compiling and
+   running unchanged. Unmigrated strategies are tape-recorded transparently
+   through an RngCore compat wrapper (§6) and keep at least their current
+   shrink quality.
+3. Incremental migration: built-in strategies move to typed draws one module
+   at a time; each migration improves shrinking for that strategy only.
+4. Later: tape-based failure persistence, fuzzer interop, and
+   Hypothesis-style generation upgrades (weird floats, biased integers)
+   expressed at the choice level.
+
+Non-goals (for now):
+
+- Replacing `ValueTree`. It stays as the generation result and as the
+  fallback shrinker; the tape engine is opt-in (`Config`) until proven.
+- Fork mode support in the first phases (tape shrinking falls back to the
+  ValueTree shrinker under `fork = true`).
+- DataTree-style novelty search / targeted property testing (Hypothesis's
+  `datatree.py`, `optimiser.py`). Out of scope entirely.
+
+## 3. Architecture overview
+
+```
+generation:  Strategy::new_tree(runner)
+             ├─ typed draws: runner.draw_integer(..) / draw_float(..) / draw_bool(..)
+             └─ raw draws:   runner.rng() → next_u32 / next_u64 / fill_bytes
+                             (compat wrapper: each raw call is an untyped
+                              Choice on the same tape)
+                both, per tape mode:
+                ├─ tape Off:        sample fresh (exactly today's distributions)
+                ├─ tape Recording:  sample fresh, append Choice to tape
+                └─ tape Replaying:  pop next Choice from edited tape,
+                                    clamp into current constraints,
+                                    append actual Choice to the *output* tape
+
+shrinking:   loop over passes until fixpoint / budget:
+               propose edited tape
+               re-run Strategy::new_tree in Replaying mode
+               run the test on tree.current()
+               accept iff test still fails AND output tape < best (shortlex)
+```
+
+(An earlier revision planned a final ValueTree simplify/complicate "polish"
+pass for unmigrated strategies. It was dropped during phase 1: numeric
+bisection would undo the roundness the typed passes achieve — polishing
+`2.0` back into `1.75…` — and a polished value cannot be re-expressed as a
+tape, so the two shrinkers cannot alternate. Unmigrated strategies shrink
+via raw-choice lex-lowering instead; migrating them is the durable fix.)
+
+The single load-bearing idea, copied from Conjecture: **the edited tape is a
+suggestion; the replay's output tape is the truth.** Replay re-records what
+was actually consumed, so the accepted tape is always self-consistent, and
+constraint changes mid-replay (e.g. a dependent range from `flat_map`) are
+handled by clamping rather than by rejecting the attempt.
+
+## 4. The choice IR
+
+New module `proptest/src/tape/` (name: "tape" in code, "choice tape" in
+docs).
+
+```rust
+pub(crate) enum Choice {
+    /// All integer draws, any width/signedness, stored order-preserving
+    /// in u128 "offset space" (unsigned: identity; signed: offset binary,
+    /// i.e. `(v as u128) ^ (1 << 127)`).
+    Integer {
+        value: u128,
+        min: u128,        // constraint at draw time, offset space
+        max: u128,
+        shrink_to: u128,  // usually encode(clamp(0, min, max))
+    },
+    /// All float draws; f32 widens to f64 (as in Hypothesis).
+    Float {
+        value: f64,
+        min: f64,         // -inf/+inf when unconstrained
+        max: f64,
+        allow_nan: bool,
+    },
+    Bool { value: bool },
+    /// Untyped entropy from the RngCore compat wrapper (§6): one choice
+    /// per raw RNG call. Shrink target is 0 / all-zero bytes.
+    RawU32 { value: u32 },
+    RawU64 { value: u64 },
+    RawBytes { value: Vec<u8> },  // length fixed by the fill_bytes call
+    // Later phases: Char and String choices for smarter text shrinking.
+}
+```
+
+Ordering. Each choice has a complexity key, `fn complexity(&self) -> Key`
+where `Key` is a small `Ord` enum (an integer-like `u128` key for
+`Integer`/`Float`/`Bool`/`RawU32`/`RawU64`; `(len, bytes)` for `RawBytes`):
+
+- `Integer`: zigzag distance from `shrink_to`, preferring the positive
+  direction: `0` for the target, `2*(v-t) - 1` above, `2*(t-v)` below.
+- `Float`: sign-major, then a port of Hypothesis's `float_to_lex`
+  (`conjecture/floats.py`): integer-valued floats ≤ 2^56 encode as
+  themselves; otherwise tag bit + reordered exponent table + bit-reversed
+  mantissa. This single function is what makes float shrinking produce round
+  numbers, because "smaller key" ≈ "simpler decimal". NaN keys above
+  infinity.
+- `Bool`: `value as u128`.
+- `RawU32`/`RawU64`: the value itself; `RawBytes`: length, then bytes
+  lexicographically. Untyped entropy shrinks toward zero bits, which is
+  meaningful more often than not: rand's widening-multiply `Uniform` is
+  monotone in the raw draw, so lex-lowering a raw choice lowers the sampled
+  value for most unmigrated strategies.
+
+A tape `A` is better than `B` iff `(A.len(), A.complexity_vec()) <
+(B.len(), B.complexity_vec())` — shortlex, same as Hypothesis's
+shortlex-over-choice-indices.
+
+Spans. The tape also records a span tree (start/end markers with a label),
+pushed by combinators around logical units (one collection element, one
+tuple field, one union branch). Spans drive the deletion and (later)
+reordering passes. Spans are metadata only; they do not affect replay.
+
+## 5. The recording seam: typed draws on `TestRunner`
+
+`TestRunner` ([runner.rs:71](../proptest/src/test_runner/runner.rs#L71))
+gains a tape handle:
+
+```rust
+enum TapeState {
+    Off,
+    Recording(Tape),
+    Replaying { input: Tape, cursor: usize, output: Tape, overrun: bool },
+}
+```
+
+The handle is an `Rc<RefCell<TapeState>>` shared between the runner and its
+`TestRng`, because there are two producers writing to one tape:
+
+1. **Typed draws** on `TestRunner` (below) — the quality path.
+2. **The `RngCore` compat wrapper**: `TestRng`'s `next_u32` / `next_u64` /
+   `fill_bytes` record each call as an untyped `Raw*` choice when the tape
+   is on, and pop from it when replaying. `runner.rng()` keeps its exact
+   signature (`&mut TestRng`), so every existing strategy — third-party
+   included — is tape-recorded with **zero code changes**. Migration to
+   typed draws is purely a shrink-quality upgrade, never a compatibility
+   requirement.
+
+The typed draw API (public, since strategy authors are the eventual
+audience):
+
+```rust
+impl TestRunner {
+    pub fn draw_integer_in<T: TapeInt>(&mut self, min: T, max: T) -> T;
+    pub fn draw_f64_in(&mut self, min: f64, max: f64,
+                       sample: impl FnOnce(&mut TestRng) -> f64) -> f64;
+    pub fn draw_bool(&mut self, probability_true: f64) -> bool;
+    pub fn start_span(&mut self, label: &'static str);
+    pub fn end_span(&mut self);
+}
+```
+
+`TapeInt` is a small trait over all primitive ints providing the u128
+offset-space encode/decode; `numeric_api!` in
+[num.rs](../proptest/src/num.rs) switches its `new_tree` sampling from
+`sample_uniform` to `draw_integer_in`, which in `Off`/`Recording` mode
+samples through exactly the same `rand::Uniform` path as today (identical
+distribution, identical RNG consumption), and in `Replaying` mode returns
+the recorded value clamped into `[min, max]` without touching the RNG.
+
+Floats: the range strategies pass their existing interval-splitting sampler
+([float_samplers.rs](../proptest/src/num/float_samplers.rs)) as the `sample`
+closure. `f64::Any`/`f32::Any` (class-based generation) selects its class
+via the compat wrapper (raw choices, so the class is pinned during replay)
+and then draws the assembled value through `draw_f64_in` with the
+bit-masking procedure as the `sample` closure, so the value itself is a
+typed `Float` choice that the float shrink passes can work on.
+
+Replay semantics, in order:
+
+1. Cursor past end of input → sample fresh, set `overrun = true`. The
+   shrinker discards overrun attempts without running the test, following
+   Hypothesis: they are usually junk, and skipping them keeps replay
+   bounded. (Such an attempt could occasionally be a genuinely smaller
+   failing example — the deletion passes rediscover it in aligned form.)
+2. Next choice has the right kind → clamp value into the *current*
+   constraints, consume it, append the clamped actual to `output`.
+3. Kind mismatch (tape says Float, strategy asks for Integer) → do not
+   consume; sample fresh and append. Misaligned tails are usually worse in
+   shortlex order and get discarded naturally; occasionally they jump to a
+   different failing example, which is fine — Hypothesis relies on the same
+   effect.
+
+Local rejects (`prop_filter` retries) during replay work unchanged: the
+predicate re-runs against replayed values; if the strategy ultimately
+returns `Err` (rejection budget exhausted) the attempt is discarded. This is
+what fixes the filter-stall problem: the shrinker proposes *values*, the
+filter re-vets them, and no simplify/complicate contract is involved.
+
+## 6. Unmigrated strategies: the RngCore compat wrapper
+
+Everything that still draws raw entropy via `runner.rng()` (char, string,
+regex, bits, sample, third-party strategies) goes through the compat
+wrapper: each `next_u32` / `next_u64` / `fill_bytes` call is one untyped
+`Raw*` choice on the same tape. This was originally designed as an
+RNG-reset fallback (reset the seed per attempt and hope call sequences
+align); recording raw calls as first-class choices is strictly better:
+
+- **Determinism is structural.** Unmigrated draws replay their recorded
+  values *positionally* from the tape, so a tape edit elsewhere (e.g. a
+  deleted span, a lowered integer) does not disturb them — no reliance on
+  RNG call sequences staying aligned, no fresh-randomness hazard. The case
+  seed is still reset per attempt, but only so that genuinely fresh draws
+  (overrun, kind mismatch) are reproducible for debugging.
+- **Free (if crude) shrinking.** Raw choices participate in the minimize
+  passes lexicographically. Because rand's widening-multiply `Uniform` is
+  monotone in the raw draw, lex-lowering raw choices meaningfully shrinks
+  many unmigrated strategies — this is exactly how byte-level Conjecture
+  worked before Hypothesis introduced the typed IR.
+- **Quality floor via opt-in.** While the tape engine is opt-in, nobody
+  loses shrink quality by default. Under the tape engine, an unmigrated
+  strategy's shrinking can be weaker than its ValueTree shrinking (notably
+  collections until phase 2 gives them deletion); the durable fix is
+  migration, not a hybrid polish pass (see §3 for why polish was dropped).
+
+One caveat inherited from byte-level Conjecture: a replayed raw value can
+change how many *further* raw draws a rejection-sampling loop consumes
+(rand's `Uniform` zone check, `prop_filter` retries), shifting alignment of
+the tail. Such attempts usually lose the shortlex comparison and are
+discarded; occasionally they land on a different valid candidate, which the
+acceptance rule handles. Typed migration removes the effect per strategy.
+
+This wrapper is the key to zero breakage and incremental migration.
+
+## 7. Collections: continuation encoding
+
+`vec(elem, len_range)` currently draws a size, then `size` elements
+([collection.rs](../proptest/src/collection.rs)). Deleting one element's
+span from such a tape misaligns replay (the size choice still says N).
+Hypothesis solves this with its `many` protocol; we adopt the same in tape
+mode:
+
+```
+for i in 0..max_len {
+    if i >= min_len {
+        if !draw_bool(p_continue) { break }   // one Bool choice per element
+    }
+    start_span("elem"); <generate element>; end_span();
+}
+```
+
+with `p_continue` chosen so the expected length matches the middle of
+today's uniform range (the size distribution changes from uniform to
+truncated-geometric-ish; accepted per the 2026-07-07 decision, and only in
+tape mode). Now the generic "delete span + its preceding continuation Bool"
+pass shrinks any collection, and `Bool → false` truncates it — no
+collection-specific shrinker code.
+
+Non-tape mode keeps the existing size-then-elements path and `VecValueTree`
+untouched.
+
+## 8. The shrinker
+
+`proptest/src/tape/shrink.rs`. Passes, run round-robin until a full round
+makes no progress (Hypothesis's fixpoint loop, minus its pass-scheduling
+sophistication), all bounded by the existing `max_shrink_iters` /
+`max_shrink_time` budgets (each replay+test counts as one iteration):
+
+1. `try_trivial`: one attempt with every choice at its shrink target.
+   Catches the very common "any small input fails" case in O(1).
+2. `delete_spans`: try removing each span (largest first), with the
+   adaptive exponential batching trick (try deleting 1, 2, 4, ... adjacent
+   spans) to make list shrinking O(log n) in the common case.
+3. `minimize_individual`: per choice —
+   - Integer: binary search on the complexity key toward 0 (i.e. toward
+     `shrink_to`, preferring the positive side).
+   - Float: candidate ladder first — `0.0`, `trunc(v)`, `ceil(v)`,
+     small integers near `v` — then binary search on the integer part,
+     then precision-drop by scaled rounding (port of
+     `conjecture/shrinking/floats.py`).
+   - Bool: `true → false`.
+   - Raw: lexicographic lowering (zero the value, then binary search on
+     the integer interpretation) — crude but monotone through rand's
+     `Uniform`, and all the shrinking unmigrated strategies get from the
+     tape itself.
+4. Later phases: `minimize_duplicates` (equal choices lowered together),
+   `redistribute_pairs` (shrink x while growing y for numeric pairs),
+   `reorder_spans`.
+
+Acceptance: run the test on the replayed value; accept iff it still fails
+(a `Reject` counts as not-failing, same as today's shrink loop at
+[runner.rs:859](../proptest/src/test_runner/runner.rs#L859)) and the output
+tape is shortlex-smaller than the incumbent. The existing `result_cache`
+dedups repeated identical attempts.
+
+## 9. Runner integration
+
+- `Config` gains `shrink_engine: ShrinkEngine` (`ValueTree` | `Tape`),
+  default `ValueTree` for the spike; env var `PROPTEST_SHRINK_ENGINE`.
+  Flipping the default is a later, deliberate step.
+- `gen_and_run_case` ([runner.rs:650](../proptest/src/test_runner/runner.rs#L650))
+  is the integration point (it is the innermost frame that still has the
+  `&S: Strategy`): wrap `new_tree` in `Recording` mode; on `Fail` with the
+  tape engine selected (and not under fork), call
+  `tape_shrink(strategy, seed, tape, &test)` instead of the ValueTree
+  `shrink`. The public `run_one(case, test)` (no strategy available) keeps
+  the ValueTree path unconditionally.
+- Fork mode: `shrink_engine = Tape` + `fork = true` → warn once, use
+  ValueTree path. (Future: the forkfile protocol replays pass/fail
+  decisions; the tape shrinker is deterministic given those, so the same
+  trick can work — deferred.)
+
+## 10. Persistence and fuzzer interop (later phase)
+
+Persist the winning tape alongside (then instead of) the seed: a new
+persisted form `ct1:<base64 of a simple length-prefixed serialization>`,
+parallel to the existing `Seed::PassThrough` ("pt") machinery in
+[rng.rs](../proptest/src/test_runner/rng.rs). Replaying a persisted tape is
+just the Replaying mode with no shrinking. This makes regressions survive
+strategy refactors and rand upgrades, and gives fuzzer harnesses a
+structured format to mutate (today's `PassThrough` byte interface remains
+for raw-entropy fuzzing).
+
+## 11. Generation-side upgrades (later phase, same seam)
+
+Once draws are typed, Hypothesis's generation tricks become one-line-ish
+changes inside `draw_integer_in`/`draw_f64_in`, applied uniformly to every
+strategy:
+
+- occasional "weird" values: bounds, `next_up/next_down` of bounds, ±0,
+  ±inf, NaN (where permitted), matching Hypothesis's ~5% special-value
+  injection;
+- biased integer magnitudes for wide ranges (Hypothesis now uses a
+  piecewise uniform-within-±256 / heavy-tailed-beyond distribution,
+  CDF-truncated for bounded ranges);
+- these change default distributions (approved), and are deliberately
+  sequenced *after* the shrinker exists, so any newly-found nasty failures
+  shrink well.
+
+## 12. Risks / open questions
+
+- **Replay cost.** Each shrink attempt re-runs `new_tree`. Proptest's README
+  already notes generation can be 10x QuickCheck's cost; shrink budgets
+  (`max_shrink_iters`) bound the damage, and `try_trivial` + adaptive
+  deletion keep attempt counts low. Measure on proptest's own test suite.
+- **Tape size.** Recording at the RngCore level means entropy-hungry
+  strategies (regex/string generation, large collections) produce long
+  tapes; shortlex comparison and pass iteration are O(len). Hypothesis
+  capped its buffer (8KB) for the same reason. Mitigation if it bites: a
+  soft cap on recorded choices beyond which the tape degrades to
+  seed-replay for the tail.
+- **Union/oneof branch shrinking.** The compat wrapper pins branch
+  selection during replay (it's a raw choice), but shrinking *across*
+  branches (prefer earlier `prop_oneof` arms, like today's union
+  ValueTree) needs the branch index as a typed `Integer` choice — phase 2.
+- **`Just`-heavy tapes.** Strategies that draw nothing record nothing —
+  fine; spans may be empty.
+- **u128 offset space** assumes all integer draws fit u128 — true for all
+  primitive types.
+- **f32 round-trip:** widening to f64 and clamping back must not escape
+  `[min, max]` after `as f32` narrowing; clamp in f32 space at the call
+  site.
+- **API commitment.** `draw_*` on `TestRunner` becomes public API for
+  strategy authors. Keep the surface minimal (the five methods above) and
+  document Replaying semantics as implementation-defined.
+
+## 13. Staged plan
+
+- **Phase 1 (spike, next):** `tape` module (Choice, Tape, complexity,
+  shortlex), shared `TapeState` handle, the RngCore compat wrapper in
+  `TestRng`, typed draws wired into the `numeric_api!` integer ranges +
+  `int_any!` + float range strategies + float `Any`, shrinker with
+  `try_trivial` + `minimize_individual` (integer binary search, float
+  candidate ladder + `float_to_lex` port, raw lex-lowering),
+  `ShrinkEngine` config, runner integration. Tests: round-float minimal
+  examples, filter no-stall, flat_map shrink quality, unmigrated-strategy
+  shrinking via raw choices, budget respect.
+  **Status: DONE — see `design/choice-tape-status.md`.**
+- **Phase 2:** spans; continuation encoding for `vec`/collections;
+  `delete_spans` with adaptive batching; `prop_oneof` branch choice.
+- **Phase 3:** migrate char/string/bits/sample; state-machine crate
+  evaluation.
+- **Phase 4:** cross-value passes (duplicates, redistribute, reorder).
+- **Phase 5:** tape persistence (`ct1:`), corpus reuse, fuzzer entry point.
+- **Phase 6:** generation upgrades (§11).
+- **Phase 7:** flip `shrink_engine` default to `Tape`; ValueTree path
+  remains for `run_one` and unmigrated strategies.

--- a/proptest-state-machine/src/strategy.rs
+++ b/proptest-state-machine/src/strategy.rs
@@ -240,8 +240,7 @@ impl<
                     if (self.preconditions)(&state, &tree.current()) {
                         break tree;
                     }
-                    runner
-                        .reject_local("Pre-conditions were not satisfied")?;
+                    runner.reject_local("Pre-conditions were not satisfied")?;
                 };
                 runner.end_span();
                 let transition = transition_tree.current();
@@ -1164,10 +1163,15 @@ mod test {
         // Call simplify - this should trigger the optimization
         let simplified = value_tree.simplify();
 
-        assert_eq!(value_tree.included_transitions.count(), 0,
-            "All transitions should be removed when none were seen");
-        assert!(matches!(value_tree.shrink, InitialState),
-            "Shrink should be set to InitialState when kept_count == 0");
+        assert_eq!(
+            value_tree.included_transitions.count(),
+            0,
+            "All transitions should be removed when none were seen"
+        );
+        assert!(
+            matches!(value_tree.shrink, InitialState),
+            "Shrink should be set to InitialState when kept_count == 0"
+        );
 
         // The HeapStateMachine uses Just(vec![]) for initial state, which is not shrinkable
         // So simplify() should return false, but the optimization still works correctly
@@ -1175,7 +1179,9 @@ mod test {
             "Simplification should return false since initial state (Just(vec![])) is not shrinkable");
 
         let (_, transitions, _) = value_tree.current();
-        assert!(transitions.is_empty(),
-            "No transitions should remain when none were seen");
+        assert!(
+            transitions.is_empty(),
+            "No transitions should remain when none were seen"
+        );
     }
 }

--- a/proptest-state-machine/src/strategy.rs
+++ b/proptest-state-machine/src/strategy.rs
@@ -213,25 +213,16 @@ impl<
         // transition fewer, with preconditions re-checked against the
         // re-evolved state during replay.
         if runner.tape_is_on() {
-            let extra = (end - min_size) as f64 / 2.0;
-            let p_continue = extra / (extra + 1.0);
             let mut transitions = Vec::with_capacity(min_size);
             let mut acceptable_transitions = Vec::with_capacity(min_size);
             let mut state = initial_state.current();
             let mut i = 0;
-            while i < end {
+            loop {
                 runner.start_span();
-                // Below the minimum length the flag is forced during
-                // generation (the sequence always reaches min_size), but
-                // honored during replay: the classic shrinker deletes
-                // transitions below the declared minimum too, and the
-                // tape engine must be able to match that.
-                let more = if i < min_size {
-                    runner.draw_bool_forced(true)
-                } else {
-                    runner.draw_bool(p_continue)
-                };
-                if !more {
+                // soft_minimum: the classic shrinker deletes transitions
+                // below the declared minimum too, so below-min flags are
+                // generation-forced but shrink-editable.
+                if !runner.draw_element_flag(i, min_size, end, true) {
                     runner.end_span();
                     break;
                 }
@@ -250,13 +241,6 @@ impl<
                 transitions.push(transition_tree);
                 i += 1;
             }
-            if i == end && end > 0 {
-                // Forced stop marker: maximum-length sequences must have
-                // the same tape shape as shorter ones so deletion edits
-                // stay aligned.
-                runner.record_forced_bool(false);
-            }
-
             let size = transitions.len();
             let max_ix = size.saturating_sub(1);
             return Ok(SequentialValueTree {

--- a/proptest-state-machine/src/strategy.rs
+++ b/proptest-state-machine/src/strategy.rs
@@ -203,6 +203,85 @@ impl<
         let last_valid_initial_state = initial_state.current();
 
         let (min_size, end) = self.size.start_end_incl();
+
+        // Under the choice-tape shrink engine, encode the number of
+        // transitions as one continuation flag per transition beyond the
+        // minimum, with each transition (including its flag and any
+        // precondition-rejected retries) wrapped in a deletable span.
+        // This is the same encoding as proptest's collection strategies:
+        // deleting a span replays as the same sequence with one
+        // transition fewer, with preconditions re-checked against the
+        // re-evolved state during replay.
+        if runner.tape_is_on() {
+            let extra = (end - min_size) as f64 / 2.0;
+            let p_continue = extra / (extra + 1.0);
+            let mut transitions = Vec::with_capacity(min_size);
+            let mut acceptable_transitions = Vec::with_capacity(min_size);
+            let mut state = initial_state.current();
+            let mut i = 0;
+            while i < end {
+                runner.start_span();
+                // Below the minimum length the flag is forced during
+                // generation (the sequence always reaches min_size), but
+                // honored during replay: the classic shrinker deletes
+                // transitions below the declared minimum too, and the
+                // tape engine must be able to match that.
+                let more = if i < min_size {
+                    runner.draw_bool_forced(true)
+                } else {
+                    runner.draw_bool(p_continue)
+                };
+                if !more {
+                    runner.end_span();
+                    break;
+                }
+                let transition_tree = loop {
+                    let tree = (self.transitions)(&state).new_tree(runner)?;
+                    if (self.preconditions)(&state, &tree.current()) {
+                        break tree;
+                    }
+                    runner
+                        .reject_local("Pre-conditions were not satisfied")?;
+                };
+                runner.end_span();
+                let transition = transition_tree.current();
+                state = (self.next)(state, &transition);
+                acceptable_transitions
+                    .push((TransitionState::Accepted, transition));
+                transitions.push(transition_tree);
+                i += 1;
+            }
+            if i == end && end > 0 {
+                // Forced stop marker: maximum-length sequences must have
+                // the same tape shape as shorter ones so deletion edits
+                // stay aligned.
+                runner.record_forced_bool(false);
+            }
+
+            let size = transitions.len();
+            let max_ix = size.saturating_sub(1);
+            return Ok(SequentialValueTree {
+                initial_state,
+                is_initial_state_shrinkable: true,
+                last_valid_initial_state,
+                preconditions: self.preconditions.clone(),
+                next: self.next.clone(),
+                transitions,
+                acceptable_transitions,
+                included_transitions: VarBitSet::saturated(size),
+                shrinkable_transitions: VarBitSet::saturated(size),
+                max_ix,
+                shrink: Shrink::DeleteTransition(max_ix),
+                last_shrink: None,
+                // The seen-transitions counter drives the ValueTree
+                // shrinker's delete-unseen optimization; the tape engine
+                // deletes via spans instead, and re-reads `current()`
+                // after the test has already consumed transitions, so
+                // the counter must be disabled here.
+                seen_transitions_counter: None,
+            });
+        }
+
         // Sample the maximum number of the transitions from the size range
         let max_size = sample_uniform_incl(runner, min_size, end);
         let mut transitions = Vec::with_capacity(max_size);
@@ -1041,18 +1120,8 @@ mod test {
                 // We need to explicitly run create a runner so that we can
                 // inspect the output, and determine if it does return an input that
                 // should fail, and is minimal.
-                // State-machine strategies rely on their hand-written
-                // ValueTree shrinker (transition deletion, initial-state
-                // shrinking), which the choice-tape engine cannot yet
-                // match for unmigrated strategies; pin the classic
-                // engine until the sequential strategy records typed
-                // choices and spans.
-                let config = Config {
-                    shrink_engine: proptest::test_runner::ShrinkEngine::ValueTree,
-                    ..Config::default()
-                };
                 let mut runner = TestRunner::new_with_rng(
-                    config, TestRng::from_seed(Default::default(), &seed));
+                    Config::default(), TestRng::from_seed(Default::default(), &seed));
                 let result = runner.run(
                     &FailIfLessThan::sequential_strategy(10..50_usize),
                     |(ref_state, transitions, seen_counter)| {

--- a/proptest-state-machine/src/strategy.rs
+++ b/proptest-state-machine/src/strategy.rs
@@ -19,7 +19,7 @@ use proptest::std_facade::fmt::{Debug, Formatter, Result};
 use proptest::std_facade::Vec;
 use proptest::strategy::BoxedStrategy;
 use proptest::strategy::{NewTree, Strategy, ValueTree};
-use proptest::test_runner::TestRunner;
+use proptest::test_runner::{ElementMinimum, TestRunner};
 
 /// This trait is used to model system under test as an abstract state machine.
 ///
@@ -222,7 +222,12 @@ impl<
                 // soft_minimum: the classic shrinker deletes transitions
                 // below the declared minimum too, so below-min flags are
                 // generation-forced but shrink-editable.
-                if !runner.draw_element_flag(i, min_size, end, true) {
+                if !runner.draw_element_flag(
+                    i,
+                    min_size,
+                    end,
+                    ElementMinimum::Soft,
+                ) {
                     runner.end_span();
                     break;
                 }

--- a/proptest-state-machine/src/strategy.rs
+++ b/proptest-state-machine/src/strategy.rs
@@ -1041,8 +1041,18 @@ mod test {
                 // We need to explicitly run create a runner so that we can
                 // inspect the output, and determine if it does return an input that
                 // should fail, and is minimal.
+                // State-machine strategies rely on their hand-written
+                // ValueTree shrinker (transition deletion, initial-state
+                // shrinking), which the choice-tape engine cannot yet
+                // match for unmigrated strategies; pin the classic
+                // engine until the sequential strategy records typed
+                // choices and spans.
+                let config = Config {
+                    shrink_engine: proptest::test_runner::ShrinkEngine::ValueTree,
+                    ..Config::default()
+                };
                 let mut runner = TestRunner::new_with_rng(
-                    Config::default(), TestRng::from_seed(Default::default(), &seed));
+                    config, TestRng::from_seed(Default::default(), &seed));
                 let result = runner.run(
                     &FailIfLessThan::sequential_strategy(10..50_usize),
                     |(ref_state, transitions, seen_counter)| {

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -29,8 +29,22 @@
   edge cases like issue #500's `total_count % count == 0` are found
   reliably instead of essentially never. Float draws occasionally inject
   boundary and special values (bounds, one ulp inside the bounds, plus
-  or minus zero and one, simple fractions, NaN where allowed). Tests
-  that depended on the old uniform distributions may need adjusting.
+  or minus zero and one, simple fractions, NaN where allowed). These
+  generation changes apply regardless of the configured shrink engine;
+  selecting `ShrinkEngine::ValueTree` does not restore the old uniform
+  distributions. Tests that depended on them may need adjusting.
+- Under the tape engine (only), collection and state-machine sequence
+  lengths are encoded as per-element continuation flags, changing the
+  length distribution from uniform over the size range to a
+  truncated-geometric shape with the same order of mean: short lengths
+  and the exact maximum become more likely, upper-middle lengths less
+  likely. Length-sensitive properties may want explicit size ranges.
+- Because generation consumes randomness differently than before, RNG
+  seed entries in existing regression files (`xs`/`cc` lines) still
+  parse but generally regenerate different values than the failure they
+  were saved for; delete them or re-trigger the failures to repopulate.
+  Tape entries (`ct1` lines, the new default) do not have this problem:
+  they replay the recorded values themselves.
 
 ### Bug Fixes
 

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -20,14 +20,17 @@
   in the regression file instead of RNG seeds. Replaying a tape
   regenerates the exact shrunken values, independent of RNG algorithm and
   robust to strategy refactors. Old seed entries are still understood.
-- Numeric generation now hunts edge cases, after Hypothesis: wide integer
-  ranges mostly produce values within a small random bit-size of the
-  shrink target with occasional exact bounds and a uniform tail (e.g.
-  `any::<i64>()` now actually generates `i64::MIN`); float draws
-  occasionally inject boundary and special values (bounds, one ulp inside
-  the bounds, plus/minus zero and one, simple fractions, NaN where
-  allowed). Tests that depended on the old uniform distributions may need
-  adjusting.
+- Numeric generation now hunts edge cases, after Hypothesis: integer
+  ranges of any width occasionally produce exact boundary values (min,
+  max, one inside each bound, the shrink target and its successor), and
+  wide ranges (over 24 bits) additionally produce mostly values within a
+  small random bit-size of the shrink target, keeping a uniform tail.
+  `any::<i64>()` now actually generates `i64::MIN`, and divisibility
+  edge cases like issue #500's `total_count % count == 0` are found
+  reliably instead of essentially never. Float draws occasionally inject
+  boundary and special values (bounds, one ulp inside the bounds, plus
+  or minus zero and one, simple fractions, NaN where allowed). Tests
+  that depended on the old uniform distributions may need adjusting.
 
 ### Bug Fixes
 

--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -3,12 +3,45 @@
 ### Breaking Changes
 
 - The minimum supported Rust version has been increased to 1.86.0.
+- The default shrink engine is now the Conjecture-style choice tape
+  (`Config::shrink_engine = ShrinkEngine::Tape`). Generation is recorded
+  as a tape of typed choices; shrinking edits the tape and re-runs
+  generation. Compared to the classic `ValueTree` shrinker this produces
+  rounder minimal values (a float threshold failure shrinks to `2.0`
+  instead of an arbitrary long fraction, or often not shrinking at all),
+  does not get stuck on `prop_filter`, shrinks cleanly through
+  `prop_flat_map`, deletes collection elements via a generic span pass,
+  and has cross-value passes (redistributing weight between numeric
+  choices, lowering equal choices together). Set
+  `ShrinkEngine::ValueTree` or `PROPTEST_SHRINK_ENGINE=valuetree` to get
+  the old shrinker. `fork`/`timeout` configurations still use the
+  `ValueTree` engine.
+- Failures shrunk by the tape engine persist as `ct1` choice-tape entries
+  in the regression file instead of RNG seeds. Replaying a tape
+  regenerates the exact shrunken values, independent of RNG algorithm and
+  robust to strategy refactors. Old seed entries are still understood.
+- Numeric generation now hunts edge cases, after Hypothesis: wide integer
+  ranges mostly produce values within a small random bit-size of the
+  shrink target with occasional exact bounds and a uniform tail (e.g.
+  `any::<i64>()` now actually generates `i64::MIN`); float draws
+  occasionally inject boundary and special values (bounds, one ulp inside
+  the bounds, plus/minus zero and one, simple fractions, NaN where
+  allowed). Tests that depended on the old uniform distributions may need
+  adjusting.
 
 ### Bug Fixes
 
 - Fixed a panic when sampling from a single-point inclusive float range like `0.0..=0.0`. ([\#479](https://github.com/proptest-rs/proptest/issues/479))
 - [Soundness] Asserts that rdrand feature is supported by the CPU before invoking rdrand functions ([\#648](https://github.com/proptest-rs/proptest/issues/648))
 - [Soundness] Fixes data race on static mut between assigning thread and accessing thread ([\#648](https://github.com/proptest-rs/proptest/issues/648))
+- `Arbitrary for Duration` no longer panics when generating `u64::MAX`
+  seconds together with nanoseconds that carry over (found immediately by
+  the edge-case-biased generator).
+
+### New Features
+
+- `Config::shrink_engine` / `PROPTEST_SHRINK_ENGINE` select between the
+  choice-tape and ValueTree shrink engines.
 
 ### Other Notes
 

--- a/proptest/examples/shrink-quality.rs
+++ b/proptest/examples/shrink-quality.rs
@@ -67,7 +67,8 @@ fn compare<S: Strategy>(
 ) where
     S::Value: Debug,
 {
-    let (vt_value, vt_calls) = run_case(ShrinkEngine::ValueTree, &strategy, &fail);
+    let (vt_value, vt_calls) =
+        run_case(ShrinkEngine::ValueTree, &strategy, &fail);
     let (tp_value, tp_calls) = run_case(ShrinkEngine::Tape, &strategy, &fail);
     println!("{}", name);
     println!("  valuetree: {:<40} ({} test calls)", vt_value, vt_calls);

--- a/proptest/examples/shrink-quality.rs
+++ b/proptest/examples/shrink-quality.rs
@@ -1,0 +1,148 @@
+//-
+// Copyright 2026 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Side-by-side comparison of the ValueTree and choice-tape shrink
+//! engines: same strategies, same failure predicates, same RNG seed.
+//! Prints the minimal counterexample each engine finds and how many
+//! times it ran the test function (generation + shrinking).
+//!
+//! Run with: cargo run --example shrink-quality
+
+use std::cell::Cell;
+use std::fmt::Debug;
+
+use proptest::prelude::*;
+use proptest::test_runner::{
+    Config, RngAlgorithm, ShrinkEngine, TestError, TestRng, TestRunner,
+};
+
+const SEED: [u8; 32] = [
+    0x5e, 0xed, 0x5e, 0xed, 0x5e, 0xed, 0x5e, 0xed, 0x5e, 0xed, 0x5e, 0xed,
+    0x5e, 0xed, 0x5e, 0xed, 0x5e, 0xed, 0x5e, 0xed, 0x5e, 0xed, 0x5e, 0xed,
+    0x5e, 0xed, 0x5e, 0xed, 0x5e, 0xed, 0x5e, 0xed,
+];
+
+fn run_case<S: Strategy>(
+    engine: ShrinkEngine,
+    strategy: &S,
+    fail: &impl Fn(&S::Value) -> bool,
+) -> (String, u64)
+where
+    S::Value: Debug,
+{
+    let calls = Cell::new(0u64);
+    let mut runner = TestRunner::new_with_rng(
+        Config {
+            shrink_engine: engine,
+            failure_persistence: None,
+            ..Config::default()
+        },
+        TestRng::from_seed(RngAlgorithm::ChaCha, &SEED),
+    );
+    let result = runner.run(strategy, |v| {
+        calls.set(calls.get() + 1);
+        if fail(&v) {
+            Err(TestCaseError::fail("dogfood failure"))
+        } else {
+            Ok(())
+        }
+    });
+    match result {
+        Err(TestError::Fail(_, value)) => (format!("{:?}", value), calls.get()),
+        Err(other) => (format!("ABORT: {:?}", other), calls.get()),
+        Ok(()) => ("NO FAILURE FOUND".to_owned(), calls.get()),
+    }
+}
+
+fn compare<S: Strategy>(
+    name: &str,
+    strategy: S,
+    fail: impl Fn(&S::Value) -> bool,
+) where
+    S::Value: Debug,
+{
+    let (vt_value, vt_calls) = run_case(ShrinkEngine::ValueTree, &strategy, &fail);
+    let (tp_value, tp_calls) = run_case(ShrinkEngine::Tape, &strategy, &fail);
+    println!("{}", name);
+    println!("  valuetree: {:<40} ({} test calls)", vt_value, vt_calls);
+    println!("  tape:      {:<40} ({} test calls)", tp_value, tp_calls);
+    println!();
+}
+
+fn main() {
+    compare("f64 in 0.0..10.0, fail iff v >= 1.7", 0.0f64..10.0, |v| {
+        *v >= 1.7
+    });
+
+    compare(
+        "any-class f64, fail iff finite && v >= 1.7",
+        proptest::num::f64::ANY,
+        |v| v.is_finite() && *v >= 1.7,
+    );
+
+    compare(
+        "i64 in 0..1_000_000, fail iff v >= 123_457",
+        0i64..1_000_000,
+        |v| *v >= 123_457,
+    );
+
+    compare(
+        "pair (0..1000, 0..1000), fail iff a + b >= 100",
+        (0i32..1000, 0i32..1000),
+        |(a, b)| a + b >= 100,
+    );
+
+    compare(
+        "vec(0..100, 0..20), fail iff len >= 3",
+        proptest::collection::vec(0i32..100, 0..20),
+        |v| v.len() >= 3,
+    );
+
+    compare(
+        "vec(0..100, 0..20), fail iff sum >= 50",
+        proptest::collection::vec(0i32..100, 0..20),
+        |v| v.iter().sum::<i32>() >= 50,
+    );
+
+    compare(
+        "(0..1000).prop_filter(even), fail iff v >= 100",
+        (0i32..1000).prop_filter("even", |v| 0 == v % 2),
+        |v| *v >= 100,
+    );
+
+    compare(
+        "(1..=5).prop_flat_map(|n| 0..n*100), fail iff v >= 57",
+        (1i32..=5).prop_flat_map(|n| 0..n * 100),
+        |v| *v >= 57,
+    );
+
+    compare(
+        "prop_oneof![10..20, 100..200], fail always",
+        prop_oneof![10i32..20, 100i32..200],
+        |_| true,
+    );
+
+    compare(
+        "char in 'a'..='z', fail iff c >= 'd'",
+        proptest::char::range('a', 'z'),
+        |c| *c >= 'd',
+    );
+
+    compare(
+        "string from [a-z]{0,20}, fail iff len >= 3",
+        proptest::string::string_regex("[a-z]{0,20}").unwrap(),
+        |s| s.len() >= 3,
+    );
+
+    compare(
+        "btree_map(0..100 -> 0..100, 0..10), fail iff len >= 2",
+        proptest::collection::btree_map(0i32..100, 0i32..100, 0..10),
+        |m| m.len() >= 2,
+    );
+}

--- a/proptest/examples/shrink-quality.rs
+++ b/proptest/examples/shrink-quality.rs
@@ -124,6 +124,15 @@ fn main() {
     );
 
     compare(
+        "matrix (1..=8, 1..=8) flat_map r*c vec (issue #181), fail iff any elem >= 10",
+        (1usize..=8, 1usize..=8).prop_flat_map(|(r, c)| {
+            proptest::collection::vec(0i32..1000, r * c)
+                .prop_map(move |data| (r, c, data))
+        }),
+        |(_, _, data)| data.iter().any(|&x| x >= 10),
+    );
+
+    compare(
         "prop_oneof![10..20, 100..200], fail always",
         prop_oneof![10i32..20, 100i32..200],
         |_| true,

--- a/proptest/src/arbitrary/_std/time.rs
+++ b/proptest/src/arbitrary/_std/time.rs
@@ -17,7 +17,13 @@ use crate::num;
 use crate::strategy::statics::{self, static_map};
 
 arbitrary!(Duration, SMapped<(u64, u32), Self>;
-    static_map(any::<(u64, u32)>(), |(a, b)| Duration::new(a, b))
+    static_map(any::<(u64, u32)>(), |(a, b)| {
+        // Duration::new panics when carrying whole seconds out of `b`
+        // overflows the seconds counter. (Found by the edge-case-biased
+        // generator, which actually produces u64::MAX seconds.)
+        let b = if a >= u64::MAX - 4 { b % 1_000_000_000 } else { b };
+        Duration::new(a, b)
+    })
 );
 
 // Instant::now() "never" returns the same Instant, so no shrinking may occur!

--- a/proptest/src/bool.rs
+++ b/proptest/src/bool.rs
@@ -12,8 +12,6 @@
 use crate::strategy::*;
 use crate::test_runner::*;
 
-use rand::RngExt;
-
 /// The type of the `ANY` constant.
 #[derive(Clone, Copy, Debug)]
 pub struct Any(());
@@ -28,7 +26,11 @@ impl Strategy for Any {
     type Value = bool;
 
     fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-        Ok(BoolValueTree::new(runner.rng().random()))
+        // A typed choice so the tape engine shrinks toward `false`. The
+        // raw fallback would depend on the sampler's bit mapping (rand's
+        // Bernoulli maps a zeroed u64 to `true`, inverting the shrink
+        // direction).
+        Ok(BoolValueTree::new(runner.draw_bool(0.5)))
     }
 }
 
@@ -50,7 +52,7 @@ impl Strategy for Weighted {
     type Value = bool;
 
     fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-        Ok(BoolValueTree::new(runner.rng().random_bool(self.0)))
+        Ok(BoolValueTree::new(runner.draw_bool(self.0)))
     }
 }
 

--- a/proptest/src/char.rs
+++ b/proptest/src/char.rs
@@ -257,8 +257,7 @@ impl<'a> Strategy for CharStrategy<'a> {
         if runner.tape_is_on() {
             let global_min =
                 self.ranges.iter().map(|r| *r.start() as u32).min();
-            let global_max =
-                self.ranges.iter().map(|r| *r.end() as u32).max();
+            let global_max = self.ranges.iter().map(|r| *r.end() as u32).max();
             let (global_min, global_max) = match (global_min, global_max) {
                 (Some(lo), Some(hi)) => (lo, hi),
                 _ => panic!("CharStrategy with no ranges"),
@@ -272,12 +271,8 @@ impl<'a> Strategy for CharStrategy<'a> {
                 |v| shrink_bottom(v, base_of(v, ranges)),
                 |v| conform_to_ranges(v, ranges),
                 |r| {
-                    let (base, offset) = select_range_index(
-                        r.rng(),
-                        special,
-                        preferred,
-                        ranges,
-                    );
+                    let (base, offset) =
+                        select_range_index(r.rng(), special, preferred, ranges);
                     base + offset
                 },
             );

--- a/proptest/src/char.rs
+++ b/proptest/src/char.rs
@@ -250,6 +250,43 @@ impl<'a> Strategy for CharStrategy<'a> {
     type Value = char;
 
     fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+        // Under the tape shrink engine, the selected character is one
+        // typed integer choice whose shrink target is the same "bottom"
+        // the ValueTree uses; the conform hook keeps shrink proposals
+        // inside the union of ranges (and off the surrogate hole).
+        if runner.tape_is_on() {
+            let global_min =
+                self.ranges.iter().map(|r| *r.start() as u32).min();
+            let global_max =
+                self.ranges.iter().map(|r| *r.end() as u32).max();
+            let (global_min, global_max) = match (global_min, global_max) {
+                (Some(lo), Some(hi)) => (lo, hi),
+                _ => panic!("CharStrategy with no ranges"),
+            };
+            let special = &self.special;
+            let preferred = &self.preferred;
+            let ranges = &self.ranges;
+            let start = runner.draw_integer_in_with(
+                global_min,
+                global_max,
+                |v| shrink_bottom(v, base_of(v, ranges)),
+                |v| conform_to_ranges(v, ranges),
+                |r| {
+                    let (base, offset) = select_range_index(
+                        r.rng(),
+                        special,
+                        preferred,
+                        ranges,
+                    );
+                    base + offset
+                },
+            );
+            let bottom = shrink_bottom(start, base_of(start, &self.ranges));
+            return Ok(CharValueTree {
+                value: num::u32::BinarySearch::new_above(bottom, start),
+            });
+        }
+
         let (base, offset) = select_range_index(
             runner.rng(),
             &self.special,
@@ -259,24 +296,76 @@ impl<'a> Strategy for CharStrategy<'a> {
 
         // Select a minimum point more convenient than 0
         let start = base + offset;
-        let bottom = if start >= '¡' as u32 && base < '¡' as u32 {
-            '¡' as u32
-        } else if start >= 'a' as u32 && base < 'a' as u32 {
-            'a' as u32
-        } else if start >= 'A' as u32 && base < 'A' as u32 {
-            'A' as u32
-        } else if start >= '0' as u32 && base < '0' as u32 {
-            '0' as u32
-        } else if start >= ' ' as u32 && base < ' ' as u32 {
-            ' ' as u32
-        } else {
-            base
-        };
+        let bottom = shrink_bottom(start, base);
 
         Ok(CharValueTree {
             value: num::u32::BinarySearch::new_above(bottom, start),
         })
     }
+}
+
+/// The hard-wired ASCII-oriented shrink floor: the highest of the
+/// convenient simplification targets that lies in `(base, start]`.
+fn shrink_bottom(start: u32, base: u32) -> u32 {
+    if start >= '¡' as u32 && base < '¡' as u32 {
+        '¡' as u32
+    } else if start >= 'a' as u32 && base < 'a' as u32 {
+        'a' as u32
+    } else if start >= 'A' as u32 && base < 'A' as u32 {
+        'A' as u32
+    } else if start >= '0' as u32 && base < '0' as u32 {
+        '0' as u32
+    } else if start >= ' ' as u32 && base < ' ' as u32 {
+        ' ' as u32
+    } else {
+        base
+    }
+}
+
+/// The start of the first range containing `v`, mirroring the `in_range`
+/// lookup used during selection. Falls back to `v` itself when `v` is not
+/// in any range (`shrink_bottom` then degenerates to `v`).
+fn base_of(v: u32, ranges: &[CharRange]) -> u32 {
+    ranges
+        .iter()
+        .find(|r| v >= *r.start() as u32 && v <= *r.end() as u32)
+        .map(|r| *r.start() as u32)
+        .unwrap_or(v)
+}
+
+/// Map an arbitrary code-point proposal to the nearest value inside the
+/// union of `ranges` that is a valid `char`.
+fn conform_to_ranges(v: u32, ranges: &[CharRange]) -> u32 {
+    fn fix_surrogate(c: u32, lo: u32, hi: u32) -> Option<u32> {
+        if ::core::char::from_u32(c).is_some() {
+            return Some(c);
+        }
+        // c is in the surrogate hole D800..=DFFF (the only invalid
+        // region below MAX); move to whichever side of it stays in
+        // [lo, hi].
+        if lo <= 0xD7FF {
+            Some(0xD7FF.min(hi).max(lo))
+        } else if hi >= 0xE000 {
+            Some(0xE000.max(lo).min(hi))
+        } else {
+            None
+        }
+    }
+
+    let mut best: Option<(u32, u32)> = None;
+    for range in ranges {
+        let lo = *range.start() as u32;
+        let hi = *range.end() as u32;
+        let clamped = v.clamp(lo, hi);
+        if let Some(fixed) = fix_surrogate(clamped, lo, hi) {
+            let distance = fixed.max(v) - fixed.min(v);
+            if best.map_or(true, |(d, _)| distance < d) {
+                best = Some((distance, fixed));
+            }
+        }
+    }
+    best.map(|(_, val)| val)
+        .unwrap_or_else(|| *ranges[0].start() as u32)
 }
 
 impl CharValueTree {

--- a/proptest/src/collection.rs
+++ b/proptest/src/collection.rs
@@ -576,6 +576,13 @@ impl<T: Strategy> Strategy for VecStrategy<T> {
                 elements.push(element?);
                 i += 1;
             }
+            if i == end && end > start {
+                // A maximum-length vec never draws a "stop" flag, which
+                // would leave its tape one Bool shorter than shorter
+                // vecs' tapes and misalign every deletion edit. Record a
+                // forced stop marker so all lengths share one shape.
+                runner.record_forced_bool(false);
+            }
             let len = elements.len();
             return Ok(VecValueTree {
                 elements,

--- a/proptest/src/collection.rs
+++ b/proptest/src/collection.rs
@@ -551,6 +551,41 @@ impl<T: Strategy> Strategy for VecStrategy<T> {
 
     fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let (start, end) = self.size.start_end_incl();
+
+        // Under the tape shrink engine, encode the length as one
+        // continuation flag per element beyond the minimum (Hypothesis's
+        // "many" protocol) instead of an up-front size. This makes each
+        // element (with its flag) an independently deletable span:
+        // removing one replays cleanly as "the same vec, one element
+        // shorter", and flags shrink to false, truncating the tail. The
+        // length distribution becomes truncated-geometric with the same
+        // mean instead of uniform.
+        if runner.tape_is_on() {
+            let extra = (end - start) as f64 / 2.0;
+            let p_continue = extra / (extra + 1.0);
+            let mut elements = Vec::with_capacity(start);
+            let mut i = 0;
+            while i < end {
+                runner.start_span();
+                if i >= start && !runner.draw_bool(p_continue) {
+                    runner.end_span();
+                    break;
+                }
+                let element = self.element.new_tree(runner);
+                runner.end_span();
+                elements.push(element?);
+                i += 1;
+            }
+            let len = elements.len();
+            return Ok(VecValueTree {
+                elements,
+                included_elements: VarBitSet::saturated(len),
+                min_size: start,
+                shrink: Shrink::DeleteElement(0),
+                prev_shrink: None,
+            });
+        }
+
         let max_size = sample_uniform_incl(runner, start, end);
         let mut elements = Vec::with_capacity(max_size);
         while elements.len() < max_size {

--- a/proptest/src/collection.rs
+++ b/proptest/src/collection.rs
@@ -565,7 +565,12 @@ impl<T: Strategy> Strategy for VecStrategy<T> {
             let mut i = 0;
             loop {
                 runner.start_span();
-                if !runner.draw_element_flag(i, start, end, false) {
+                if !runner.draw_element_flag(
+                    i,
+                    start,
+                    end,
+                    ElementMinimum::Hard,
+                ) {
                     runner.end_span();
                     break;
                 }

--- a/proptest/src/collection.rs
+++ b/proptest/src/collection.rs
@@ -561,13 +561,11 @@ impl<T: Strategy> Strategy for VecStrategy<T> {
         // length distribution becomes truncated-geometric with the same
         // mean instead of uniform.
         if runner.tape_is_on() {
-            let extra = (end - start) as f64 / 2.0;
-            let p_continue = extra / (extra + 1.0);
             let mut elements = Vec::with_capacity(start);
             let mut i = 0;
-            while i < end {
+            loop {
                 runner.start_span();
-                if i >= start && !runner.draw_bool(p_continue) {
+                if !runner.draw_element_flag(i, start, end, false) {
                     runner.end_span();
                     break;
                 }
@@ -575,13 +573,6 @@ impl<T: Strategy> Strategy for VecStrategy<T> {
                 runner.end_span();
                 elements.push(element?);
                 i += 1;
-            }
-            if i == end && end > start {
-                // A maximum-length vec never draws a "stop" flag, which
-                // would leave its tape one Bool shorter than shorter
-                // vecs' tapes and misalign every deletion edit. Record a
-                // forced stop marker so all lengths share one shape.
-                runner.record_forced_bool(false);
             }
             let len = elements.len();
             return Ok(VecValueTree {

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -1183,6 +1183,38 @@ mod test {
     }
 
     #[test]
+    fn finds_divisibility_edge_case_from_upstream_issue_500() {
+        // https://github.com/proptest-rs/proptest/issues/500: a paging
+        // computation `total_count / count + 1` is wrong exactly when
+        // `total_count % count == 0`, and uniform generation over these
+        // ranges essentially never produces a multiple (P per case is
+        // about 1e-4). Boundary injection produces `total_count == 0`
+        // (a multiple of everything) and `count == 1` (divides
+        // everything) constantly, so the bug is found reliably, and the
+        // failure shrinks to the minimal witness (0, 1).
+        let mut runner = TestRunner::new_with_rng(
+            Config {
+                failure_persistence: None,
+                ..Config::default()
+            },
+            TestRng::deterministic_rng(RngAlgorithm::default()),
+        );
+        match runner.run(
+            &(0usize..1_000_000, 1usize..100_000),
+            |(total_count, count)| {
+                if 0 == total_count % count {
+                    Err(TestCaseError::fail("get_total_pages off by one"))
+                } else {
+                    Ok(())
+                }
+            },
+        ) {
+            Err(TestError::Fail(_, value)) => assert_eq!((0, 1), value),
+            other => panic!("issue 500 bug was not found: {:?}", other),
+        }
+    }
+
+    #[test]
     fn any_biases_toward_small_magnitudes() {
         let mut runner = TestRunner::new_with_rng(
             Config {

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -107,8 +107,32 @@ macro_rules! int_any {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-                // One typed choice when the tape is on; the closure is the
-                // unchanged upstream sampling path when it is off.
+                Ok(BinarySearch::new(runner.draw_integer_in_biased(
+                    <$typ>::MIN,
+                    <$typ>::MAX,
+                    |r| $int_any!(r, $typ),
+                )))
+            }
+        }
+
+        /// Like `Any`, but strictly uniform over the whole range.
+        /// Crate-internal: for draws whose value is positional (a
+        /// fraction of a collection, like `sample::Index`) rather than a
+        /// magnitude, where edge-case biasing would skew what gets
+        /// selected instead of making values more interesting.
+        #[derive(Clone, Copy, Debug)]
+        #[must_use = "strategies do nothing unless used"]
+        #[allow(dead_code)]
+        pub(crate) struct AnyUniform(());
+
+        #[allow(dead_code)]
+        pub(crate) const ANY_UNIFORM: AnyUniform = AnyUniform(());
+
+        impl Strategy for AnyUniform {
+            type Tree = BinarySearch;
+            type Value = $typ;
+
+            fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 Ok(BinarySearch::new(runner.draw_integer_in(
                     <$typ>::MIN,
                     <$typ>::MAX,
@@ -117,20 +141,20 @@ macro_rules! int_any {
             }
         }
 
-        /// Tape-aware uniform sample from `[lo, hi)`.
+        /// Tape-aware, edge-case-biased sample from `[lo, hi)`.
         fn tape_sample(
             runner: &mut TestRunner,
             lo: $typ,
             hi: $typ,
         ) -> $typ {
             assert!(lo < hi, "Uniform::new called with `low >= high`");
-            runner.draw_integer_in(lo, hi - 1, |r| {
+            runner.draw_integer_in_biased(lo, hi - 1, |r| {
                 $crate::num::$uniform::<$typ>(r, lo.into(), hi.into())
                     .into()
             })
         }
 
-        /// Tape-aware uniform sample from `[lo, hi]`.
+        /// Tape-aware, edge-case-biased sample from `[lo, hi]`.
         fn tape_sample_incl(
             runner: &mut TestRunner,
             lo: $typ,
@@ -140,7 +164,7 @@ macro_rules! int_any {
                 lo <= hi,
                 "Uniform::new_inclusive called with `low > high`"
             );
-            runner.draw_integer_in(lo, hi, |r| {
+            runner.draw_integer_in_biased(lo, hi, |r| {
                 $crate::num::$incl::<$typ>(r, lo.into(), hi.into()).into()
             })
         }
@@ -852,13 +876,14 @@ macro_rules! float_bin_search {
                     Subnormal => allowed.contains(FloatTypes::SUBNORMAL),
                     Normal => allowed.contains(FloatTypes::NORMAL),
                 };
-                let signum = v.signum();
-                let sign_allowed = if signum > 0.0 {
-                    allowed.contains(FloatTypes::POSITIVE)
-                } else if signum < 0.0 {
+                // Check the sign bit directly so that NaNs (whose signum
+                // is NaN) are sign-checked too; the generator masks NaN
+                // sign bits to match the flags, and conform_to_types must
+                // hold shrink proposals to the same standard.
+                let sign_allowed = if v.is_sign_negative() {
                     allowed.contains(FloatTypes::NEGATIVE)
                 } else {
-                    true
+                    allowed.contains(FloatTypes::POSITIVE)
                 };
 
                 class_allowed && sign_allowed
@@ -894,14 +919,21 @@ macro_rules! float_bin_search {
                     return sign * ::core::$typ::INFINITY;
                 }
                 if allowed.contains(FloatTypes::QUIET_NAN) {
-                    return ::core::$typ::NAN;
+                    return if sign < 0.0 {
+                        -::core::$typ::NAN
+                    } else {
+                        ::core::$typ::NAN
+                    };
                 }
                 // Signaling NaN only: same construction as in
                 // `Any::new_tree`.
                 let quiet_or = ::core::$typ::NAN.to_bits()
                     & ($typ::EXP_MASK | ($typ::EXP_MASK >> 1));
-                let signaling =
+                let mut signaling =
                     (quiet_or ^ ($typ::EXP_MASK >> 1)) | $typ::EXP_MASK | 1;
+                if sign < 0.0 {
+                    signaling |= $typ::SIGN_MASK;
+                }
                 $typ::from_bits(signaling)
             }
 
@@ -1124,6 +1156,77 @@ mod test {
     use crate::test_runner::*;
 
     use super::*;
+
+    #[test]
+    fn any_finds_extreme_values() {
+        // The README used to cite `abs(i64::MIN)` as a bug property
+        // testing would "virtually always" miss, because uniform
+        // sampling cannot hit one value out of 2^64. The edge-case-biased
+        // generator produces boundary values deliberately.
+        let mut runner = TestRunner::new_with_rng(
+            Config {
+                failure_persistence: None,
+                ..Config::default()
+            },
+            TestRng::deterministic_rng(RngAlgorithm::default()),
+        );
+        match runner.run(&super::i64::ANY, |v| {
+            if i64::MIN == v {
+                Err(TestCaseError::fail("hit i64::MIN"))
+            } else {
+                Ok(())
+            }
+        }) {
+            Err(TestError::Fail(_, value)) => assert_eq!(i64::MIN, value),
+            other => panic!("i64::MIN was not found: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn any_biases_toward_small_magnitudes() {
+        let mut runner = TestRunner::new_with_rng(
+            Config {
+                failure_persistence: None,
+                ..Config::default()
+            },
+            TestRng::deterministic_rng(RngAlgorithm::default()),
+        );
+        let mut small = 0;
+        for _ in 0..512 {
+            let v = super::i64::ANY
+                .new_tree(&mut runner)
+                .unwrap()
+                .current();
+            if v.unsigned_abs() < (1 << 16) {
+                small += 1;
+            }
+        }
+        assert!(
+            small > 512 * 3 / 10,
+            "only {}/512 samples were small",
+            small
+        );
+    }
+
+    #[test]
+    fn float_ranges_inject_boundary_values() {
+        let mut runner = TestRunner::new_with_rng(
+            Config {
+                failure_persistence: None,
+                ..Config::default()
+            },
+            TestRng::deterministic_rng(RngAlgorithm::default()),
+        );
+        let mut hit_max = false;
+        for _ in 0..4000 {
+            let v = (1.5f64..=8.5).new_tree(&mut runner).unwrap().current();
+            assert!(v >= 1.5 && v <= 8.5, "out of range: {}", v);
+            if 8.5 == v {
+                hit_max = true;
+            }
+        }
+        assert!(hit_max, "inclusive maximum never generated");
+    }
 
     #[test]
     fn u8_inclusive_end_included() {

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -142,15 +142,10 @@ macro_rules! int_any {
         }
 
         /// Tape-aware, edge-case-biased sample from `[lo, hi)`.
-        fn tape_sample(
-            runner: &mut TestRunner,
-            lo: $typ,
-            hi: $typ,
-        ) -> $typ {
+        fn tape_sample(runner: &mut TestRunner, lo: $typ, hi: $typ) -> $typ {
             assert!(lo < hi, "Uniform::new called with `low >= high`");
             runner.draw_integer_in_biased(lo, hi - 1, |r| {
-                $crate::num::$uniform::<$typ>(r, lo.into(), hi.into())
-                    .into()
+                $crate::num::$uniform::<$typ>(r, lo.into(), hi.into()).into()
             })
         }
 
@@ -900,12 +895,11 @@ macro_rules! float_bin_search {
                 if float_class_allowed(-v, allowed) {
                     return -v;
                 }
-                let sign: $typ =
-                    if allowed.contains(FloatTypes::POSITIVE) {
-                        1.0
-                    } else {
-                        -1.0
-                    };
+                let sign: $typ = if allowed.contains(FloatTypes::POSITIVE) {
+                    1.0
+                } else {
+                    -1.0
+                };
                 if allowed.contains(FloatTypes::ZERO) {
                     return sign * 0.0;
                 }
@@ -1097,10 +1091,13 @@ macro_rules! float_bin_search {
                     tape_next_down(hi) as f64,
                     false,
                     |r| {
-                        let s: $typ = $crate::num::sample_uniform::<
-                            $sample_typ,
-                        >(r, lo.into(), hi.into())
-                        .into();
+                        let s: $typ =
+                            $crate::num::sample_uniform::<$sample_typ>(
+                                r,
+                                lo.into(),
+                                hi.into(),
+                            )
+                            .into();
                         s as f64
                     },
                 );
@@ -1232,10 +1229,7 @@ mod test {
         );
         let mut small = 0;
         for _ in 0..512 {
-            let v = super::i64::ANY
-                .new_tree(&mut runner)
-                .unwrap()
-                .current();
+            let v = super::i64::ANY.new_tree(&mut runner).unwrap().current();
             if v.unsigned_abs() < (1 << 16) {
                 small += 1;
             }

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -98,8 +98,11 @@ macro_rules! int_any {
         #[derive(Clone, Copy, Debug)]
         #[must_use = "strategies do nothing unless used"]
         pub struct Any(());
-        /// Generates integers with completely arbitrary values, uniformly
-        /// distributed over the whole range.
+        /// Generates integers with completely arbitrary values over the
+        /// whole range, biased toward interesting cases: exact boundary
+        /// values appear occasionally, most values have small magnitude,
+        /// and a uniform tail keeps the full range reachable. The bias
+        /// applies regardless of the configured shrink engine.
         pub const ANY: Any = Any(());
 
         impl Strategy for Any {
@@ -857,14 +860,25 @@ macro_rules! float_bin_search {
                 use core::num::FpCategory::*;
 
                 let class_allowed = match v.classify() {
-                    Nan =>
-                    // We don't need to inspect whether the
-                    // signallingness of the NaN matches the allowed
-                    // set, as we never try to switch between them,
-                    // instead shrinking to 0.
-                    {
-                        allowed.contains(FloatTypes::QUIET_NAN)
-                            || allowed.contains(FloatTypes::SIGNALING_NAN)
+                    Nan => {
+                        // Check the signalling bit: weird-value
+                        // injection and tape replay can propose the
+                        // "wrong" kind of NaN, which conform_to_types
+                        // must be able to reject. (The hardware's
+                        // interpretation of the bit is taken from the
+                        // NAN constant, as in Any::new_tree.)
+                        let quiet_bit = ::core::$typ::NAN.to_bits()
+                            & ($typ::EXP_MASK >> 1)
+                            & <$typ as FloatLayout>::MANTISSA_MASK;
+                        let is_quiet = (v.to_bits()
+                            & ($typ::EXP_MASK >> 1)
+                            & <$typ as FloatLayout>::MANTISSA_MASK)
+                            == quiet_bit;
+                        if is_quiet {
+                            allowed.contains(FloatTypes::QUIET_NAN)
+                        } else {
+                            allowed.contains(FloatTypes::SIGNALING_NAN)
+                        }
                     }
                     Infinite => allowed.contains(FloatTypes::INFINITE),
                     Zero => allowed.contains(FloatTypes::ZERO),
@@ -982,7 +996,19 @@ macro_rules! float_bin_search {
                 }
 
                 fn current_allowed(&self) -> bool {
-                    float_class_allowed(self.curr, self.allowed)
+                    // The binary search moves values through float
+                    // arithmetic, which quiets signaling NaNs on most
+                    // hardware, so class membership here must treat the
+                    // two NaN classes as one. (conform_to_types uses the
+                    // strict check: tape proposals are pure bit
+                    // patterns, never results of arithmetic.)
+                    let nan = FloatTypes::QUIET_NAN | FloatTypes::SIGNALING_NAN;
+                    let allowed = if self.allowed.intersects(nan) {
+                        self.allowed | nan
+                    } else {
+                        self.allowed
+                    };
+                    float_class_allowed(self.curr, allowed)
                 }
 
                 fn ensure_acceptable(&mut self) {
@@ -1065,19 +1091,6 @@ macro_rules! float_bin_search {
                 }
             }
 
-            /// The largest value of `$typ` strictly below `a`, assuming
-            /// `a` is neither NaN nor the minimum finite value. `-0.0` is
-            /// treated as `0.0`.
-            fn tape_next_down(a: $typ) -> $typ {
-                if a == 0.0 {
-                    -$typ::from_bits(1)
-                } else if a < 0.0 {
-                    $typ::from_bits(a.to_bits() + 1)
-                } else {
-                    $typ::from_bits(a.to_bits() - 1)
-                }
-            }
-
             /// Tape-aware uniform sample from `[lo, hi)`. The recorded
             /// choice's constraints are inclusive, so the upper constraint
             /// is the next value down from `hi`.
@@ -1088,7 +1101,7 @@ macro_rules! float_bin_search {
             ) -> $typ {
                 let sampled = runner.draw_f64_in(
                     lo as f64,
-                    tape_next_down(hi) as f64,
+                    hi.next_down() as f64,
                     false,
                     |r| {
                         let s: $typ =
@@ -1108,7 +1121,7 @@ macro_rules! float_bin_search {
                     out = lo;
                 }
                 if !(out < hi) {
-                    out = tape_next_down(hi);
+                    out = hi.next_down();
                 }
                 out
             }
@@ -1575,6 +1588,40 @@ mod test {
         assert!(value.current().is_nan());
         assert!(!value.clone().complicate());
         assert!(!value.clone().simplify());
+    }
+
+    #[test]
+    fn signaling_nan_class_never_yields_quiet_nan() {
+        // Weird-value injection proposes plain NAN (a quiet NaN);
+        // conform_to_types must map it to a signaling NaN when the
+        // class flags exclude QUIET_NAN. Regression test: previously
+        // the class check accepted any NaN, so about 0.5% of draws
+        // from a SIGNALING_NAN-only strategy were quiet.
+        //
+        // Skip on platforms that do not honour NaN payloads in
+        // from_bits (same check as the generation tests).
+        let fidelity_1 = f32::from_bits(0x7F80_0001).to_bits();
+        let fidelity_2 = f32::from_bits(0xFF80_0001).to_bits();
+        if fidelity_1 == fidelity_2 {
+            return;
+        }
+
+        let quiet_mask = 0x0008_0000_0000_0000u64;
+        let quiet_pattern = ::std::f64::NAN.to_bits() & quiet_mask;
+        let mut runner = TestRunner::deterministic();
+        for _ in 0..4096 {
+            let value = f64::SIGNALING_NAN
+                .new_tree(&mut runner)
+                .unwrap()
+                .current();
+            assert!(value.is_nan());
+            assert_ne!(
+                quiet_pattern,
+                value.to_bits() & quiet_mask,
+                "SIGNALING_NAN-only strategy generated a quiet NaN: {:#x}",
+                value.to_bits()
+            );
+        }
     }
 
     #[test]

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -1610,10 +1610,8 @@ mod test {
         let quiet_pattern = ::std::f64::NAN.to_bits() & quiet_mask;
         let mut runner = TestRunner::deterministic();
         for _ in 0..4096 {
-            let value = f64::SIGNALING_NAN
-                .new_tree(&mut runner)
-                .unwrap()
-                .current();
+            let value =
+                f64::SIGNALING_NAN.new_tree(&mut runner).unwrap().current();
             assert!(value.is_nan());
             assert_ne!(
                 quiet_pattern,

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -940,7 +940,11 @@ macro_rules! float_bin_search {
                 let mut signaling =
                     (quiet_or ^ ($typ::EXP_MASK >> 1)) | $typ::EXP_MASK | 1;
                 if sign < 0.0 {
-                    signaling |= $typ::SIGN_MASK;
+                    // Fully qualified: newer std adds an inherent
+                    // `f32`/`f64::SIGN_MASK`, and the resulting name
+                    // collision is a `future_incompatible` lint, which
+                    // this crate forbids. Matches lines 755/762.
+                    signaling |= <$typ as FloatLayout>::SIGN_MASK;
                 }
                 $typ::from_bits(signaling)
             }

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -1192,9 +1192,16 @@ mod test {
         // (a multiple of everything) and `count == 1` (divides
         // everything) constantly, so the bug is found reliably, and the
         // failure shrinks to the minimal witness (0, 1).
+        //
+        // Finding the bug is engine-independent, but the exact minimal
+        // witness needs the tape engine: the ValueTree shrinker cannot
+        // renavigate the sparse set of multiples after the other tuple
+        // component has changed. Pin the engine so the assertion holds
+        // under PROPTEST_SHRINK_ENGINE=valuetree runs too.
         let mut runner = TestRunner::new_with_rng(
             Config {
                 failure_persistence: None,
+                shrink_engine: ShrinkEngine::Tape,
                 ..Config::default()
             },
             TestRng::deterministic_rng(RngAlgorithm::default()),

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -778,23 +778,40 @@ macro_rules! float_any {
                              true, false)),
                     ].new_tree(runner)?.current();
 
-                let mut generated_value: <$typ as FloatLayout>::Bits =
-                    runner.rng().random();
-                generated_value &= sign_mask | class_mask;
-                generated_value |= sign_or | class_or;
-                let exp = generated_value & $typ::EXP_MASK;
-                if !allow_edge_exp && (0 == exp || $typ::EXP_MASK == exp) {
-                    generated_value &= !$typ::EXP_MASK;
-                    generated_value |= $typ::EXP_ZERO;
-                }
-                if !allow_zero_mant &&
-                    0 == generated_value & <$typ as FloatLayout>::MANTISSA_MASK
-                {
-                    generated_value |= 1;
-                }
+                // The value is one typed Float choice on the tape; the
+                // conform hook keeps shrink proposals inside the allowed
+                // class set (the class pick above is a separate typed
+                // choice via prop_oneof).
+                let value = runner.draw_f64_in_with(
+                    <$typ>::NEG_INFINITY as f64,
+                    <$typ>::INFINITY as f64,
+                    flags.intersects(
+                        FloatTypes::QUIET_NAN | FloatTypes::SIGNALING_NAN,
+                    ),
+                    |v| conform_to_types(v as $typ, flags) as f64,
+                    |r| {
+                        let mut generated_value:
+                            <$typ as FloatLayout>::Bits = r.rng().random();
+                        generated_value &= sign_mask | class_mask;
+                        generated_value |= sign_or | class_or;
+                        let exp = generated_value & $typ::EXP_MASK;
+                        if !allow_edge_exp
+                            && (0 == exp || $typ::EXP_MASK == exp)
+                        {
+                            generated_value &= !$typ::EXP_MASK;
+                            generated_value |= $typ::EXP_ZERO;
+                        }
+                        if !allow_zero_mant
+                            && 0 == generated_value
+                                & <$typ as FloatLayout>::MANTISSA_MASK
+                        {
+                            generated_value |= 1;
+                        }
+                        $typ::from_bits(generated_value) as f64
+                    },
+                ) as $typ;
 
-                Ok(BinarySearch::new_with_types(
-                    $typ::from_bits(generated_value), flags))
+                Ok(BinarySearch::new_with_types(value, flags))
             }
         }
     }
@@ -815,6 +832,78 @@ macro_rules! float_bin_search {
             use super::{FloatLayout, FloatTypes};
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
+
+            /// Whether `v`'s class and sign are permitted by `allowed`.
+            fn float_class_allowed(v: $typ, allowed: FloatTypes) -> bool {
+                use core::num::FpCategory::*;
+
+                let class_allowed = match v.classify() {
+                    Nan =>
+                    // We don't need to inspect whether the
+                    // signallingness of the NaN matches the allowed
+                    // set, as we never try to switch between them,
+                    // instead shrinking to 0.
+                    {
+                        allowed.contains(FloatTypes::QUIET_NAN)
+                            || allowed.contains(FloatTypes::SIGNALING_NAN)
+                    }
+                    Infinite => allowed.contains(FloatTypes::INFINITE),
+                    Zero => allowed.contains(FloatTypes::ZERO),
+                    Subnormal => allowed.contains(FloatTypes::SUBNORMAL),
+                    Normal => allowed.contains(FloatTypes::NORMAL),
+                };
+                let signum = v.signum();
+                let sign_allowed = if signum > 0.0 {
+                    allowed.contains(FloatTypes::POSITIVE)
+                } else if signum < 0.0 {
+                    allowed.contains(FloatTypes::NEGATIVE)
+                } else {
+                    true
+                };
+
+                class_allowed && sign_allowed
+            }
+
+            /// Map an arbitrary float (e.g. a tape shrink proposal) to a
+            /// value the class-restricted `Any` strategy could actually
+            /// generate: keep it if allowed, else try the sign flip, else
+            /// fall back to the simplest allowed value.
+            fn conform_to_types(v: $typ, allowed: FloatTypes) -> $typ {
+                if float_class_allowed(v, allowed) {
+                    return v;
+                }
+                if float_class_allowed(-v, allowed) {
+                    return -v;
+                }
+                let sign: $typ =
+                    if allowed.contains(FloatTypes::POSITIVE) {
+                        1.0
+                    } else {
+                        -1.0
+                    };
+                if allowed.contains(FloatTypes::ZERO) {
+                    return sign * 0.0;
+                }
+                if allowed.contains(FloatTypes::NORMAL) {
+                    return sign * 1.0;
+                }
+                if allowed.contains(FloatTypes::SUBNORMAL) {
+                    return sign * $typ::from_bits(1);
+                }
+                if allowed.contains(FloatTypes::INFINITE) {
+                    return sign * ::core::$typ::INFINITY;
+                }
+                if allowed.contains(FloatTypes::QUIET_NAN) {
+                    return ::core::$typ::NAN;
+                }
+                // Signaling NaN only: same construction as in
+                // `Any::new_tree`.
+                let quiet_or = ::core::$typ::NAN.to_bits()
+                    & ($typ::EXP_MASK | ($typ::EXP_MASK >> 1));
+                let signaling =
+                    (quiet_or ^ ($typ::EXP_MASK >> 1)) | $typ::EXP_MASK | 1;
+                $typ::from_bits(signaling)
+            }
 
             float_any!($typ);
 
@@ -867,38 +956,7 @@ macro_rules! float_bin_search {
                 }
 
                 fn current_allowed(&self) -> bool {
-                    use core::num::FpCategory::*;
-
-                    // Don't reposition if the new value is not allowed
-                    let class_allowed = match self.curr.classify() {
-                        Nan =>
-                        // We don't need to inspect whether the
-                        // signallingness of the NaN matches the allowed
-                        // set, as we never try to switch between them,
-                        // instead shrinking to 0.
-                        {
-                            self.allowed.contains(FloatTypes::QUIET_NAN)
-                                || self
-                                    .allowed
-                                    .contains(FloatTypes::SIGNALING_NAN)
-                        }
-                        Infinite => self.allowed.contains(FloatTypes::INFINITE),
-                        Zero => self.allowed.contains(FloatTypes::ZERO),
-                        Subnormal => {
-                            self.allowed.contains(FloatTypes::SUBNORMAL)
-                        }
-                        Normal => self.allowed.contains(FloatTypes::NORMAL),
-                    };
-                    let signum = self.curr.signum();
-                    let sign_allowed = if signum > 0.0 {
-                        self.allowed.contains(FloatTypes::POSITIVE)
-                    } else if signum < 0.0 {
-                        self.allowed.contains(FloatTypes::NEGATIVE)
-                    } else {
-                        true
-                    };
-
-                    class_allowed && sign_allowed
+                    float_class_allowed(self.curr, self.allowed)
                 }
 
                 fn ensure_acceptable(&mut self) {

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -867,7 +867,7 @@ macro_rules! float_bin_search {
                         // must be able to reject. (The hardware's
                         // interpretation of the bit is taken from the
                         // NAN constant, as in Any::new_tree.)
-                        let quiet_bit = ::core::$typ::NAN.to_bits()
+                        let quiet_bit = $typ::NAN.to_bits()
                             & ($typ::EXP_MASK >> 1)
                             & <$typ as FloatLayout>::MANTISSA_MASK;
                         let is_quiet = (v.to_bits()
@@ -924,18 +924,18 @@ macro_rules! float_bin_search {
                     return sign * $typ::from_bits(1);
                 }
                 if allowed.contains(FloatTypes::INFINITE) {
-                    return sign * ::core::$typ::INFINITY;
+                    return sign * $typ::INFINITY;
                 }
                 if allowed.contains(FloatTypes::QUIET_NAN) {
                     return if sign < 0.0 {
-                        -::core::$typ::NAN
+                        -$typ::NAN
                     } else {
-                        ::core::$typ::NAN
+                        $typ::NAN
                     };
                 }
                 // Signaling NaN only: same construction as in
                 // `Any::new_tree`.
-                let quiet_or = ::core::$typ::NAN.to_bits()
+                let quiet_or = $typ::NAN.to_bits()
                     & ($typ::EXP_MASK | ($typ::EXP_MASK >> 1));
                 let mut signaling =
                     (quiet_or ^ ($typ::EXP_MASK >> 1)) | $typ::EXP_MASK | 1;

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -93,7 +93,7 @@ macro_rules! unsupported_int_any {
 }
 
 macro_rules! int_any {
-    ($typ: ident, $int_any: ident) => {
+    ($typ: ident, $int_any: ident, $uniform: ident, $incl: ident) => {
         /// Type of the `ANY` constant.
         #[derive(Clone, Copy, Debug)]
         #[must_use = "strategies do nothing unless used"]
@@ -107,29 +107,53 @@ macro_rules! int_any {
             type Value = $typ;
 
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-                Ok(BinarySearch::new($int_any!(runner, $typ)))
+                // One typed choice when the tape is on; the closure is the
+                // unchanged upstream sampling path when it is off.
+                Ok(BinarySearch::new(runner.draw_integer_in(
+                    <$typ>::MIN,
+                    <$typ>::MAX,
+                    |r| $int_any!(r, $typ),
+                )))
             }
+        }
+
+        /// Tape-aware uniform sample from `[lo, hi)`.
+        fn tape_sample(
+            runner: &mut TestRunner,
+            lo: $typ,
+            hi: $typ,
+        ) -> $typ {
+            assert!(lo < hi, "Uniform::new called with `low >= high`");
+            runner.draw_integer_in(lo, hi - 1, |r| {
+                $crate::num::$uniform::<$typ>(r, lo.into(), hi.into())
+                    .into()
+            })
+        }
+
+        /// Tape-aware uniform sample from `[lo, hi]`.
+        fn tape_sample_incl(
+            runner: &mut TestRunner,
+            lo: $typ,
+            hi: $typ,
+        ) -> $typ {
+            assert!(
+                lo <= hi,
+                "Uniform::new_inclusive called with `low > high`"
+            );
+            runner.draw_integer_in(lo, hi, |r| {
+                $crate::num::$incl::<$typ>(r, lo.into(), hi.into()).into()
+            })
         }
     };
 }
 
+// Implements the `Strategy` for the five range types. The invoking module
+// must define `tape_sample(runner, lo, hi)` (uniform over the half-open
+// range `[lo, hi)`) and `tape_sample_incl(runner, lo, hi)` (uniform over
+// the closed range `[lo, hi]`); both record the draw on the choice tape
+// when the tape shrink engine is active.
 macro_rules! numeric_api {
     ($typ:ident, $epsilon:expr) => {
-        numeric_api!($typ, $typ, $epsilon);
-    };
-    ($typ:ident, $sample_typ:ty, $epsilon:expr) => {
-        numeric_api!(
-            $typ,
-            $sample_typ,
-            $epsilon,
-            sample_uniform,
-            sample_uniform_incl
-        );
-    };
-    ($typ:ident, $epsilon:expr, $uniform:ident, $incl:ident) => {
-        numeric_api!($typ, $typ, $epsilon, $uniform, $incl);
-    };
-    ($typ:ident, $sample_typ:ty, $epsilon:expr, $uniform:ident, $incl:ident) => {
         impl Strategy for ::core::ops::Range<$typ> {
             type Tree = BinarySearch;
             type Value = $typ;
@@ -144,12 +168,7 @@ macro_rules! numeric_api {
 
                 Ok(BinarySearch::new_clamped(
                     self.start,
-                    $crate::num::$uniform::<$sample_typ>(
-                        runner,
-                        self.start.into(),
-                        self.end.into(),
-                    )
-                    .into(),
+                    tape_sample(runner, self.start, self.end),
                     self.end - $epsilon,
                 ))
             }
@@ -170,12 +189,7 @@ macro_rules! numeric_api {
 
                 Ok(BinarySearch::new_clamped(
                     *self.start(),
-                    $crate::num::$incl::<$sample_typ>(
-                        runner,
-                        (*self.start()).into(),
-                        (*self.end()).into(),
-                    )
-                    .into(),
+                    tape_sample_incl(runner, *self.start(), *self.end()),
                     *self.end(),
                 ))
             }
@@ -188,12 +202,7 @@ macro_rules! numeric_api {
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 Ok(BinarySearch::new_clamped(
                     self.start,
-                    $crate::num::$incl::<$sample_typ>(
-                        runner,
-                        self.start.into(),
-                        <$typ>::MAX.into(),
-                    )
-                    .into(),
+                    tape_sample_incl(runner, self.start, <$typ>::MAX),
                     <$typ>::MAX,
                 ))
             }
@@ -206,12 +215,7 @@ macro_rules! numeric_api {
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 Ok(BinarySearch::new_clamped(
                     <$typ>::MIN,
-                    $crate::num::$uniform::<$sample_typ>(
-                        runner,
-                        <$typ>::MIN.into(),
-                        self.end.into(),
-                    )
-                    .into(),
+                    tape_sample(runner, <$typ>::MIN, self.end),
                     self.end,
                 ))
             }
@@ -224,12 +228,7 @@ macro_rules! numeric_api {
             fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
                 Ok(BinarySearch::new_clamped(
                     <$typ>::MIN,
-                    $crate::num::$incl::<$sample_typ>(
-                        runner,
-                        <$typ>::MIN.into(),
-                        self.end.into(),
-                    )
-                    .into(),
+                    tape_sample_incl(runner, <$typ>::MIN, self.end),
                     self.end,
                 ))
             }
@@ -255,7 +254,7 @@ macro_rules! signed_integer_bin_search {
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
 
-            int_any!($typ, $int_any);
+            int_any!($typ, $int_any, $uniform, $incl);
 
             /// Shrinks an integer towards 0, using binary search to find
             /// boundary points.
@@ -343,7 +342,7 @@ macro_rules! signed_integer_bin_search {
                 }
             }
 
-            numeric_api!($typ, 1, $uniform, $incl);
+            numeric_api!($typ, 1);
         }
     };
 }
@@ -366,7 +365,7 @@ macro_rules! unsigned_integer_bin_search {
             use crate::strategy::*;
             use crate::test_runner::TestRunner;
 
-            int_any!($typ, $int_any);
+            int_any!($typ, $int_any, $uniform, $incl);
 
             /// Shrinks an integer towards 0, using binary search to find
             /// boundary points.
@@ -440,7 +439,7 @@ macro_rules! unsigned_integer_bin_search {
                 }
             }
 
-            numeric_api!($typ, 1, $uniform, $incl);
+            numeric_api!($typ, 1);
         }
     };
 }
@@ -982,7 +981,76 @@ macro_rules! float_bin_search {
                 }
             }
 
-            numeric_api!($typ, $sample_typ, 0.0);
+            /// The largest value of `$typ` strictly below `a`, assuming
+            /// `a` is neither NaN nor the minimum finite value. `-0.0` is
+            /// treated as `0.0`.
+            fn tape_next_down(a: $typ) -> $typ {
+                if a == 0.0 {
+                    -$typ::from_bits(1)
+                } else if a < 0.0 {
+                    $typ::from_bits(a.to_bits() + 1)
+                } else {
+                    $typ::from_bits(a.to_bits() - 1)
+                }
+            }
+
+            /// Tape-aware uniform sample from `[lo, hi)`. The recorded
+            /// choice's constraints are inclusive, so the upper constraint
+            /// is the next value down from `hi`.
+            fn tape_sample(
+                runner: &mut TestRunner,
+                lo: $typ,
+                hi: $typ,
+            ) -> $typ {
+                let sampled = runner.draw_f64_in(
+                    lo as f64,
+                    tape_next_down(hi) as f64,
+                    false,
+                    |r| {
+                        let s: $typ = $crate::num::sample_uniform::<
+                            $sample_typ,
+                        >(r, lo.into(), hi.into())
+                        .into();
+                        s as f64
+                    },
+                );
+                // Narrowing from the f64 choice back to $typ can round
+                // past the range bounds; clamp in $typ space.
+                let mut out = sampled as $typ;
+                if !(out >= lo) {
+                    out = lo;
+                }
+                if !(out < hi) {
+                    out = tape_next_down(hi);
+                }
+                out
+            }
+
+            /// Tape-aware uniform sample from `[lo, hi]`.
+            fn tape_sample_incl(
+                runner: &mut TestRunner,
+                lo: $typ,
+                hi: $typ,
+            ) -> $typ {
+                let sampled =
+                    runner.draw_f64_in(lo as f64, hi as f64, false, |r| {
+                        let s: $typ = $crate::num::sample_uniform_incl::<
+                            $sample_typ,
+                        >(r, lo.into(), hi.into())
+                        .into();
+                        s as f64
+                    });
+                let mut out = sampled as $typ;
+                if !(out >= lo) {
+                    out = lo;
+                }
+                if !(out <= hi) {
+                    out = hi;
+                }
+                out
+            }
+
+            numeric_api!($typ, 0.0);
         }
     };
 }

--- a/proptest/src/num.rs
+++ b/proptest/src/num.rs
@@ -1606,7 +1606,10 @@ mod test {
             return;
         }
 
-        let quiet_mask = 0x0008_0000_0000_0000u64;
+        // Derive the mask exactly as the production check does
+        // (float_class_allowed), so a FloatLayout change cannot
+        // silently decouple this test from the code path it pins.
+        let quiet_mask = (f64::EXP_MASK >> 1) & <f64 as FloatLayout>::MANTISSA_MASK;
         let quiet_pattern = ::std::f64::NAN.to_bits() & quiet_mask;
         let mut runner = TestRunner::deterministic();
         for _ in 0..4096 {

--- a/proptest/src/sample.rs
+++ b/proptest/src/sample.rs
@@ -267,7 +267,7 @@ opaque_strategy_wrapper! {
     /// Created via `any::<Index>()`.
     #[derive(Clone, Debug)]
     pub struct IndexStrategy[][](
-        statics::Map<num::usize::Any, UsizeToIndex>)
+        statics::Map<num::usize::AnyUniform, UsizeToIndex>)
         -> IndexValueTree;
     /// `ValueTree` corresponding to `IndexStrategy`.
     #[derive(Clone, Debug)]
@@ -278,7 +278,7 @@ opaque_strategy_wrapper! {
 
 impl IndexStrategy {
     pub(crate) fn new() -> Self {
-        IndexStrategy(statics::Map::new(num::usize::ANY, UsizeToIndex))
+        IndexStrategy(statics::Map::new(num::usize::ANY_UNIFORM, UsizeToIndex))
     }
 }
 

--- a/proptest/src/strategy/unions.rs
+++ b/proptest/src/strategy/unions.rs
@@ -106,8 +106,16 @@ fn pick_weighted<I: Iterator<Item = u32>>(
     weights1: I,
     weights2: I,
 ) -> usize {
-    let sum = weights1.map(u64::from).sum();
-    let weighted_pick = sample_uniform(runner, 0, sum);
+    let sum: u64 = weights1.map(u64::from).sum();
+    // Equivalent panic to the `Uniform::new(0, 0)` in the code this
+    // replaced.
+    assert!(sum > 0, "picking from union with no weight");
+    // A typed draw so that, under the tape shrink engine, branch
+    // selection is pinned during replay and shrinks toward the first
+    // (lowest cumulative weight) alternative. With the tape off this is
+    // the same uniform sample as before.
+    let weighted_pick =
+        runner.draw_integer_in(0u64, sum - 1, |r| sample_uniform(r, 0, sum));
     weights2
         .scan(0u64, |state, w| {
             *state += u64::from(w);

--- a/proptest/src/sugar.rs
+++ b/proptest/src/sugar.rs
@@ -1539,8 +1539,11 @@ mod closure_tests {
     fn test_simple() {
         let x = 420;
 
+        // These only exercise closure capture, so the assertion must
+        // hold for every `y`: edge-biased generation does eventually
+        // produce any small value, including 420.
         proptest!(|(y: i32)| {
-            assert!(x != y);
+            assert_eq!(420, x, "y = {}", y);
         });
 
         proptest!(|(y in 0..100)| {
@@ -1549,7 +1552,7 @@ mod closure_tests {
         });
 
         proptest!(|(y: i32,)| {
-            assert!(x != y);
+            assert_eq!(420, x, "y = {}", y);
         });
 
         proptest!(|(y in 0..100,)| {

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -13,6 +13,49 @@ use core::{fmt, str, u32};
 use crate::test_runner::result_cache::{noop_result_cache, ResultCache};
 use crate::test_runner::rng::RngAlgorithm;
 use crate::test_runner::FailurePersistence;
+/// Selects the algorithm used to shrink failing test cases.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ShrinkEngine {
+    /// The classic shrinker: walk the failing case's `ValueTree` with
+    /// `simplify()`/`complicate()`. This is the default.
+    ValueTree,
+    /// Experimental: Conjecture-style choice-tape shrinking. Generation is
+    /// recorded as a tape of typed choices; shrinking edits the tape and
+    /// re-runs generation, accepting an edit iff the test still fails and
+    /// the result is simpler. Produces rounder minimal values (especially
+    /// for floats) and does not get stuck on `prop_filter`, at the cost of
+    /// re-running generation for every shrink attempt.
+    ///
+    /// Not yet supported together with `fork`/`timeout`; those
+    /// configurations fall back to `ValueTree`.
+    Tape,
+}
+
+impl Default for ShrinkEngine {
+    fn default() -> Self {
+        ShrinkEngine::ValueTree
+    }
+}
+
+impl str::FromStr for ShrinkEngine {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, ()> {
+        match s {
+            "valuetree" | "value-tree" => Ok(ShrinkEngine::ValueTree),
+            "tape" => Ok(ShrinkEngine::Tape),
+            _ => Err(()),
+        }
+    }
+}
+
+impl fmt::Display for ShrinkEngine {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ShrinkEngine::ValueTree => write!(f, "valuetree"),
+            ShrinkEngine::Tape => write!(f, "tape"),
+        }
+    }
+}
 
 /// Override the config fields from environment variables, if any are set.
 /// Without the `std` feature this function returns config unchanged.
@@ -38,6 +81,7 @@ pub fn contextualize_config(mut result: Config) -> Config {
     const VERBOSE: &str = "PROPTEST_VERBOSE";
     const RNG_ALGORITHM: &str = "PROPTEST_RNG_ALGORITHM";
     const RNG_SEED: &str = "PROPTEST_RNG_SEED";
+    const SHRINK_ENGINE: &str = "PROPTEST_SHRINK_ENGINE";
     const DISABLE_FAILURE_PERSISTENCE: &str =
         "PROPTEST_DISABLE_FAILURE_PERSISTENCE";
 
@@ -138,6 +182,13 @@ pub fn contextualize_config(mut result: Config) -> Config {
             );
         } else if var == RNG_SEED {
             parse_or_warn(&value, &mut result.rng_seed, "u64", RNG_SEED);
+        } else if var == SHRINK_ENGINE {
+            parse_or_warn(
+                &value,
+                &mut result.shrink_engine,
+                "ShrinkEngine (valuetree|tape)",
+                SHRINK_ENGINE,
+            );
         } else if var == DISABLE_FAILURE_PERSISTENCE {
             result.failure_persistence = None;
         } else if var.starts_with("PROPTEST_") {
@@ -176,6 +227,7 @@ fn default_default_config() -> Config {
         verbose: 0,
         rng_algorithm: RngAlgorithm::default(),
         rng_seed: RngSeed::Random,
+        shrink_engine: ShrinkEngine::default(),
         _non_exhaustive: (),
     }
 }
@@ -431,6 +483,18 @@ pub struct Config {
     /// Seed used for the RNG. Set by using the PROPTEST_RNG_SEED environment variable
     /// If the environment variable is undefined, a random seed is generated (this is the default option).
     pub rng_seed: RngSeed,
+
+    /// Which shrink engine to use when a failing test case is found.
+    ///
+    /// The default is `ShrinkEngine::ValueTree`, the classic proptest
+    /// shrinker. `ShrinkEngine::Tape` selects the experimental
+    /// Conjecture-style choice-tape shrinker.
+    ///
+    /// The default can be overridden by setting the
+    /// `PROPTEST_SHRINK_ENGINE` environment variable to `valuetree` or
+    /// `tape`. (The variable is only considered when the `std` feature is
+    /// enabled, which it is by default.)
+    pub shrink_engine: ShrinkEngine,
 
     // Needs to be public so FRU syntax can be used.
     #[doc(hidden)]

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -17,23 +17,27 @@ use crate::test_runner::FailurePersistence;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ShrinkEngine {
     /// The classic shrinker: walk the failing case's `ValueTree` with
-    /// `simplify()`/`complicate()`. This is the default.
+    /// `simplify()`/`complicate()`.
     ValueTree,
-    /// Experimental: Conjecture-style choice-tape shrinking. Generation is
+    /// Conjecture-style choice-tape shrinking, the default. Generation is
     /// recorded as a tape of typed choices; shrinking edits the tape and
     /// re-runs generation, accepting an edit iff the test still fails and
-    /// the result is simpler. Produces rounder minimal values (especially
-    /// for floats) and does not get stuck on `prop_filter`, at the cost of
-    /// re-running generation for every shrink attempt.
+    /// the result is simpler. Compared to `ValueTree` it produces rounder
+    /// minimal values (especially for floats), does not get stuck on
+    /// `prop_filter`, shrinks naturally through `prop_flat_map`, has
+    /// cross-value passes (redistribution, joint lowering of duplicates),
+    /// and persists failures as replayable choice tapes (`ct1` entries)
+    /// instead of RNG seeds. The cost is re-running generation for every
+    /// shrink attempt.
     ///
-    /// Not yet supported together with `fork`/`timeout`; those
+    /// Not supported together with `fork`/`timeout` yet; those
     /// configurations fall back to `ValueTree`.
     Tape,
 }
 
 impl Default for ShrinkEngine {
     fn default() -> Self {
-        ShrinkEngine::ValueTree
+        ShrinkEngine::Tape
     }
 }
 
@@ -486,9 +490,9 @@ pub struct Config {
 
     /// Which shrink engine to use when a failing test case is found.
     ///
-    /// The default is `ShrinkEngine::ValueTree`, the classic proptest
-    /// shrinker. `ShrinkEngine::Tape` selects the experimental
-    /// Conjecture-style choice-tape shrinker.
+    /// The default is `ShrinkEngine::Tape`, the Conjecture-style
+    /// choice-tape shrinker. `ShrinkEngine::ValueTree` selects the classic
+    /// proptest shrinker.
     ///
     /// The default can be overridden by setting the
     /// `PROPTEST_SHRINK_ENGINE` environment variable to `valuetree` or

--- a/proptest/src/test_runner/failure_persistence/mod.rs
+++ b/proptest/src/test_runner/failure_persistence/mod.rs
@@ -192,11 +192,10 @@ mod tests {
     use super::{PersistedFailure, PersistedSeed};
     use crate::test_runner::rng::Seed;
 
-    pub const INC_SEED: PersistedSeed = PersistedSeed(
-        PersistedFailure::Seed(Seed::XorShift([
+    pub const INC_SEED: PersistedSeed =
+        PersistedSeed(PersistedFailure::Seed(Seed::XorShift([
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-        ])),
-    );
+        ])));
 
     pub const HI_PATH: Option<&str> = Some("hi");
     pub const UNREL_PATH: Option<&str> = Some("unrelated");

--- a/proptest/src/test_runner/failure_persistence/mod.rs
+++ b/proptest/src/test_runner/failure_persistence/mod.rs
@@ -72,9 +72,7 @@ impl PartialOrd for PersistedFailure {
 impl Ord for PersistedFailure {
     fn cmp(&self, other: &Self) -> Ordering {
         match (self, other) {
-            (PersistedFailure::Seed(a), PersistedFailure::Seed(b)) => {
-                a.cmp(b)
-            }
+            (PersistedFailure::Seed(a), PersistedFailure::Seed(b)) => a.cmp(b),
             (PersistedFailure::Seed(..), PersistedFailure::Tape { .. }) => {
                 Ordering::Less
             }
@@ -188,9 +186,7 @@ pub trait FailurePersistence: Send + Sync + fmt::Debug {
             | PersistedFailure::Tape {
                 seed: Some(Seed::XorShift(seed)),
                 ..
-            } => {
-                self.save_persisted_failure(source_file, seed, shrunken_value)
-            }
+            } => self.save_persisted_failure(source_file, seed, shrunken_value),
             _ => (),
         }
     }

--- a/proptest/src/test_runner/failure_persistence/mod.rs
+++ b/proptest/src/test_runner/failure_persistence/mod.rs
@@ -7,8 +7,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::std_facade::{fmt, Box, Vec};
+use crate::std_facade::{fmt, Box, String, Vec};
 use core::any::Any;
+use core::cmp::Ordering;
 use core::fmt::Display;
 use core::result::Result;
 use core::str::FromStr;
@@ -35,12 +36,57 @@ use crate::test_runner::Seed;
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PersistedSeed(pub(crate) PersistedFailure);
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug)]
 pub(crate) enum PersistedFailure {
     Seed(Seed),
     /// A serialized choice tape (see `tape::serialize_tape`), written as
     /// `ct1 <base16>`.
-    Tape(Vec<u8>),
+    Tape {
+        bytes: Vec<u8>,
+        /// The RNG seed of the run that produced the failure. Not
+        /// persisted (the tape supersedes it for replay); carried so the
+        /// default `save_persisted_failure2` can keep forwarding seeds
+        /// to implementations that only override the legacy hooks.
+        /// `None` for entries loaded from a persistence file.
+        seed: Option<Seed>,
+    },
+}
+
+// Equality and ordering ignore the carried seed: a tape loaded from disk
+// (seed: None) and the same tape as saved (seed: Some) are one entry for
+// deduplication purposes.
+impl PartialEq for PersistedFailure {
+    fn eq(&self, other: &Self) -> bool {
+        Ordering::Equal == self.cmp(other)
+    }
+}
+
+impl Eq for PersistedFailure {}
+
+impl PartialOrd for PersistedFailure {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PersistedFailure {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (PersistedFailure::Seed(a), PersistedFailure::Seed(b)) => {
+                a.cmp(b)
+            }
+            (PersistedFailure::Seed(..), PersistedFailure::Tape { .. }) => {
+                Ordering::Less
+            }
+            (PersistedFailure::Tape { .. }, PersistedFailure::Seed(..)) => {
+                Ordering::Greater
+            }
+            (
+                PersistedFailure::Tape { bytes: a, .. },
+                PersistedFailure::Tape { bytes: b, .. },
+            ) => a.cmp(b),
+        }
+    }
 }
 
 const TAPE_PERSISTENCE_KEY: &str = "ct1";
@@ -51,13 +97,10 @@ impl Display for PersistedSeed {
             PersistedFailure::Seed(seed) => {
                 write!(f, "{}", seed.to_persistence())
             }
-            PersistedFailure::Tape(bytes) => {
-                write!(f, "{}", TAPE_PERSISTENCE_KEY)?;
-                write!(f, " ")?;
-                for byte in bytes {
-                    write!(f, "{:02x}", byte)?;
-                }
-                Ok(())
+            PersistedFailure::Tape { bytes, .. } => {
+                let mut hex = String::new();
+                crate::test_runner::rng::to_base16(&mut hex, bytes);
+                write!(f, "{} {}", TAPE_PERSISTENCE_KEY, hex)
             }
         }
     }
@@ -76,12 +119,12 @@ impl FromStr for PersistedSeed {
             if 0 != hex.len() % 2 {
                 return Err(());
             }
-            let mut bytes = Vec::with_capacity(hex.len() / 2);
-            for pair in hex.as_bytes().chunks(2) {
-                let s = core::str::from_utf8(pair).map_err(|_| ())?;
-                bytes.push(u8::from_str_radix(s, 16).map_err(|_| ())?);
-            }
-            return Ok(PersistedSeed(PersistedFailure::Tape(bytes)));
+            let mut bytes = vec![0u8; hex.len() / 2];
+            crate::test_runner::rng::from_base16(&mut bytes, hex).ok_or(())?;
+            return Ok(PersistedSeed(PersistedFailure::Tape {
+                bytes,
+                seed: None,
+            }));
         }
         Seed::from_persistence(trimmed)
             .map(|seed| PersistedSeed(PersistedFailure::Seed(seed)))
@@ -141,7 +184,11 @@ pub trait FailurePersistence: Send + Sync + fmt::Debug {
         shrunken_value: &dyn fmt::Debug,
     ) {
         match seed.0 {
-            PersistedFailure::Seed(Seed::XorShift(seed)) => {
+            PersistedFailure::Seed(Seed::XorShift(seed))
+            | PersistedFailure::Tape {
+                seed: Some(Seed::XorShift(seed)),
+                ..
+            } => {
                 self.save_persisted_failure(source_file, seed, shrunken_value)
             }
             _ => (),

--- a/proptest/src/test_runner/failure_persistence/mod.rs
+++ b/proptest/src/test_runner/failure_persistence/mod.rs
@@ -25,16 +25,41 @@ pub use self::map::*;
 
 use crate::test_runner::Seed;
 
-/// Opaque struct representing a seed which can be persisted.
+/// Opaque struct representing a persisted failure: either an RNG seed
+/// (regenerates and re-shrinks the historical failure) or, under the tape
+/// shrink engine, a recorded choice tape (replays the already-shrunken
+/// values exactly, surviving strategy refactors and RNG changes).
 ///
 /// The `Display` and `FromStr` implementations go to and from the format
 /// Proptest uses for its persistence file.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct PersistedSeed(pub(crate) Seed);
+pub struct PersistedSeed(pub(crate) PersistedFailure);
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum PersistedFailure {
+    Seed(Seed),
+    /// A serialized choice tape (see `tape::serialize_tape`), written as
+    /// `ct1 <base16>`.
+    Tape(Vec<u8>),
+}
+
+const TAPE_PERSISTENCE_KEY: &str = "ct1";
 
 impl Display for PersistedSeed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0.to_persistence())
+        match &self.0 {
+            PersistedFailure::Seed(seed) => {
+                write!(f, "{}", seed.to_persistence())
+            }
+            PersistedFailure::Tape(bytes) => {
+                write!(f, "{}", TAPE_PERSISTENCE_KEY)?;
+                write!(f, " ")?;
+                for byte in bytes {
+                    write!(f, "{:02x}", byte)?;
+                }
+                Ok(())
+            }
+        }
     }
 }
 
@@ -42,7 +67,25 @@ impl FromStr for PersistedSeed {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, ()> {
-        Seed::from_persistence(s).map(PersistedSeed).ok_or(())
+        let trimmed = s.trim();
+        if let Some(hex) = trimmed
+            .strip_prefix(TAPE_PERSISTENCE_KEY)
+            .and_then(|rest| rest.strip_prefix(' '))
+        {
+            let hex = hex.trim();
+            if 0 != hex.len() % 2 {
+                return Err(());
+            }
+            let mut bytes = Vec::with_capacity(hex.len() / 2);
+            for pair in hex.as_bytes().chunks(2) {
+                let s = core::str::from_utf8(pair).map_err(|_| ())?;
+                bytes.push(u8::from_str_radix(s, 16).map_err(|_| ())?);
+            }
+            return Ok(PersistedSeed(PersistedFailure::Tape(bytes)));
+        }
+        Seed::from_persistence(trimmed)
+            .map(|seed| PersistedSeed(PersistedFailure::Seed(seed)))
+            .ok_or(())
     }
 }
 
@@ -67,7 +110,9 @@ pub trait FailurePersistence: Send + Sync + fmt::Debug {
     ) -> Vec<PersistedSeed> {
         self.load_persisted_failures(source_file)
             .into_iter()
-            .map(|seed| PersistedSeed(Seed::XorShift(seed)))
+            .map(|seed| {
+                PersistedSeed(PersistedFailure::Seed(Seed::XorShift(seed)))
+            })
             .collect()
     }
 
@@ -96,7 +141,7 @@ pub trait FailurePersistence: Send + Sync + fmt::Debug {
         shrunken_value: &dyn fmt::Debug,
     ) {
         match seed.0 {
-            Seed::XorShift(seed) => {
+            PersistedFailure::Seed(Seed::XorShift(seed)) => {
                 self.save_persisted_failure(source_file, seed, shrunken_value)
             }
             _ => (),
@@ -144,12 +189,14 @@ impl Clone for Box<dyn FailurePersistence> {
 
 #[cfg(test)]
 mod tests {
-    use super::PersistedSeed;
+    use super::{PersistedFailure, PersistedSeed};
     use crate::test_runner::rng::Seed;
 
-    pub const INC_SEED: PersistedSeed = PersistedSeed(Seed::XorShift([
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-    ]));
+    pub const INC_SEED: PersistedSeed = PersistedSeed(
+        PersistedFailure::Seed(Seed::XorShift([
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        ])),
+    );
 
     pub const HI_PATH: Option<&str> = Some("hi");
     pub const UNREL_PATH: Option<&str> = Some("unrelated");

--- a/proptest/src/test_runner/failure_persistence/mod.rs
+++ b/proptest/src/test_runner/failure_persistence/mod.rs
@@ -187,7 +187,22 @@ pub trait FailurePersistence: Send + Sync + fmt::Debug {
                 seed: Some(Seed::XorShift(seed)),
                 ..
             } => self.save_persisted_failure(source_file, seed, shrunken_value),
-            _ => (),
+            _ => {
+                // The deprecated hook's signature is XorShift-only
+                // ([u8; 16]); ChaCha seeds and seedless tapes cannot be
+                // forwarded through it. Defaults produce exactly those,
+                // so a legacy-only implementation would silently
+                // persist nothing: say so instead.
+                #[cfg(feature = "std")]
+                eprintln!(
+                    "proptest: failure NOT persisted: this \
+                     FailurePersistence implementation only overrides \
+                     the deprecated XorShift-based hook; implement \
+                     save_persisted_failure2/load_persisted_failures2 \
+                     to persist failures under the default \
+                     configuration."
+                );
+            }
         }
     }
 

--- a/proptest/src/test_runner/mod.rs
+++ b/proptest/src/test_runner/mod.rs
@@ -22,6 +22,7 @@ mod result_cache;
 mod rng;
 mod runner;
 mod scoped_panic_hook;
+pub(crate) mod tape;
 
 pub use self::config::*;
 pub use self::errors::*;

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -110,10 +110,17 @@ impl fmt::Display for RngAlgorithm {
     }
 }
 
+use crate::test_runner::tape::{Choice, TapeState};
+
 /// Proptest's random number generator.
 #[derive(Clone, Debug)]
 pub struct TestRng {
     rng: TestRngImpl,
+    /// Choice-tape state for the experimental tape shrink engine. `Off`
+    /// (and thus zero-cost beyond a branch) unless the engine is active.
+    /// Lives here rather than on `TestRunner` so that raw `RngCore` calls
+    /// and the runner's typed draws share one tape.
+    pub(crate) tape: TapeState,
 }
 
 #[derive(Clone, Debug)]
@@ -192,18 +199,60 @@ impl TestRng {
     }
 }
 
+// The choice-tape interception seam: rand 0.10 routes all infallible RNG
+// use through `TryRng`, so recording/replaying here covers every raw draw
+// any strategy makes.
 impl TryRng for TestRng {
     type Error = Infallible;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        if self.tape.raw_active() {
+            if let Some(Choice::RawU32 { value }) =
+                self.tape.pop_replay(|c| matches!(c, Choice::RawU32 { .. }))
+            {
+                self.tape.record(Choice::RawU32 { value });
+                return Ok(value);
+            }
+            let value = self.next_u32_inner();
+            self.tape.record(Choice::RawU32 { value });
+            return Ok(value);
+        }
         Ok(self.next_u32_inner())
     }
 
     fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        if self.tape.raw_active() {
+            if let Some(Choice::RawU64 { value }) =
+                self.tape.pop_replay(|c| matches!(c, Choice::RawU64 { .. }))
+            {
+                self.tape.record(Choice::RawU64 { value });
+                return Ok(value);
+            }
+            let value = self.next_u64_inner();
+            self.tape.record(Choice::RawU64 { value });
+            return Ok(value);
+        }
         Ok(self.next_u64_inner())
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        if self.tape.raw_active() {
+            if let Some(Choice::RawBytes { value }) =
+                self.tape.pop_replay(|c| matches!(
+                    c,
+                    Choice::RawBytes { value } if value.len() == dest.len()
+                ))
+            {
+                dest.copy_from_slice(&value);
+                self.tape.record(Choice::RawBytes { value });
+                return Ok(());
+            }
+            self.fill_bytes_inner(dest);
+            self.tape.record(Choice::RawBytes {
+                value: dest.to_vec(),
+            });
+            return Ok(());
+        }
         self.fill_bytes_inner(dest);
         Ok(())
     }
@@ -439,6 +488,7 @@ impl TestRng {
                     },
                     RngAlgorithm::_NonExhaustive => unreachable!(),
                 },
+                tape: TapeState::default(),
             }
         }
         #[cfg(all(
@@ -553,9 +603,12 @@ impl TestRng {
         Self::from_seed_internal(self.new_rng_seed())
     }
 
-    /// Overwrite the given TestRng with the provided seed.
+    /// Overwrite the given TestRng with the provided seed, preserving any
+    /// active choice-tape state.
     pub(crate) fn set_seed(&mut self, seed: Seed) {
+        let tape = core::mem::take(&mut self.tape);
         *self = Self::from_seed_internal(seed);
+        self.tape = tape;
     }
 
     /// Generate a new randomized seed, set it to this TestRng,
@@ -568,6 +621,43 @@ impl TestRng {
 
     /// Randomize a perturbed randomized seed from the given TestRng.
     pub(crate) fn new_rng_seed(&mut self) -> Seed {
+        // When the choice tape is active, derive child seeds through the
+        // intercepted `fill_bytes` path so that the derivation is recorded
+        // on (and replayed from) the tape. This keeps strategies that
+        // derive RNGs (`prop_perturb`, `Just`-with-rng, ...) deterministic
+        // under tape replay even though the inner RNG's state diverges
+        // between recording and replay.
+        if self.tape.raw_active() {
+            match self.rng {
+                TestRngImpl::XorShift(..) => {
+                    let mut seed = [0u8; 16];
+                    self.fill_bytes(&mut seed);
+                    // Perturb the seed as in the untaped path below, in
+                    // case the tape happens to replay the RNG's own next
+                    // output.
+                    for word in seed.chunks_mut(4) {
+                        word[3] ^= 0xde;
+                        word[2] ^= 0xad;
+                        word[1] ^= 0xbe;
+                        word[0] ^= 0xef;
+                    }
+                    return Seed::XorShift(seed);
+                }
+                TestRngImpl::ChaCha(..) => {
+                    let mut seed = [0u8; 32];
+                    self.fill_bytes(&mut seed);
+                    return Seed::ChaCha(seed);
+                }
+                TestRngImpl::Recorder { .. } => {
+                    let mut seed = [0u8; 32];
+                    self.fill_bytes(&mut seed);
+                    return Seed::Recorder(seed);
+                }
+                // PassThrough splits its remaining data rather than
+                // drawing entropy; fall through to the untaped path.
+                TestRngImpl::PassThrough { .. } => (),
+            }
+        }
         match self.rng {
             TestRngImpl::XorShift(ref mut rng) => {
                 let mut seed = rng.random::<[u8; 16]>();
@@ -634,6 +724,7 @@ impl TestRng {
                     record: Vec::new(),
                 },
             },
+            tape: TapeState::default(),
         }
     }
 }

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -269,6 +269,27 @@ pub(crate) enum Seed {
     Recorder([u8; 32]),
 }
 
+/// Hex-decode `src` into `dst`; `src` must be exactly twice as long.
+pub(crate) fn from_base16(dst: &mut [u8], src: &str) -> Option<()> {
+    if dst.len() * 2 != src.len() {
+        return None;
+    }
+
+    for (dst_byte, src_pair) in dst.into_iter().zip(src.as_bytes().chunks(2)) {
+        *dst_byte =
+            u8::from_str_radix(str::from_utf8(src_pair).ok()?, 16).ok()?;
+    }
+
+    Some(())
+}
+
+/// Hex-encode `src`, appending to `dst`.
+pub(crate) fn to_base16(dst: &mut String, src: &[u8]) {
+    for byte in src {
+        dst.push_str(&format!("{:02x}", byte));
+    }
+}
+
 impl Seed {
     pub(crate) fn from_bytes(algorithm: RngAlgorithm, seed: &[u8]) -> Self {
         match algorithm {
@@ -300,22 +321,6 @@ impl Seed {
     }
 
     pub(crate) fn from_persistence(string: &str) -> Option<Seed> {
-        fn from_base16(dst: &mut [u8], src: &str) -> Option<()> {
-            if dst.len() * 2 != src.len() {
-                return None;
-            }
-
-            for (dst_byte, src_pair) in
-                dst.into_iter().zip(src.as_bytes().chunks(2))
-            {
-                *dst_byte =
-                    u8::from_str_radix(str::from_utf8(src_pair).ok()?, 16)
-                        .ok()?;
-            }
-
-            Some(())
-        }
-
         let parts =
             string.trim().split(char::is_whitespace).collect::<Vec<_>>();
         RngAlgorithm::from_persistence_key(&parts[0]).and_then(
@@ -379,12 +384,6 @@ impl Seed {
     }
 
     pub(crate) fn to_persistence(&self) -> String {
-        fn to_base16(dst: &mut String, src: &[u8]) {
-            for byte in src {
-                dst.push_str(&format!("{:02x}", byte));
-            }
-        }
-
         match *self {
             Seed::XorShift(ref seed) => {
                 let dwords = [

--- a/proptest/src/test_runner/rng.rs
+++ b/proptest/src/test_runner/rng.rs
@@ -8,15 +8,15 @@
 // except according to those terms.
 
 use crate::std_facade::{Arc, String, ToOwned, Vec};
+use crate::test_runner::config;
 use core::convert::{Infallible, TryInto};
 use core::result::Result;
 use core::{fmt, str, u8};
-use crate::test_runner::config;
-use rand::{Rng, RngExt, SeedableRng, TryRng};
 #[cfg(feature = "std")]
 use rand::rand_core::UnwrapErr;
 #[cfg(feature = "std")]
 use rand::rngs::SysRng;
+use rand::{Rng, RngExt, SeedableRng, TryRng};
 use rand_chacha::ChaChaRng;
 use rand_xorshift::XorShiftRng;
 
@@ -185,9 +185,10 @@ impl TestRng {
             TestRngImpl::ChaCha(rng) => rng.fill_bytes(dest),
             TestRngImpl::PassThrough { off, end, data } => {
                 let bytes_to_copy = dest.len().min(*end - *off);
-                dest[.. bytes_to_copy].copy_from_slice(&data[*off .. *off + bytes_to_copy]);
+                dest[..bytes_to_copy]
+                    .copy_from_slice(&data[*off..*off + bytes_to_copy]);
                 *off += bytes_to_copy;
-                for i in bytes_to_copy .. dest.len() {
+                for i in bytes_to_copy..dest.len() {
                     dest[i] = 0;
                 }
             }
@@ -238,10 +239,12 @@ impl TryRng for TestRng {
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         if self.tape.raw_active() {
             if let Some(Choice::RawBytes { value }) =
-                self.tape.pop_replay(|c| matches!(
-                    c,
-                    Choice::RawBytes { value } if value.len() == dest.len()
-                ))
+                self.tape.pop_replay(|c| {
+                    matches!(
+                        c,
+                        Choice::RawBytes { value } if value.len() == dest.len()
+                    )
+                })
             {
                 dest.copy_from_slice(&value);
                 self.tape.record(Choice::RawBytes { value });
@@ -457,22 +460,33 @@ impl TestRng {
     }
 
     /// Construct a default TestRng from entropy.
-    pub(crate) fn default_rng(seed: config::RngSeed, algorithm: RngAlgorithm) -> Self {
+    pub(crate) fn default_rng(
+        seed: config::RngSeed,
+        algorithm: RngAlgorithm,
+    ) -> Self {
         #[cfg(feature = "std")]
         {
             Self {
                 rng: match algorithm {
                     RngAlgorithm::XorShift => {
                         let rng = match seed {
-                            config::RngSeed::Random => from_sys_rng::<XorShiftRng>(),
-                            config::RngSeed::Fixed(seed) => XorShiftRng::seed_from_u64(seed),
+                            config::RngSeed::Random => {
+                                from_sys_rng::<XorShiftRng>()
+                            }
+                            config::RngSeed::Fixed(seed) => {
+                                XorShiftRng::seed_from_u64(seed)
+                            }
                         };
                         TestRngImpl::XorShift(rng)
                     }
                     RngAlgorithm::ChaCha => {
                         let rng = match seed {
-                            config::RngSeed::Random => from_sys_rng::<ChaChaRng>(),
-                            config::RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
+                            config::RngSeed::Random => {
+                                from_sys_rng::<ChaChaRng>()
+                            }
+                            config::RngSeed::Fixed(seed) => {
+                                ChaChaRng::seed_from_u64(seed)
+                            }
                         };
                         TestRngImpl::ChaCha(rng)
                     }
@@ -480,12 +494,19 @@ impl TestRng {
                         panic!("cannot create default instance of PassThrough")
                     }
                     RngAlgorithm::Recorder => {
-                        let rng =  match seed {
-                            config::RngSeed::Random => from_sys_rng::<ChaChaRng>(),
-                            config::RngSeed::Fixed(seed) => ChaChaRng::seed_from_u64(seed),
+                        let rng = match seed {
+                            config::RngSeed::Random => {
+                                from_sys_rng::<ChaChaRng>()
+                            }
+                            config::RngSeed::Fixed(seed) => {
+                                ChaChaRng::seed_from_u64(seed)
+                            }
                         };
-                        TestRngImpl::Recorder {rng, record: Vec::new()}
-                    },
+                        TestRngImpl::Recorder {
+                            rng,
+                            record: Vec::new(),
+                        }
+                    }
                     RngAlgorithm::_NonExhaustive => unreachable!(),
                 },
                 tape: TapeState::default(),
@@ -816,22 +837,15 @@ mod test {
     #[test]
     fn seeded_xorshift_output_is_stable() {
         let seed = [
-            0x00, 0x01, 0x02, 0x03,
-            0x04, 0x05, 0x06, 0x07,
-            0x08, 0x09, 0x0a, 0x0b,
-            0x0c, 0x0d, 0x0e, 0x0f,
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+            0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
         ];
         let mut rng_u32 = TestRng::from_seed(RngAlgorithm::XorShift, &seed);
         let mut rng_u64 = TestRng::from_seed(RngAlgorithm::XorShift, &seed);
         let mut rng_fill = TestRng::from_seed(RngAlgorithm::XorShift, &seed);
 
         assert_eq!(
-            [
-                471271404,
-                722341711,
-                1880555887,
-                252576780,
-            ],
+            [471271404, 722341711, 1880555887, 252576780,],
             [
                 rng_u32.next_u32(),
                 rng_u32.next_u32(),
@@ -865,26 +879,16 @@ mod test {
     #[test]
     fn seeded_chacha_output_is_stable() {
         let seed = [
-            0x00, 0x01, 0x02, 0x03,
-            0x04, 0x05, 0x06, 0x07,
-            0x08, 0x09, 0x0a, 0x0b,
-            0x0c, 0x0d, 0x0e, 0x0f,
-            0x10, 0x11, 0x12, 0x13,
-            0x14, 0x15, 0x16, 0x17,
-            0x18, 0x19, 0x1a, 0x1b,
-            0x1c, 0x1d, 0x1e, 0x1f,
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+            0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+            0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
         ];
         let mut rng_u32 = TestRng::from_seed(RngAlgorithm::ChaCha, &seed);
         let mut rng_u64 = TestRng::from_seed(RngAlgorithm::ChaCha, &seed);
         let mut rng_fill = TestRng::from_seed(RngAlgorithm::ChaCha, &seed);
 
         assert_eq!(
-            [
-                2100034873,
-                1780073945,
-                1996733837,
-                1229642936,
-            ],
+            [2100034873, 1780073945, 1996733837, 1229642936,],
             [
                 rng_u32.next_u32(),
                 rng_u32.next_u32(),
@@ -910,7 +914,10 @@ mod test {
         let mut fill = [0u8; 16];
         rng_fill.fill_bytes(&mut fill);
         assert_eq!(
-            [57, 253, 43, 125, 217, 197, 25, 106, 141, 189, 3, 119, 184, 220, 74, 73],
+            [
+                57, 253, 43, 125, 217, 197, 25, 106, 141, 189, 3, 119, 184,
+                220, 74, 73
+            ],
             fill
         );
     }
@@ -918,25 +925,15 @@ mod test {
     #[test]
     fn derived_child_rng_output_is_stable() {
         let seed = [
-            0x00, 0x01, 0x02, 0x03,
-            0x04, 0x05, 0x06, 0x07,
-            0x08, 0x09, 0x0a, 0x0b,
-            0x0c, 0x0d, 0x0e, 0x0f,
-            0x10, 0x11, 0x12, 0x13,
-            0x14, 0x15, 0x16, 0x17,
-            0x18, 0x19, 0x1a, 0x1b,
-            0x1c, 0x1d, 0x1e, 0x1f,
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+            0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+            0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
         ];
         let mut parent = TestRng::from_seed(RngAlgorithm::ChaCha, &seed);
         let mut child = parent.gen_rng();
 
         assert_eq!(
-            [
-                357635273,
-                1295757006,
-                1334659017,
-                3423482104,
-            ],
+            [357635273, 1295757006, 1334659017, 3423482104,],
             [
                 child.next_u32(),
                 child.next_u32(),
@@ -949,14 +946,9 @@ mod test {
     #[test]
     fn recorder_bytes_used_matches_emitted_bytes() {
         let seed = [
-            0x00, 0x01, 0x02, 0x03,
-            0x04, 0x05, 0x06, 0x07,
-            0x08, 0x09, 0x0a, 0x0b,
-            0x0c, 0x0d, 0x0e, 0x0f,
-            0x10, 0x11, 0x12, 0x13,
-            0x14, 0x15, 0x16, 0x17,
-            0x18, 0x19, 0x1a, 0x1b,
-            0x1c, 0x1d, 0x1e, 0x1f,
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+            0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+            0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
         ];
         let mut rng = TestRng::from_seed(RngAlgorithm::Recorder, &seed);
         let first = rng.next_u32();
@@ -971,5 +963,4 @@ mod test {
 
         assert_eq!(expected, rng.bytes_used());
     }
-
 }

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -31,7 +31,9 @@ use tempfile;
 use crate::strategy::*;
 use crate::test_runner::config::*;
 use crate::test_runner::errors::*;
-use crate::test_runner::failure_persistence::PersistedSeed;
+use crate::test_runner::failure_persistence::{
+    PersistedFailure, PersistedSeed,
+};
 use crate::test_runner::reason::*;
 #[cfg(feature = "fork")]
 use crate::test_runner::replay;
@@ -82,6 +84,11 @@ pub struct TestRunner {
 
     local_reject_detail: RejectionDetail,
     global_reject_detail: RejectionDetail,
+
+    /// Serialized winning tape of the most recent tape shrink, picked up
+    /// by the failure-persistence save site (which is outside the tape
+    /// code path).
+    shrunk_tape: Option<Vec<u8>>,
 }
 
 impl fmt::Debug for TestRunner {
@@ -355,6 +362,7 @@ impl TestRunner {
             flat_map_regens: Arc::new(AtomicUsize::new(0)),
             local_reject_detail: BTreeMap::new(),
             global_reject_detail: BTreeMap::new(),
+            shrunk_tape: None,
         }
     }
 
@@ -371,6 +379,7 @@ impl TestRunner {
             flat_map_regens: Arc::clone(&self.flat_map_regens),
             local_reject_detail: BTreeMap::new(),
             global_reject_detail: BTreeMap::new(),
+            shrunk_tape: None,
         }
     }
 
@@ -602,18 +611,39 @@ impl TestRunner {
 
         let mut result_cache = self.new_cache();
 
-        for PersistedSeed(persisted_seed) in
+        for PersistedSeed(persisted) in
             persisted_failure_seeds.into_iter().rev()
         {
-            self.rng.set_seed(persisted_seed);
-            self.gen_and_run_case(
-                strategy,
-                &test,
-                &mut replay_from_fork,
-                &mut *result_cache,
-                &mut fork_output,
-                true,
-            )?;
+            match persisted {
+                PersistedFailure::Seed(persisted_seed) => {
+                    self.rng.set_seed(persisted_seed);
+                    self.gen_and_run_case(
+                        strategy,
+                        &test,
+                        &mut replay_from_fork,
+                        &mut *result_cache,
+                        &mut fork_output,
+                        true,
+                    )?;
+                }
+                PersistedFailure::Tape(bytes) => {
+                    match tape::deserialize_tape(&bytes) {
+                        Some(input) => self.replay_persisted_tape(
+                            strategy,
+                            input,
+                            &test,
+                            &mut replay_from_fork,
+                            &mut *result_cache,
+                            &mut fork_output,
+                        )?,
+                        None => verbose_message!(
+                            self,
+                            ALWAYS,
+                            "Ignoring corrupt persisted choice tape"
+                        ),
+                    }
+                }
+            }
         }
         self.rng = old_rng;
 
@@ -639,9 +669,17 @@ impl TestRunner {
                     // process. The parent relies on it remaining consistent
                     // and will take care of updating it itself.
                     if !fork_output.is_in_fork() {
+                        // Prefer persisting the winning choice tape when
+                        // the tape engine shrank this failure: it replays
+                        // the shrunken values exactly, independent of the
+                        // RNG, and survives strategy refactors.
+                        let persisted = match self.shrunk_tape.take() {
+                            Some(bytes) => PersistedFailure::Tape(bytes),
+                            None => PersistedFailure::Seed(seed),
+                        };
                         failure_persistence.save_persisted_failure2(
                             *source_file,
-                            PersistedSeed(seed),
+                            PersistedSeed(persisted),
                             value,
                         );
                     }
@@ -1361,8 +1399,97 @@ impl TestRunner {
             budget.iterations
         );
 
+        if self.config.failure_persistence.is_some() {
+            self.shrunk_tape = Some(tape::serialize_tape(&best.tape));
+        }
+
         self.rng = rng_snapshot;
         (best.why, best.tree.current())
+    }
+
+    /// Replay a persisted choice tape: regenerate a value from it, run
+    /// the test, and re-shrink on failure. Stale tapes (the strategy has
+    /// changed since they were saved) replay best-effort: misaligned
+    /// draws sample fresh, and a tape that no longer generates anything
+    /// is skipped.
+    fn replay_persisted_tape<S: Strategy>(
+        &mut self,
+        strategy: &S,
+        input: Tape,
+        f: &impl Fn(S::Value) -> TestCaseResult,
+        replay_from_fork: &mut impl Iterator<Item = TestCaseResult>,
+        result_cache: &mut dyn ResultCache,
+        fork_output: &mut ForkOutput,
+    ) -> TestRunResult<S> {
+        let rng_snapshot = self.rng.clone();
+        self.rng.tape.start_replay(input);
+        let case = match strategy.new_tree(self) {
+            Ok(case) => case,
+            Err(_) => {
+                self.rng.tape.finish_replay();
+                self.rng = rng_snapshot;
+                verbose_message!(
+                    self,
+                    ALWAYS,
+                    "Persisted choice tape no longer generates a value; \
+                     ignoring it"
+                );
+                return Ok(());
+            }
+        };
+        let (output, _overrun) = self.rng.tape.finish_replay();
+
+        if ShrinkEngine::Tape == self.config.shrink_engine
+            && !self.config.fork()
+            && !fork_output.is_in_fork()
+        {
+            let result = call_test(
+                self,
+                case.current(),
+                f,
+                replay_from_fork,
+                result_cache,
+                fork_output,
+                true,
+            );
+            match result {
+                Ok(_) => {
+                    self.rng = rng_snapshot;
+                    Ok(())
+                }
+                Err(TestCaseError::Fail(why)) => {
+                    let (why, value) = self.tape_shrink(
+                        strategy,
+                        f,
+                        rng_snapshot,
+                        output,
+                        case,
+                        why,
+                        result_cache,
+                        fork_output,
+                    );
+                    Err(TestError::Fail(why, value))
+                }
+                Err(TestCaseError::Reject(whence)) => {
+                    self.rng = rng_snapshot;
+                    self.reject_global(whence)?;
+                    Ok(())
+                }
+            }
+        } else {
+            // ValueTree engine (or fork mode): hand the generated case to
+            // the classic path, which shrinks with the ValueTree walker.
+            self.rng = rng_snapshot;
+            self.run_one_with_replay(
+                case,
+                f,
+                replay_from_fork,
+                result_cache,
+                fork_output,
+                true,
+            )
+            .map(|_| ())
+        }
     }
 
     /// Run one shrink attempt: replay `proposal` through generation, run

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -616,17 +616,30 @@ impl TestRunner {
         {
             match persisted {
                 PersistedFailure::Seed(persisted_seed) => {
+                    // Replay seeds through the classic, tape-off
+                    // generation path: seed entries are only written by
+                    // tape-off runs (fork/timeout, ValueTree engine, or
+                    // persistence impls that drop tapes), and tape-mode
+                    // generation consumes the RNG differently (e.g.
+                    // collection continuation flags), so recording here
+                    // would regenerate a different value than the one
+                    // that failed.
                     self.rng.set_seed(persisted_seed);
-                    self.gen_and_run_case(
-                        strategy,
+                    let case = unwrap_or!(strategy.new_tree(self), msg =>
+                        return Err(TestError::Abort(msg)));
+                    let ok_type = self.run_one_with_replay(
+                        case,
                         &test,
                         &mut replay_from_fork,
                         &mut *result_cache,
                         &mut fork_output,
                         true,
                     )?;
+                    if let TestCaseOk::ReplayFromForkSuccess = ok_type {
+                        self.successes += 1;
+                    }
                 }
-                PersistedFailure::Tape(bytes) => {
+                PersistedFailure::Tape { bytes, .. } => {
                     match tape::deserialize_tape(&bytes) {
                         Some(input) => self.replay_persisted_tape(
                             strategy,
@@ -636,11 +649,14 @@ impl TestRunner {
                             &mut *result_cache,
                             &mut fork_output,
                         )?,
-                        None => verbose_message!(
-                            self,
-                            ALWAYS,
-                            "Ignoring corrupt persisted choice tape"
-                        ),
+                        None => {
+                            return Err(TestError::Abort(
+                                "A persisted choice tape (ct1 entry) in \
+                                 the regression file is corrupt; delete \
+                                 the stale line to continue."
+                                    .into(),
+                            ))
+                        }
                     }
                 }
             }
@@ -674,7 +690,10 @@ impl TestRunner {
                         // the shrunken values exactly, independent of the
                         // RNG, and survives strategy refactors.
                         let persisted = match self.shrunk_tape.take() {
-                            Some(bytes) => PersistedFailure::Tape(bytes),
+                            Some(bytes) => PersistedFailure::Tape {
+                                bytes,
+                                seed: Some(seed),
+                            },
                             None => PersistedFailure::Seed(seed),
                         };
                         failure_persistence.save_persisted_failure2(
@@ -1288,15 +1307,6 @@ impl TestRunner {
         if 0 != self.rng.random_range(0..20u32) {
             return None;
         }
-        fn next_up(a: f64) -> f64 {
-            if a == 0.0 {
-                f64::from_bits(1)
-            } else if a > 0.0 {
-                f64::from_bits(a.to_bits() + 1)
-            } else {
-                f64::from_bits(a.to_bits() - 1)
-            }
-        }
         let candidates = [
             0.0,
             -0.0,
@@ -1306,8 +1316,8 @@ impl TestRunner {
             1.5,
             min,
             max,
-            if min.is_finite() { next_up(min) } else { min },
-            if max.is_finite() { -next_up(-max) } else { max },
+            if min.is_finite() { min.next_up() } else { min },
+            if max.is_finite() { max.next_down() } else { max },
             if allow_nan { f64::NAN } else { 0.0 },
         ];
         let candidate = candidates[self.rng.random_range(0..candidates.len())];
@@ -1375,6 +1385,46 @@ impl TestRunner {
     /// replayed value is honored). See `TapeState::draw_bool_forced`.
     pub fn draw_bool_forced(&mut self, forced: bool) -> bool {
         self.rng.tape.draw_bool_forced(forced)
+    }
+
+    /// Drive the tape encoding of a variable-length sequence of
+    /// generation units (collection elements, state-machine
+    /// transitions). Call once per candidate element with its index;
+    /// returns whether one more element should be generated. Only
+    /// meaningful while the tape is on; callers keep their classic
+    /// generation path for the tape-off case.
+    ///
+    /// Encodes one continuation flag per element (truncated-geometric
+    /// length with the same mean as uniform over `[min, max]`), plus a
+    /// forced stop marker at the maximum so all lengths share one tape
+    /// shape. With `soft_minimum`, elements below `min` get
+    /// generation-forced but shrink-editable flags, letting the shrinker
+    /// delete below the declared minimum (state-machine semantics);
+    /// without it, `min` is a hard floor (collection semantics).
+    pub fn draw_element_flag(
+        &mut self,
+        index: usize,
+        min: usize,
+        max: usize,
+        soft_minimum: bool,
+    ) -> bool {
+        if index >= max {
+            let any_flags = if soft_minimum { max > 0 } else { max > min };
+            if any_flags {
+                self.record_forced_bool(false);
+            }
+            return false;
+        }
+        if index < min {
+            return if soft_minimum {
+                self.draw_bool_forced(true)
+            } else {
+                true
+            };
+        }
+        let extra = (max - min) as f64 / 2.0;
+        let p_continue = extra / (extra + 1.0);
+        self.draw_bool(p_continue)
     }
 
     /// The tape-engine analogue of `gen_and_run_case`.
@@ -1593,16 +1643,22 @@ impl TestRunner {
         self.rng.tape.start_replay(input);
         let case = match strategy.new_tree(self) {
             Ok(case) => case,
-            Err(_) => {
+            Err(reason) => {
                 self.rng.tape.finish_replay();
                 self.rng = rng_snapshot;
-                verbose_message!(
-                    self,
-                    ALWAYS,
-                    "Persisted choice tape no longer generates a value; \
-                     ignoring it"
-                );
-                return Ok(());
+                // Fail as loudly as a dead persisted seed would: a
+                // regression entry that stops generating (usually after
+                // a strategy refactor) is guarding nothing, and silently
+                // continuing would let a reintroduced bug ship.
+                return Err(TestError::Abort(
+                    format!(
+                        "A persisted choice tape (ct1 entry) in the \
+                         regression file no longer generates a value \
+                         ({}); delete the stale line to continue.",
+                        reason
+                    )
+                    .into(),
+                ));
             }
         };
         let (output, _overrun) = self.rng.tape.finish_replay();
@@ -1680,7 +1736,15 @@ impl TestRunner {
 
         self.rng = rng_snapshot.clone();
         self.rng.tape.start_replay(proposal);
+        // Local rejects incurred while re-vetting a shrink proposal (e.g.
+        // a filter refusing edited values) must not drain the run-wide
+        // budget: the classic shrinker never consumes it while shrinking,
+        // and a filter-heavy strategy could otherwise exhaust it mid-way
+        // and silently doom every remaining attempt. Each attempt still
+        // has the remaining budget as its own retry bound.
+        let local_rejects_before = self.local_rejects;
         let tree = strategy.new_tree(self);
+        self.local_rejects = local_rejects_before;
         let (output, overrun) = self.rng.tape.finish_replay();
         let tree = match tree {
             Ok(tree) => tree,
@@ -1880,26 +1944,23 @@ impl TestRunner {
                 } else {
                     (value_i + d, value_j - d)
                 };
-                let proposal = best
-                    .tape
-                    .with_choice(
-                        i,
-                        Choice::Integer {
-                            value: new_i,
-                            min: min_i,
-                            max: max_i,
-                            shrink_to: shrink_to_i,
-                        },
-                    )
-                    .with_choice(
-                        j,
-                        Choice::Integer {
-                            value: new_j,
-                            min: min_j,
-                            max: max_j,
-                            shrink_to: shrink_to_j,
-                        },
-                    );
+                // One clone for the two-index edit (chaining with_choice
+                // would clone the whole tape twice).
+                let mut proposal = best.tape.with_choice(
+                    i,
+                    Choice::Integer {
+                        value: new_i,
+                        min: min_i,
+                        max: max_i,
+                        shrink_to: shrink_to_i,
+                    },
+                );
+                proposal.choices[j] = Choice::Integer {
+                    value: new_j,
+                    min: min_j,
+                    max: max_j,
+                    shrink_to: shrink_to_j,
+                };
                 match self.tape_attempt(
                     strategy,
                     test,

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -72,6 +72,18 @@ macro_rules! verbose_message {
 
 type RejectionDetail = BTreeMap<Reason, u32>;
 
+/// How [`TestRunner::draw_element_flag`] treats the declared minimum
+/// length: `Hard` (collection semantics: the shrinker must respect the
+/// floor) or `Soft` (state-machine semantics: elements below the
+/// minimum get shrink-editable flags, so shrinking may go below it).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ElementMinimum {
+    /// `min` is a floor the shrinker must respect.
+    Hard,
+    /// The shrinker may delete elements below `min`.
+    Soft,
+}
+
 /// State used when running a proptest test.
 #[derive(Clone)]
 pub struct TestRunner {
@@ -611,6 +623,13 @@ impl TestRunner {
 
         let mut result_cache = self.new_cache();
 
+        // Dead regression entries (corrupt lines, or tapes that no
+        // longer generate) are collected and reported AFTER every
+        // other entry and all fresh cases have run: one bit-rotted
+        // line must not reduce the property's coverage to zero, but
+        // it must not silently pass either.
+        let mut dead_entries: Vec<String> = Vec::new();
+
         for PersistedSeed(persisted) in
             persisted_failure_seeds.into_iter().rev()
         {
@@ -625,38 +644,33 @@ impl TestRunner {
                     // would regenerate a different value than the one
                     // that failed.
                     self.rng.set_seed(persisted_seed);
-                    let case = unwrap_or!(strategy.new_tree(self), msg =>
-                        return Err(TestError::Abort(msg)));
-                    let ok_type = self.run_one_with_replay(
-                        case,
+                    self.run_classic_case(
+                        strategy,
                         &test,
                         &mut replay_from_fork,
                         &mut *result_cache,
                         &mut fork_output,
                         true,
                     )?;
-                    if let TestCaseOk::ReplayFromForkSuccess = ok_type {
-                        self.successes += 1;
-                    }
                 }
                 PersistedFailure::Tape { bytes, .. } => {
                     match tape::deserialize_tape(&bytes) {
-                        Some(input) => self.replay_persisted_tape(
-                            strategy,
-                            input,
-                            &test,
-                            &mut replay_from_fork,
-                            &mut *result_cache,
-                            &mut fork_output,
-                        )?,
-                        None => {
-                            return Err(TestError::Abort(
-                                "A persisted choice tape (ct1 entry) in \
-                                 the regression file is corrupt; delete \
-                                 the stale line to continue."
-                                    .into(),
-                            ))
+                        Some(input) => {
+                            if let Err(dead) = self.replay_persisted_tape(
+                                strategy,
+                                input,
+                                &test,
+                                &mut replay_from_fork,
+                                &mut *result_cache,
+                                &mut fork_output,
+                            )? {
+                                dead_entries.push(dead);
+                            }
                         }
+                        None => dead_entries.push(format!(
+                            "a persisted choice tape (ct1 entry) is \
+                             corrupt"
+                        )),
                     }
                 }
             }
@@ -712,6 +726,50 @@ impl TestRunner {
         }
 
         fork_output.terminate();
+
+        if !dead_entries.is_empty() {
+            return Err(TestError::Abort(
+                format!(
+                    "{} regression file entr{} stopped guarding ({}); \
+                     delete the stale line(s) or re-trigger the \
+                     failure(s) to re-record them. All other entries \
+                     and the configured fresh cases ran first.",
+                    dead_entries.len(),
+                    if dead_entries.len() == 1 { "y" } else { "ies" },
+                    dead_entries.join("; "),
+                )
+                .into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// The classic (tape-off) generate-and-run tail shared by
+    /// `gen_and_run_case` and persisted-seed replay: one place owns the
+    /// success-accounting contract for `run_one_with_replay`.
+    fn run_classic_case<S: Strategy>(
+        &mut self,
+        strategy: &S,
+        f: &impl Fn(S::Value) -> TestCaseResult,
+        replay_from_fork: &mut impl Iterator<Item = TestCaseResult>,
+        result_cache: &mut dyn ResultCache,
+        fork_output: &mut ForkOutput,
+        is_from_persisted_seed: bool,
+    ) -> TestRunResult<S> {
+        let case = unwrap_or!(strategy.new_tree(self), msg =>
+            return Err(TestError::Abort(msg)));
+        let ok_type = self.run_one_with_replay(
+            case,
+            f,
+            replay_from_fork,
+            result_cache,
+            fork_output,
+            is_from_persisted_seed,
+        )?;
+        if let TestCaseOk::ReplayFromForkSuccess = ok_type {
+            self.successes += 1;
+        }
         Ok(())
     }
 
@@ -746,7 +804,10 @@ impl TestRunner {
                 return Err(TestError::Abort(msg)));
 
         // We only count new cases to our set of successful runs against
-        // `PROPTEST_CASES` config.
+        // `PROPTEST_CASES` config. NOTE: this accounting deliberately
+        // differs from `run_classic_case` (the persisted-seed variant),
+        // which must NOT count `NewCaseSuccess`; change them together
+        // only if that distinction is meant to go away.
         let ok_type = self.run_one_with_replay(
             case,
             f,
@@ -1401,17 +1462,30 @@ impl TestRunner {
     /// Encodes one continuation flag per element (truncated-geometric
     /// length with the same mean as uniform over `[min, max]`), plus a
     /// forced stop marker at the maximum so all lengths share one tape
-    /// shape. With `soft_minimum`, elements below `min` get
-    /// generation-forced but shrink-editable flags, letting the shrinker
-    /// delete below the declared minimum (state-machine semantics);
-    /// without it, `min` is a hard floor (collection semantics).
+    /// shape.
+    ///
+    /// The `minimum` mode also selects the stop-marker condition; the
+    /// two differ deliberately and getting this wrong silently
+    /// misaligns tape shapes between lengths:
+    ///
+    /// | mode   | below `min`                      | stop marker when  |
+    /// |--------|----------------------------------|-------------------|
+    /// | `Hard` | plain `true`, nothing recorded   | `max > min`       |
+    /// | `Soft` | forced but shrink-editable flag  | `max > 0`         |
+    ///
+    /// `Hard` is collection semantics (`min` is a floor the shrinker
+    /// must respect); `Soft` is state-machine semantics (the shrinker
+    /// may delete below the declared minimum, so every element below
+    /// `min` needs an editable flag and the marker exists whenever any
+    /// element could).
     pub fn draw_element_flag(
         &mut self,
         index: usize,
         min: usize,
         max: usize,
-        soft_minimum: bool,
+        minimum: ElementMinimum,
     ) -> bool {
+        let soft_minimum = matches!(minimum, ElementMinimum::Soft);
         if index >= max {
             let any_flags = if soft_minimum { max > 0 } else { max > min };
             if any_flags {
@@ -1646,8 +1720,11 @@ impl TestRunner {
     /// Replay a persisted choice tape: regenerate a value from it, run
     /// the test, and re-shrink on failure. Stale tapes (the strategy has
     /// changed since they were saved) replay best-effort: misaligned
-    /// draws sample fresh, and a tape that no longer generates anything
-    /// is skipped.
+    /// draws sample fresh. Returns `Ok(Err(reason))` for a dead tape
+    /// (one that no longer generates a value): the caller collects
+    /// those and reports them after every other entry and all fresh
+    /// cases have run, so one bit-rotted line neither hides a later
+    /// failure nor silently passes.
     fn replay_persisted_tape<S: Strategy>(
         &mut self,
         strategy: &S,
@@ -1656,7 +1733,7 @@ impl TestRunner {
         replay_from_fork: &mut impl Iterator<Item = TestCaseResult>,
         result_cache: &mut dyn ResultCache,
         fork_output: &mut ForkOutput,
-    ) -> TestRunResult<S> {
+    ) -> Result<Result<(), String>, TestError<S::Value>> {
         let rng_snapshot = self.rng.clone();
         self.rng.tape.start_replay(input);
         let case = match strategy.new_tree(self) {
@@ -1664,19 +1741,11 @@ impl TestRunner {
             Err(reason) => {
                 self.rng.tape.finish_replay();
                 self.rng = rng_snapshot;
-                // Fail as loudly as a dead persisted seed would: a
-                // regression entry that stops generating (usually after
-                // a strategy refactor) is guarding nothing, and silently
-                // continuing would let a reintroduced bug ship.
-                return Err(TestError::Abort(
-                    format!(
-                        "A persisted choice tape (ct1 entry) in the \
-                         regression file no longer generates a value \
-                         ({}); delete the stale line to continue.",
-                        reason
-                    )
-                    .into(),
-                ));
+                return Ok(Err(format!(
+                    "a persisted choice tape (ct1 entry) no longer \
+                     generates a value ({})",
+                    reason
+                )));
             }
         };
         let (output, _overrun) = self.rng.tape.finish_replay();
@@ -1697,7 +1766,7 @@ impl TestRunner {
             match result {
                 Ok(_) => {
                     self.rng = rng_snapshot;
-                    Ok(())
+                    Ok(Ok(()))
                 }
                 Err(TestCaseError::Fail(why)) => {
                     let (why, value) = self.tape_shrink(
@@ -1715,7 +1784,7 @@ impl TestRunner {
                 Err(TestCaseError::Reject(whence)) => {
                     self.rng = rng_snapshot;
                     self.reject_global(whence)?;
-                    Ok(())
+                    Ok(Ok(()))
                 }
             }
         } else {
@@ -1730,7 +1799,7 @@ impl TestRunner {
                 fork_output,
                 true,
             )
-            .map(|_| ())
+            .map(|_| Ok(()))
         }
     }
 
@@ -1914,7 +1983,7 @@ impl TestRunner {
     ) -> (bool, bool) {
         let mut improved = false;
         let mut i = 0;
-        'outer: while i < best.tape.choices.len() {
+        while i < best.tape.choices.len() {
             // Re-read on every iteration: accepted attempts rewrite the
             // tape. Only above-target integers participate; a length-like
             // choice shrinks downward.
@@ -1930,20 +1999,26 @@ impl TestRunner {
                     continue;
                 }
             };
-            // Pair the lowered integer with each span after it, last to
-            // first (matching the deletion pass's direction).
+            // Pair the lowered integer with each span after it, walking
+            // spans in ASCENDING order and, on an accepted deletion,
+            // greedily repeating at the same span position: deletable
+            // spans cluster (the redistribute pass piles zeros early),
+            // and the sibling OCaml engine measured a 26x attempt
+            // reduction from staying in place instead of restarting the
+            // whole scan (its review round then flagged the restart as
+            // the O(n^3) hot spot here).
             let mut pos = 0;
+            let mut value = value;
             loop {
-                let nspans = best.tape.spans.len();
-                if pos >= nspans {
+                if pos >= best.tape.spans.len() {
                     break;
                 }
-                let span = best.tape.spans[nspans - 1 - pos];
-                pos += 1;
+                let span = best.tape.spans[pos];
                 if span.start <= i
                     || span.end > best.tape.choices.len()
                     || span.start >= span.end
                 {
+                    pos += 1;
                     continue;
                 }
                 let mut proposal = best.tape.with_span_deleted(span);
@@ -1965,10 +2040,19 @@ impl TestRunner {
                 ) {
                     TapeAttemptResult::Accepted => {
                         improved = true;
-                        // The tape was rewritten; restart this position.
-                        continue 'outer;
+                        // Stay at this span position with the choice's
+                        // refreshed value; the next deletable span
+                        // usually sits exactly here.
+                        match best.tape.choices.get(i) {
+                            Some(Choice::Integer {
+                                value: new_value, ..
+                            }) if *new_value > shrink_to => {
+                                value = *new_value;
+                            }
+                            _ => break,
+                        }
                     }
-                    TapeAttemptResult::Rejected => {}
+                    TapeAttemptResult::Rejected => pos += 1,
                     TapeAttemptResult::Exhausted => return (improved, true),
                 }
             }

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -834,7 +834,7 @@ impl TestRunner {
                 INFO_LOG,
                 "Shrinking disabled by configuration"
             );
-            return None
+            return None;
         }
 
         #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
@@ -1027,7 +1027,11 @@ impl TestRunner {
         self.draw_integer_in_with(
             min,
             max,
-            |_| T::decode(T::encode_zero().clamp(T::encode(min), T::encode(max))),
+            |_| {
+                T::decode(
+                    T::encode_zero().clamp(T::encode(min), T::encode(max)),
+                )
+            },
             |v| v,
             sample,
         )
@@ -1050,11 +1054,13 @@ impl TestRunner {
         self.draw_integer_in_with(
             min,
             max,
-            |_| T::decode(T::encode_zero().clamp(T::encode(min), T::encode(max))),
-            |v| v,
-            |runner| {
-                runner.sample_integer_biased(min, max, &sample_uniform)
+            |_| {
+                T::decode(
+                    T::encode_zero().clamp(T::encode(min), T::encode(max)),
+                )
             },
+            |v| v,
+            |runner| runner.sample_integer_biased(min, max, &sample_uniform),
         )
     }
 
@@ -1220,8 +1226,7 @@ impl TestRunner {
         sample: impl FnOnce(&mut Self) -> f64,
     ) -> f64 {
         if !self.rng.tape.is_on() {
-            return match self.maybe_weird_float(min, max, allow_nan, &conform)
-            {
+            return match self.maybe_weird_float(min, max, allow_nan, &conform) {
                 Some(weird) => weird,
                 None => sample(self),
             };
@@ -1305,8 +1310,7 @@ impl TestRunner {
             if max.is_finite() { -next_up(-max) } else { max },
             if allow_nan { f64::NAN } else { 0.0 },
         ];
-        let candidate =
-            candidates[self.rng.random_range(0..candidates.len())];
+        let candidate = candidates[self.rng.random_range(0..candidates.len())];
         let candidate = conform(candidate);
         if candidate.is_nan() {
             return if allow_nan { Some(candidate) } else { None };
@@ -1738,8 +1742,7 @@ impl TestRunner {
                 break;
             }
             let span = best.tape.spans[nspans - 1 - pos];
-            if span.end > best.tape.choices.len() || span.start >= span.end
-            {
+            if span.end > best.tape.choices.len() || span.start >= span.end {
                 pos += 1;
                 continue;
             }
@@ -1775,8 +1778,7 @@ impl TestRunner {
                         let block = &best.tape.spans[lo_idx..=hi_idx];
                         let start =
                             block.iter().map(|s| s.start).min().unwrap();
-                        let end =
-                            block.iter().map(|s| s.end).max().unwrap();
+                        let end = block.iter().map(|s| s.end).max().unwrap();
                         if end > best.tape.choices.len() || start >= end {
                             break;
                         }
@@ -1843,9 +1845,9 @@ impl TestRunner {
                         continue;
                     }
                 };
-            let j = match (i + 1..best.tape.choices.len())
-                .find(|&j| matches!(best.tape.choices[j], Choice::Integer { .. }))
-            {
+            let j = match (i + 1..best.tape.choices.len()).find(|&j| {
+                matches!(best.tape.choices[j], Choice::Integer { .. })
+            }) {
                 Some(j) => j,
                 None => break,
             };
@@ -1978,8 +1980,7 @@ impl TestRunner {
             };
             let mut d = dist;
             while d > 0 {
-                let new_value =
-                    if above { value - d } else { value + d };
+                let new_value = if above { value - d } else { value + d };
                 let mut proposal = best.tape.clone();
                 let mut members = 0;
                 for choice in &mut proposal.choices {
@@ -2145,14 +2146,12 @@ impl TestRunner {
                     allow_nan,
                 };
                 let target = tape::float_shrink_target(min, max);
-                let read_current = |best: &TapeBest<S::Tree>| match best
-                    .tape
-                    .choices
-                    .get(idx)
-                {
-                    Some(Choice::Float { value, .. }) => Some(*value),
-                    _ => None,
-                };
+                let read_current =
+                    |best: &TapeBest<S::Tree>| match best.tape.choices.get(idx)
+                    {
+                        Some(Choice::Float { value, .. }) => Some(*value),
+                        _ => None,
+                    };
 
                 if value == target {
                     return (improved, false);
@@ -2197,8 +2196,7 @@ impl TestRunner {
                     let mut fail = cur;
                     let mut probe = 1.0f64;
                     while probe < (cur - target).abs() {
-                        let cand =
-                            tape::float_trunc(target + dir * probe);
+                        let cand = tape::float_trunc(target + dir * probe);
                         if attempt!(mk(cand)) {
                             fail = cand;
                             break;
@@ -2207,8 +2205,7 @@ impl TestRunner {
                         probe *= 2.0;
                     }
                     loop {
-                        let mid =
-                            tape::float_trunc(ok + (fail - ok) / 2.0);
+                        let mid = tape::float_trunc(ok + (fail - ok) / 2.0);
                         if mid == ok || mid == fail {
                             break;
                         }
@@ -2627,7 +2624,8 @@ mod test {
 
         // create value with recorder rng
         let default_config = Config::default();
-        let recorder_rng = TestRng::default_rng(RngSeed::Random, RngAlgorithm::Recorder);
+        let recorder_rng =
+            TestRng::default_rng(RngSeed::Random, RngAlgorithm::Recorder);
         let mut runner =
             TestRunner::new_with_rng(default_config.clone(), recorder_rng);
         let random_byte_array1 = runner.rng().random::<[u8; 16]>();

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -8,9 +8,11 @@
 // except according to those terms.
 
 use crate::std_facade::{Arc, BTreeMap, Box, String, Vec};
+use core::cmp::Ordering;
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering::SeqCst;
 use core::{fmt, iter};
+
 #[cfg(feature = "std")]
 use std::panic::{self, AssertUnwindSafe};
 
@@ -34,6 +36,7 @@ use crate::test_runner::reason::*;
 use crate::test_runner::replay;
 use crate::test_runner::result_cache::*;
 use crate::test_runner::rng::TestRng;
+use crate::test_runner::tape::{self, Choice, Tape, TapeInt};
 
 #[cfg(feature = "fork")]
 const ENV_FORK_FILE: &'static str = "_PROPTEST_FORKFILE";
@@ -663,6 +666,24 @@ impl TestRunner {
         fork_output: &mut ForkOutput,
         is_from_persisted_seed: bool,
     ) -> TestRunResult<S> {
+        // The tape engine needs the strategy in scope to re-run generation
+        // during shrinking, so it branches off here rather than in
+        // `run_one_with_replay`. It does not support fork mode (including
+        // the implicit fork from `timeout`).
+        if ShrinkEngine::Tape == self.config.shrink_engine
+            && !self.config.fork()
+            && !fork_output.is_in_fork()
+        {
+            return self.gen_and_run_case_tape(
+                strategy,
+                f,
+                replay_from_fork,
+                result_cache,
+                fork_output,
+                is_from_persisted_seed,
+            );
+        }
+
         let case = unwrap_or!(strategy.new_tree(self), msg =>
                 return Err(TestError::Abort(msg)));
 
@@ -943,6 +964,585 @@ impl TestRunner {
 
     fn new_cache(&self) -> Box<dyn ResultCache> {
         (self.config.result_cache)()
+    }
+
+    /// Draw an integer from `[min, max]` (both inclusive) using `sample`,
+    /// recording it as a typed choice when the choice tape is active and
+    /// replaying it from the tape during tape shrinking.
+    ///
+    /// With the tape off this calls straight into `sample`, so
+    /// distributions and RNG consumption are unchanged. (The sampling is
+    /// a caller-provided closure rather than a `SampleUniform` bound
+    /// because rand no longer implements the distribution traits for
+    /// `usize`/`isize`; callers route through the width-casting samplers
+    /// in `crate::num` instead.)
+    pub(crate) fn draw_integer_in<T>(
+        &mut self,
+        min: T,
+        max: T,
+        sample: impl FnOnce(&mut Self) -> T,
+    ) -> T
+    where
+        T: TapeInt,
+    {
+        if !self.rng.tape.is_on() {
+            return sample(self);
+        }
+        let emin = T::encode(min);
+        let emax = T::encode(max);
+        let shrink_to = T::encode_zero().clamp(emin, emax);
+        if self.rng.tape.is_replaying() {
+            if let Some(Choice::Integer { value, .. }) = self
+                .rng
+                .tape
+                .pop_replay(|c| matches!(c, Choice::Integer { .. }))
+            {
+                let value = value.clamp(emin, emax);
+                self.rng.tape.record(Choice::Integer {
+                    value,
+                    min: emin,
+                    max: emax,
+                    shrink_to,
+                });
+                return T::decode(value);
+            }
+        }
+        // Recording, or drawing fresh after a replay misalignment.
+        self.rng.tape.suppress_raw();
+        let sampled = sample(self);
+        self.rng.tape.unsuppress_raw();
+        self.rng.tape.record(Choice::Integer {
+            value: T::encode(sampled),
+            min: emin,
+            max: emax,
+            shrink_to,
+        });
+        sampled
+    }
+
+    /// Draw a float from `[min, max]` (both inclusive) using `sample`,
+    /// recording it as a typed choice when the choice tape is active and
+    /// replaying it from the tape during tape shrinking.
+    ///
+    /// `f32` draws widen to `f64`; the caller is responsible for clamping
+    /// after narrowing back.
+    pub(crate) fn draw_f64_in(
+        &mut self,
+        min: f64,
+        max: f64,
+        allow_nan: bool,
+        sample: impl FnOnce(&mut Self) -> f64,
+    ) -> f64 {
+        if !self.rng.tape.is_on() {
+            return sample(self);
+        }
+        if self.rng.tape.is_replaying() {
+            if let Some(Choice::Float { value, .. }) = self
+                .rng
+                .tape
+                .pop_replay(|c| matches!(c, Choice::Float { .. }))
+            {
+                let value = if value.is_nan() {
+                    if allow_nan {
+                        value
+                    } else {
+                        tape::float_shrink_target(min, max)
+                    }
+                } else {
+                    value.clamp(min, max)
+                };
+                self.rng.tape.record(Choice::Float {
+                    value,
+                    min,
+                    max,
+                    allow_nan,
+                });
+                return value;
+            }
+        }
+        self.rng.tape.suppress_raw();
+        let sampled = sample(self);
+        self.rng.tape.unsuppress_raw();
+        self.rng.tape.record(Choice::Float {
+            value: sampled,
+            min,
+            max,
+            allow_nan,
+        });
+        sampled
+    }
+
+    /// The tape-engine analogue of `gen_and_run_case`.
+    fn gen_and_run_case_tape<S: Strategy>(
+        &mut self,
+        strategy: &S,
+        f: &impl Fn(S::Value) -> TestCaseResult,
+        replay_from_fork: &mut impl Iterator<Item = TestCaseResult>,
+        result_cache: &mut dyn ResultCache,
+        fork_output: &mut ForkOutput,
+        is_from_persisted_seed: bool,
+    ) -> TestRunResult<S> {
+        // Snapshot the RNG (tape off) so every shrink attempt can rewind
+        // to the exact pre-generation state; fresh draws after a replay
+        // misalignment are then at least reproducible.
+        let rng_snapshot = self.rng.clone();
+        self.rng.tape.start_recording();
+        let case = match strategy.new_tree(self) {
+            Ok(case) => case,
+            Err(msg) => {
+                self.rng.tape.take_recording();
+                return Err(TestError::Abort(msg));
+            }
+        };
+        let recorded = self.rng.tape.take_recording();
+
+        let result = call_test(
+            self,
+            case.current(),
+            f,
+            replay_from_fork,
+            result_cache,
+            fork_output,
+            is_from_persisted_seed,
+        );
+
+        let ok_type = match result {
+            Ok(success) => success,
+            Err(TestCaseError::Fail(why)) => {
+                let (why, value) = self.tape_shrink(
+                    strategy,
+                    f,
+                    rng_snapshot,
+                    recorded,
+                    case,
+                    why,
+                    result_cache,
+                    fork_output,
+                );
+                return Err(TestError::Fail(why, value));
+            }
+            Err(TestCaseError::Reject(whence)) => {
+                self.reject_global(whence)?;
+                TestCaseOk::Reject
+            }
+        };
+        match ok_type {
+            TestCaseOk::NewCaseSuccess | TestCaseOk::ReplayFromForkSuccess => {
+                self.successes += 1
+            }
+            TestCaseOk::PersistedCaseSuccess
+            | TestCaseOk::CacheHitSuccess
+            | TestCaseOk::Reject => (),
+        }
+        Ok(())
+    }
+
+    /// Shrink a failing case by editing its recorded choice tape and
+    /// re-running generation, keeping any edit that still fails the test
+    /// and re-records to a shortlex-smaller tape.
+    fn tape_shrink<S: Strategy>(
+        &mut self,
+        strategy: &S,
+        test: &impl Fn(S::Value) -> TestCaseResult,
+        rng_snapshot: TestRng,
+        initial_tape: Tape,
+        initial_tree: S::Tree,
+        initial_why: Reason,
+        result_cache: &mut dyn ResultCache,
+        fork_output: &mut ForkOutput,
+    ) -> (Reason, S::Value) {
+        let mut best = TapeBest {
+            tape: initial_tape,
+            tree: initial_tree,
+            why: initial_why,
+        };
+        let mut budget = TapeShrinkBudget {
+            iterations: 0,
+            max_iters: self.config.max_shrink_iters(),
+            #[cfg(feature = "std")]
+            start_time: std::time::Instant::now(),
+            #[cfg(feature = "std")]
+            max_time_ms: self.config.max_shrink_time,
+        };
+
+        let mut exhausted = false;
+
+        // Pass 1: one attempt with every choice at its shrink target.
+        let trivial = best.tape.trivial();
+        if trivial != best.tape {
+            exhausted = TapeAttemptResult::Exhausted
+                == self.tape_attempt(
+                    strategy,
+                    test,
+                    &rng_snapshot,
+                    trivial,
+                    &mut best,
+                    &mut budget,
+                    result_cache,
+                    fork_output,
+                );
+        }
+
+        // Pass 2: minimize each choice individually, round-robin until a
+        // full round makes no progress.
+        while !exhausted {
+            let mut improved = false;
+            let mut idx = 0;
+            while idx < best.tape.choices.len() {
+                let (imp, ex) = self.tape_minimize_choice(
+                    idx,
+                    strategy,
+                    test,
+                    &rng_snapshot,
+                    &mut best,
+                    &mut budget,
+                    result_cache,
+                    fork_output,
+                );
+                improved |= imp;
+                if ex {
+                    exhausted = true;
+                    break;
+                }
+                idx += 1;
+            }
+            if !improved {
+                break;
+            }
+        }
+
+        verbose_message!(
+            self,
+            TRACE,
+            "Tape shrinking finished after {} attempts",
+            budget.iterations
+        );
+
+        self.rng = rng_snapshot;
+        (best.why, best.tree.current())
+    }
+
+    /// Run one shrink attempt: replay `proposal` through generation, run
+    /// the test, and accept iff the test still fails and the re-recorded
+    /// output tape is shortlex-smaller than the incumbent.
+    fn tape_attempt<S: Strategy>(
+        &mut self,
+        strategy: &S,
+        test: &impl Fn(S::Value) -> TestCaseResult,
+        rng_snapshot: &TestRng,
+        proposal: Tape,
+        best: &mut TapeBest<S::Tree>,
+        budget: &mut TapeShrinkBudget,
+        result_cache: &mut dyn ResultCache,
+        fork_output: &mut ForkOutput,
+    ) -> TapeAttemptResult {
+        if !budget.spend() {
+            return TapeAttemptResult::Exhausted;
+        }
+
+        self.rng = rng_snapshot.clone();
+        self.rng.tape.start_replay(proposal);
+        let tree = strategy.new_tree(self);
+        let (output, overrun) = self.rng.tape.finish_replay();
+        let tree = match tree {
+            Ok(tree) => tree,
+            // Generation rejected the replayed values (e.g. a filter's
+            // retry budget ran out); discard the attempt.
+            Err(_) => return TapeAttemptResult::Rejected,
+        };
+        if overrun {
+            return TapeAttemptResult::Rejected;
+        }
+        if Ordering::Less != output.cmp_key(&best.tape) {
+            return TapeAttemptResult::Rejected;
+        }
+
+        let result = call_test(
+            self,
+            tree.current(),
+            test,
+            &mut iter::empty::<TestCaseResult>().fuse(),
+            result_cache,
+            fork_output,
+            false,
+        );
+        match result {
+            Err(TestCaseError::Fail(why)) => {
+                best.tape = output;
+                best.tree = tree;
+                best.why = why;
+                TapeAttemptResult::Accepted
+            }
+            // Passes and rejections both mean the edit lost the failure.
+            Ok(_) | Err(TestCaseError::Reject(..)) => {
+                TapeAttemptResult::Rejected
+            }
+        }
+    }
+
+    /// Minimize the single choice at `idx` of the incumbent tape. Returns
+    /// `(improved_anything, budget_exhausted)`.
+    fn tape_minimize_choice<S: Strategy>(
+        &mut self,
+        idx: usize,
+        strategy: &S,
+        test: &impl Fn(S::Value) -> TestCaseResult,
+        rng_snapshot: &TestRng,
+        best: &mut TapeBest<S::Tree>,
+        budget: &mut TapeShrinkBudget,
+        result_cache: &mut dyn ResultCache,
+        fork_output: &mut ForkOutput,
+    ) -> (bool, bool) {
+        let mut improved = false;
+
+        // Try one proposal; evaluates to whether it was accepted, or
+        // returns from the function when the budget runs out or an
+        // accepted attempt restructured the tape under our feet.
+        macro_rules! attempt {
+            ($choice:expr) => {{
+                if idx >= best.tape.choices.len() {
+                    return (improved, false);
+                }
+                match self.tape_attempt(
+                    strategy,
+                    test,
+                    rng_snapshot,
+                    best.tape.with_choice(idx, $choice),
+                    best,
+                    budget,
+                    result_cache,
+                    fork_output,
+                ) {
+                    TapeAttemptResult::Accepted => {
+                        improved = true;
+                        true
+                    }
+                    TapeAttemptResult::Rejected => false,
+                    TapeAttemptResult::Exhausted => return (improved, true),
+                }
+            }};
+        }
+
+        // Bisect in "distance from target" space: `cur` is the current
+        // (known-failing) value, candidates move toward `target`. The
+        // target itself must already have been tried and rejected.
+        macro_rules! bisect_u128 {
+            ($cur:expr, $target:expr, $mk:expr) => {{
+                let cur: u128 = $cur;
+                let target: u128 = $target;
+                let above = cur >= target;
+                let mut d_fail =
+                    if above { cur - target } else { target - cur };
+                let mut d_ok = 0u128;
+                loop {
+                    let d_mid = d_ok + (d_fail - d_ok) / 2;
+                    if d_mid == d_ok || d_mid == d_fail {
+                        break;
+                    }
+                    let cand = if above {
+                        target + d_mid
+                    } else {
+                        target - d_mid
+                    };
+                    if attempt!($mk(cand)) {
+                        d_fail = d_mid;
+                    } else {
+                        d_ok = d_mid;
+                    }
+                }
+            }};
+        }
+
+        match best.tape.choices[idx].clone() {
+            Choice::Integer {
+                value,
+                min,
+                max,
+                shrink_to,
+            } => {
+                let mk = |value: u128| Choice::Integer {
+                    value,
+                    min,
+                    max,
+                    shrink_to,
+                };
+                if value == shrink_to {
+                    return (improved, false);
+                }
+                if !attempt!(mk(shrink_to)) {
+                    bisect_u128!(value, shrink_to, mk);
+                }
+            }
+
+            Choice::Float {
+                value,
+                min,
+                max,
+                allow_nan,
+            } => {
+                let mk = |value: f64| Choice::Float {
+                    value,
+                    min,
+                    max,
+                    allow_nan,
+                };
+                let target = tape::float_shrink_target(min, max);
+                let read_current = |best: &TapeBest<S::Tree>| match best
+                    .tape
+                    .choices
+                    .get(idx)
+                {
+                    Some(Choice::Float { value, .. }) => Some(*value),
+                    _ => None,
+                };
+
+                if value == target {
+                    return (improved, false);
+                }
+                attempt!(mk(target));
+                let mut cur = match read_current(best) {
+                    Some(cur) => cur,
+                    None => return (improved, false),
+                };
+                if cur == target || !cur.is_finite() {
+                    // NaN and infinity either shrink to the target in one
+                    // step or not at all.
+                    return (improved, false);
+                }
+
+                // Integerize: the truncation first (smaller magnitude),
+                // then one step away from zero (the smallest integer that
+                // can still fail for "value > threshold"-shaped tests).
+                if cur != tape::float_trunc(cur) {
+                    attempt!(mk(tape::float_trunc(cur)));
+                    cur = match read_current(best) {
+                        Some(cur) => cur,
+                        None => return (improved, false),
+                    };
+                    if cur != tape::float_trunc(cur) {
+                        attempt!(mk(tape::float_trunc(cur) + cur.signum()));
+                        cur = match read_current(best) {
+                            Some(cur) => cur,
+                            None => return (improved, false),
+                        };
+                    }
+                }
+
+                if cur == tape::float_trunc(cur)
+                    && target == tape::float_trunc(target)
+                {
+                    // Bisect over integer-valued floats toward the target.
+                    let mut fail = cur;
+                    let mut ok = target;
+                    loop {
+                        let mid =
+                            tape::float_trunc(ok + (fail - ok) / 2.0);
+                        if mid == ok || mid == fail {
+                            break;
+                        }
+                        if attempt!(mk(mid)) {
+                            fail = mid;
+                        } else {
+                            ok = mid;
+                        }
+                    }
+                } else {
+                    // Still fractional: drop precision bit by bit.
+                    for k in 1..=10 {
+                        let cand = tape::float_round_to_precision(cur, k);
+                        if cand != cur {
+                            attempt!(mk(cand));
+                            cur = match read_current(best) {
+                                Some(cur) => cur,
+                                None => return (improved, false),
+                            };
+                        }
+                    }
+                }
+            }
+
+            Choice::Bool { value } => {
+                if value {
+                    attempt!(Choice::Bool { value: false });
+                }
+            }
+
+            Choice::RawU32 { value } => {
+                if 0 != value && !attempt!(Choice::RawU32 { value: 0 }) {
+                    bisect_u128!(value as u128, 0, |v: u128| {
+                        Choice::RawU32 { value: v as u32 }
+                    });
+                }
+            }
+
+            Choice::RawU64 { value } => {
+                if 0 != value && !attempt!(Choice::RawU64 { value: 0 }) {
+                    bisect_u128!(value as u128, 0, |v: u128| {
+                        Choice::RawU64 { value: v as u64 }
+                    });
+                }
+            }
+
+            Choice::RawBytes { value } => {
+                if value.iter().any(|&b| 0 != b) {
+                    attempt!(Choice::RawBytes {
+                        value: vec![0; value.len()],
+                    });
+                }
+            }
+        }
+
+        (improved, false)
+    }
+}
+
+/// The incumbent shrink result: the simplest tape whose replay is known to
+/// fail the test, with its generated tree and failure reason.
+struct TapeBest<T> {
+    tape: Tape,
+    tree: T,
+    why: Reason,
+}
+
+#[derive(PartialEq)]
+enum TapeAttemptResult {
+    Accepted,
+    Rejected,
+    Exhausted,
+}
+
+/// Iteration/time budget for tape shrinking, mirroring the limits the
+/// ValueTree shrinker enforces.
+struct TapeShrinkBudget {
+    iterations: u32,
+    max_iters: u32,
+    #[cfg(feature = "std")]
+    start_time: std::time::Instant,
+    #[cfg(feature = "std")]
+    max_time_ms: u32,
+}
+
+impl TapeShrinkBudget {
+    /// Returns false when the budget is exhausted.
+    fn spend(&mut self) -> bool {
+        if self.iterations >= self.max_iters {
+            return false;
+        }
+        #[cfg(feature = "std")]
+        {
+            if self.max_time_ms > 0 {
+                let elapsed = self.start_time.elapsed();
+                let elapsed_ms = elapsed
+                    .as_secs()
+                    .saturating_mul(1000)
+                    .saturating_add(elapsed.subsec_millis().into());
+                if elapsed_ms > self.max_time_ms as u64 {
+                    return false;
+                }
+            }
+        }
+        self.iterations += 1;
+        true
     }
 }
 

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -13,6 +13,7 @@ use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering::SeqCst;
 use core::{fmt, iter};
 
+use rand::RngExt;
 #[cfg(feature = "std")]
 use std::panic::{self, AssertUnwindSafe};
 
@@ -1072,6 +1073,48 @@ impl TestRunner {
         sampled
     }
 
+    /// Draw a boolean that is true with probability `probability_true`,
+    /// recording it as a typed choice when the choice tape is active.
+    /// `false` is the shrink-target value, so strategies should encode
+    /// "stop"/"simpler" as `false` (e.g. collection continuation flags
+    /// are `true = one more element`).
+    pub(crate) fn draw_bool(&mut self, probability_true: f64) -> bool {
+        if !self.rng.tape.is_on() {
+            return self.rng.random_bool(probability_true);
+        }
+        if let Some(Choice::Bool { value }) = self
+            .rng
+            .tape
+            .pop_replay(|c| matches!(c, Choice::Bool { .. }))
+        {
+            self.rng.tape.record(Choice::Bool { value });
+            return value;
+        }
+        self.rng.tape.suppress_raw();
+        let sampled = self.rng.random_bool(probability_true);
+        self.rng.tape.unsuppress_raw();
+        self.rng.tape.record(Choice::Bool { value: sampled });
+        sampled
+    }
+
+    /// Whether the choice tape is currently active (recording or
+    /// replaying). Strategies use this to select tape-friendly encodings
+    /// (e.g. continuation flags instead of an up-front collection size).
+    pub(crate) fn tape_is_on(&self) -> bool {
+        self.rng.tape.is_on()
+    }
+
+    /// Open a span (a deletable logical unit) on the choice tape. No-op
+    /// when the tape is off. Always pair with `end_span`.
+    pub(crate) fn start_span(&mut self) {
+        self.rng.tape.start_span();
+    }
+
+    /// Close the innermost open span.
+    pub(crate) fn end_span(&mut self) {
+        self.rng.tape.end_span();
+    }
+
     /// The tape-engine analogue of `gen_and_run_case`.
     fn gen_and_run_case_tape<S: Strategy>(
         &mut self,
@@ -1183,10 +1226,26 @@ impl TestRunner {
                 );
         }
 
-        // Pass 2: minimize each choice individually, round-robin until a
-        // full round makes no progress.
+        // Pass 2 (each round): delete spans (collection elements etc.),
+        // then minimize each choice individually; repeat until a full
+        // round makes no progress.
         while !exhausted {
             let mut improved = false;
+
+            let (imp, ex) = self.tape_delete_spans(
+                strategy,
+                test,
+                &rng_snapshot,
+                &mut best,
+                &mut budget,
+                result_cache,
+                fork_output,
+            );
+            improved |= imp;
+            if ex {
+                break;
+            }
+
             let mut idx = 0;
             while idx < best.tape.choices.len() {
                 let (imp, ex) = self.tape_minimize_choice(
@@ -1278,6 +1337,57 @@ impl TestRunner {
                 TapeAttemptResult::Rejected
             }
         }
+    }
+
+    /// Try deleting recorded spans (one logical unit each, e.g. one
+    /// collection element with its continuation flag), last-to-first.
+    /// Returns `(improved_anything, budget_exhausted)`.
+    fn tape_delete_spans<S: Strategy>(
+        &mut self,
+        strategy: &S,
+        test: &impl Fn(S::Value) -> TestCaseResult,
+        rng_snapshot: &TestRng,
+        best: &mut TapeBest<S::Tree>,
+        budget: &mut TapeShrinkBudget,
+        result_cache: &mut dyn ResultCache,
+        fork_output: &mut ForkOutput,
+    ) -> (bool, bool) {
+        let mut improved = false;
+        // Position from the end of the span list: on acceptance the whole
+        // span list is refreshed from the replay's output, so counting
+        // from the end keeps us moving through not-yet-tried spans.
+        let mut pos = 0;
+        loop {
+            let nspans = best.tape.spans.len();
+            if pos >= nspans {
+                break;
+            }
+            let span = best.tape.spans[nspans - 1 - pos];
+            if span.end > best.tape.choices.len() || span.start >= span.end
+            {
+                pos += 1;
+                continue;
+            }
+            match self.tape_attempt(
+                strategy,
+                test,
+                rng_snapshot,
+                best.tape.with_span_deleted(span),
+                best,
+                budget,
+                result_cache,
+                fork_output,
+            ) {
+                TapeAttemptResult::Accepted => {
+                    improved = true;
+                }
+                TapeAttemptResult::Rejected => {
+                    pos += 1;
+                }
+                TapeAttemptResult::Exhausted => return (improved, true),
+            }
+        }
+        (improved, false)
     }
 
     /// Minimize the single choice at `idx` of the incumbent tape. Returns

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1033,6 +1033,107 @@ impl TestRunner {
         )
     }
 
+    /// Like `draw_integer_in`, but sampling with the edge-case-hunting
+    /// distribution: mostly small distances from the shrink target, with
+    /// occasional boundary values and a uniform tail. Used by the numeric
+    /// range strategies (NOT by union picks, which must stay
+    /// weight-faithful).
+    pub(crate) fn draw_integer_in_biased<T>(
+        &mut self,
+        min: T,
+        max: T,
+        sample_uniform: impl Fn(&mut Self) -> T,
+    ) -> T
+    where
+        T: TapeInt,
+    {
+        self.draw_integer_in_with(
+            min,
+            max,
+            |_| T::decode(T::encode_zero().clamp(T::encode(min), T::encode(max))),
+            |v| v,
+            |runner| {
+                runner.sample_integer_biased(min, max, &sample_uniform)
+            },
+        )
+    }
+
+    /// The phase-6 integer distribution, after Hypothesis: for wide
+    /// ranges (> 24 bits), 1/16 of draws take a boundary-ish value, 2/16
+    /// stay uniform over the whole range, and 13/16 land within a
+    /// weighted random bit-size of the shrink target — so small values
+    /// and exact bounds both show up often, while the full range remains
+    /// reachable. Narrow ranges stay uniform.
+    fn sample_integer_biased<T>(
+        &mut self,
+        min: T,
+        max: T,
+        sample_uniform: &impl Fn(&mut Self) -> T,
+    ) -> T
+    where
+        T: TapeInt,
+    {
+        let emin = T::encode(min);
+        let emax = T::encode(max);
+        let width = emax - emin;
+        if width < (1u128 << 24) {
+            return sample_uniform(self);
+        }
+        let target = T::encode_zero().clamp(emin, emax);
+
+        match self.rng.random_range(0..16u32) {
+            0 => {
+                // Boundary-ish values.
+                let candidates = [
+                    emin,
+                    emin + 1,
+                    emax,
+                    emax - 1,
+                    target,
+                    target.saturating_add(1).min(emax),
+                ];
+                let pick =
+                    self.rng.random_range(0..candidates.len());
+                T::decode(candidates[pick])
+            }
+            1 | 2 => sample_uniform(self),
+            _ => {
+                // Magnitude within a weighted random bit-size of the
+                // target; the same spirit as Hypothesis's INT_SIZES
+                // (small sizes heavily preferred, huge tail retained).
+                let bits: u32 = match self.rng.random_range(0..15u32) {
+                    0..=3 => 8,
+                    4..=11 => 16,
+                    12 => 32,
+                    13 => 64,
+                    14 => 128,
+                    _ => unreachable!(),
+                };
+                let mask = if bits >= 128 {
+                    u128::MAX
+                } else {
+                    (1u128 << bits) - 1
+                };
+                let magnitude = self.rng.random::<u128>() & mask;
+                let up_room = emax - target;
+                let down_room = target - emin;
+                let up = if 0 == down_room {
+                    true
+                } else if 0 == up_room {
+                    false
+                } else {
+                    self.rng.random::<bool>()
+                };
+                let value = if up {
+                    target + magnitude.min(up_room)
+                } else {
+                    target - magnitude.min(down_room)
+                };
+                T::decode(value)
+            }
+        }
+    }
+
     /// Like `draw_integer_in`, but with custom shrinking metadata and a
     /// `conform` hook for strategies whose support is not one contiguous
     /// interval (e.g. `char`, whose support is a union of ranges with
@@ -1118,11 +1219,15 @@ impl TestRunner {
         min: f64,
         max: f64,
         allow_nan: bool,
-        conform: impl FnOnce(f64) -> f64,
+        conform: impl Fn(f64) -> f64,
         sample: impl FnOnce(&mut Self) -> f64,
     ) -> f64 {
         if !self.rng.tape.is_on() {
-            return sample(self);
+            return match self.maybe_weird_float(min, max, allow_nan, &conform)
+            {
+                Some(weird) => weird,
+                None => sample(self),
+            };
         }
         if self.rng.tape.is_replaying() {
             if let Some(Choice::Float { value, .. }) = self
@@ -1150,7 +1255,11 @@ impl TestRunner {
             }
         }
         self.rng.tape.suppress_raw();
-        let sampled = sample(self);
+        let sampled =
+            match self.maybe_weird_float(min, max, allow_nan, &conform) {
+                Some(weird) => weird,
+                None => sample(self),
+            };
         self.rng.tape.unsuppress_raw();
         self.rng.tape.record(Choice::Float {
             value: sampled,
@@ -1159,6 +1268,57 @@ impl TestRunner {
             allow_nan,
         });
         sampled
+    }
+
+    /// With probability 1/20, propose a boundary or otherwise "weird"
+    /// float for the draw instead of sampling the strategy's own
+    /// distribution — bounds, values one ulp inside the bounds, ±0, ±1,
+    /// simple fractions, and NaN where permitted. Returns `None` (draw
+    /// normally) otherwise, or when the picked candidate is out of range
+    /// after conforming.
+    fn maybe_weird_float(
+        &mut self,
+        min: f64,
+        max: f64,
+        allow_nan: bool,
+        conform: &impl Fn(f64) -> f64,
+    ) -> Option<f64> {
+        if 0 != self.rng.random_range(0..20u32) {
+            return None;
+        }
+        fn next_up(a: f64) -> f64 {
+            if a == 0.0 {
+                f64::from_bits(1)
+            } else if a > 0.0 {
+                f64::from_bits(a.to_bits() + 1)
+            } else {
+                f64::from_bits(a.to_bits() - 1)
+            }
+        }
+        let candidates = [
+            0.0,
+            -0.0,
+            1.0,
+            -1.0,
+            0.5,
+            1.5,
+            min,
+            max,
+            if min.is_finite() { next_up(min) } else { min },
+            if max.is_finite() { -next_up(-max) } else { max },
+            if allow_nan { f64::NAN } else { 0.0 },
+        ];
+        let candidate =
+            candidates[self.rng.random_range(0..candidates.len())];
+        let candidate = conform(candidate);
+        if candidate.is_nan() {
+            return if allow_nan { Some(candidate) } else { None };
+        }
+        if candidate >= min && candidate <= max {
+            Some(candidate)
+        } else {
+            None
+        }
     }
 
     /// Draw a boolean that is true with probability `probability_true`,
@@ -1902,28 +2062,43 @@ impl TestRunner {
             }};
         }
 
-        // Bisect in "distance from target" space: `cur` is the current
-        // (known-failing) value, candidates move toward `target`. The
+        // Minimize distance-from-target for a known-failing value: probe
+        // exponentially outward from the target (1, 2, 4, ...) until a
+        // failing distance is found, then bisect the last gap. This costs
+        // O(log(final distance)) attempts rather than O(log(range)) —
+        // crucial when the starting value is ~1e300 but the failure
+        // boundary is near the target, which is the common case. The
         // target itself must already have been tried and rejected.
         macro_rules! bisect_u128 {
             ($cur:expr, $target:expr, $mk:expr) => {{
                 let cur: u128 = $cur;
                 let target: u128 = $target;
                 let above = cur >= target;
-                let mut d_fail =
-                    if above { cur - target } else { target - cur };
+                let dist = if above { cur - target } else { target - cur };
+                let cand_at = |d: u128| {
+                    if above {
+                        target + d
+                    } else {
+                        target - d
+                    }
+                };
                 let mut d_ok = 0u128;
+                let mut d_fail = dist;
+                let mut probe = 1u128;
+                while probe < dist {
+                    if attempt!($mk(cand_at(probe))) {
+                        d_fail = probe;
+                        break;
+                    }
+                    d_ok = probe;
+                    probe = probe.saturating_mul(2);
+                }
                 loop {
                     let d_mid = d_ok + (d_fail - d_ok) / 2;
                     if d_mid == d_ok || d_mid == d_fail {
                         break;
                     }
-                    let cand = if above {
-                        target + d_mid
-                    } else {
-                        target - d_mid
-                    };
-                    if attempt!($mk(cand)) {
+                    if attempt!($mk(cand_at(d_mid))) {
                         d_fail = d_mid;
                     } else {
                         d_ok = d_mid;
@@ -2010,9 +2185,23 @@ impl TestRunner {
                 if cur == tape::float_trunc(cur)
                     && target == tape::float_trunc(target)
                 {
-                    // Bisect over integer-valued floats toward the target.
-                    let mut fail = cur;
+                    // Minimize over integer-valued floats: exponential
+                    // probe outward from the target, then bisect the
+                    // last gap (see bisect_u128 for why).
+                    let dir = if cur >= target { 1.0 } else { -1.0 };
                     let mut ok = target;
+                    let mut fail = cur;
+                    let mut probe = 1.0f64;
+                    while probe < (cur - target).abs() {
+                        let cand =
+                            tape::float_trunc(target + dir * probe);
+                        if attempt!(mk(cand)) {
+                            fail = cand;
+                            break;
+                        }
+                        ok = cand;
+                        probe *= 2.0;
+                    }
                     loop {
                         let mid =
                             tape::float_trunc(ok + (fail - ok) / 2.0);
@@ -2720,7 +2909,12 @@ mod timeout_tests {
 
     fn test_shrink_bail(config: Config) {
         let mut runner = TestRunner::new(config);
-        let result = runner.run(&crate::num::u64::ANY, |v| {
+        // Every value of this range fails the assertion below, so the
+        // failing case is found on the first generation regardless of
+        // the generator's distribution; the test is about the shrink
+        // budget, and each test call costs 250ms against the fork
+        // harness's timeout.
+        let result = runner.run(&((u32::MAX as u64 + 1)..), |v| {
             thread::sleep(Duration::from_millis(250));
             prop_assert!(v <= u32::MAX as u64);
             Ok(())

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1034,6 +1034,25 @@ impl TestRunner {
         allow_nan: bool,
         sample: impl FnOnce(&mut Self) -> f64,
     ) -> f64 {
+        self.draw_f64_in_with(min, max, allow_nan, |v| v, sample)
+    }
+
+    /// Like `draw_f64_in`, but with a `conform` hook applied to replayed
+    /// values after the min/max/NaN normalization. Strategies whose
+    /// support is not a simple interval (e.g. the class-restricted float
+    /// `Any` strategies) use it to map an arbitrary shrink proposal to
+    /// the nearest value they could actually generate; the conformed
+    /// value is what gets re-recorded, so accepted tapes stay
+    /// self-consistent. `sample`d values are assumed conformant by
+    /// construction.
+    pub(crate) fn draw_f64_in_with(
+        &mut self,
+        min: f64,
+        max: f64,
+        allow_nan: bool,
+        conform: impl FnOnce(f64) -> f64,
+        sample: impl FnOnce(&mut Self) -> f64,
+    ) -> f64 {
         if !self.rng.tape.is_on() {
             return sample(self);
         }
@@ -1052,6 +1071,7 @@ impl TestRunner {
                 } else {
                     value.clamp(min, max)
                 };
+                let value = conform(value);
                 self.rng.tape.record(Choice::Float {
                     value,
                     min,

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1380,6 +1380,51 @@ impl TestRunner {
             ) {
                 TapeAttemptResult::Accepted => {
                     improved = true;
+                    // Adaptive batching: a successful deletion often means
+                    // many neighbors are deletable too (think "shrink a
+                    // 100-element vec to 3"). Try deleting geometrically
+                    // growing blocks of spans at this position while that
+                    // keeps working, covering long runs in O(log n)
+                    // attempts instead of one by one.
+                    let mut block_len = 2usize;
+                    loop {
+                        let nspans = best.tape.spans.len();
+                        if pos >= nspans {
+                            break;
+                        }
+                        let hi_idx = nspans - 1 - pos;
+                        if hi_idx + 1 < block_len {
+                            break;
+                        }
+                        let lo_idx = hi_idx + 1 - block_len;
+                        let block = &best.tape.spans[lo_idx..=hi_idx];
+                        let start =
+                            block.iter().map(|s| s.start).min().unwrap();
+                        let end =
+                            block.iter().map(|s| s.end).max().unwrap();
+                        if end > best.tape.choices.len() || start >= end {
+                            break;
+                        }
+                        match self.tape_attempt(
+                            strategy,
+                            test,
+                            rng_snapshot,
+                            best.tape
+                                .with_span_deleted(tape::Span { start, end }),
+                            best,
+                            budget,
+                            result_cache,
+                            fork_output,
+                        ) {
+                            TapeAttemptResult::Accepted => {
+                                block_len *= 2;
+                            }
+                            TapeAttemptResult::Rejected => break,
+                            TapeAttemptResult::Exhausted => {
+                                return (improved, true)
+                            }
+                        }
+                    }
                 }
                 TapeAttemptResult::Rejected => {
                     pos += 1;

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1302,6 +1302,34 @@ impl TestRunner {
                 break;
             }
 
+            let (imp, ex) = self.tape_redistribute_pairs(
+                strategy,
+                test,
+                &rng_snapshot,
+                &mut best,
+                &mut budget,
+                result_cache,
+                fork_output,
+            );
+            improved |= imp;
+            if ex {
+                break;
+            }
+
+            let (imp, ex) = self.tape_minimize_duplicates(
+                strategy,
+                test,
+                &rng_snapshot,
+                &mut best,
+                &mut budget,
+                result_cache,
+                fork_output,
+            );
+            improved |= imp;
+            if ex {
+                break;
+            }
+
             let mut idx = 0;
             while idx < best.tape.choices.len() {
                 let (imp, ex) = self.tape_minimize_choice(
@@ -1486,6 +1514,219 @@ impl TestRunner {
                     pos += 1;
                 }
                 TapeAttemptResult::Exhausted => return (improved, true),
+            }
+        }
+        (improved, false)
+    }
+
+    /// Cross-value pass: move weight from an earlier integer choice to
+    /// the next integer choice after it, preserving their sum. Shortlex
+    /// prefers earlier choices being smaller, so `[27, 23]` becomes
+    /// `[0, 50]` when the failure depends only on the sum — after which
+    /// the deletion pass can remove the zero. Returns
+    /// `(improved_anything, budget_exhausted)`.
+    fn tape_redistribute_pairs<S: Strategy>(
+        &mut self,
+        strategy: &S,
+        test: &impl Fn(S::Value) -> TestCaseResult,
+        rng_snapshot: &TestRng,
+        best: &mut TapeBest<S::Tree>,
+        budget: &mut TapeShrinkBudget,
+        result_cache: &mut dyn ResultCache,
+        fork_output: &mut ForkOutput,
+    ) -> (bool, bool) {
+        let mut improved = false;
+        let mut i = 0;
+        'outer: while i < best.tape.choices.len() {
+            // Repeatedly re-read: accepted attempts rewrite the tape.
+            let (value_i, min_i, max_i, shrink_to_i) =
+                match best.tape.choices[i] {
+                    Choice::Integer {
+                        value,
+                        min,
+                        max,
+                        shrink_to,
+                    } if value != shrink_to => (value, min, max, shrink_to),
+                    _ => {
+                        i += 1;
+                        continue;
+                    }
+                };
+            let j = match (i + 1..best.tape.choices.len())
+                .find(|&j| matches!(best.tape.choices[j], Choice::Integer { .. }))
+            {
+                Some(j) => j,
+                None => break,
+            };
+            let (value_j, min_j, max_j, shrink_to_j) =
+                match best.tape.choices[j] {
+                    Choice::Integer {
+                        value,
+                        min,
+                        max,
+                        shrink_to,
+                    } => (value, min, max, shrink_to),
+                    _ => unreachable!(),
+                };
+
+            // Transfer moves choice i toward its target and choice j the
+            // opposite way, within j's constraints. All values are in
+            // offset space, where differences equal value-space
+            // differences regardless of signedness.
+            let above = value_i > shrink_to_i;
+            let d_max = if above {
+                (value_i - shrink_to_i).min(max_j - value_j)
+            } else {
+                (shrink_to_i - value_i).min(value_j - min_j)
+            };
+
+            let mut d = d_max;
+            while d > 0 {
+                let (new_i, new_j) = if above {
+                    (value_i - d, value_j + d)
+                } else {
+                    (value_i + d, value_j - d)
+                };
+                let proposal = best
+                    .tape
+                    .with_choice(
+                        i,
+                        Choice::Integer {
+                            value: new_i,
+                            min: min_i,
+                            max: max_i,
+                            shrink_to: shrink_to_i,
+                        },
+                    )
+                    .with_choice(
+                        j,
+                        Choice::Integer {
+                            value: new_j,
+                            min: min_j,
+                            max: max_j,
+                            shrink_to: shrink_to_j,
+                        },
+                    );
+                match self.tape_attempt(
+                    strategy,
+                    test,
+                    rng_snapshot,
+                    proposal,
+                    best,
+                    budget,
+                    result_cache,
+                    fork_output,
+                ) {
+                    TapeAttemptResult::Accepted => {
+                        improved = true;
+                        // Values changed (and the tape may have been
+                        // restructured); restart this position.
+                        continue 'outer;
+                    }
+                    TapeAttemptResult::Rejected => d /= 2,
+                    TapeAttemptResult::Exhausted => return (improved, true),
+                }
+            }
+            i += 1;
+        }
+        (improved, false)
+    }
+
+    /// Cross-value pass: lower groups of identical integer choices
+    /// together. Catches failures conditioned on equality (`a == b`)
+    /// that no single-choice edit can preserve. Returns
+    /// `(improved_anything, budget_exhausted)`.
+    fn tape_minimize_duplicates<S: Strategy>(
+        &mut self,
+        strategy: &S,
+        test: &impl Fn(S::Value) -> TestCaseResult,
+        rng_snapshot: &TestRng,
+        best: &mut TapeBest<S::Tree>,
+        budget: &mut TapeShrinkBudget,
+        result_cache: &mut dyn ResultCache,
+        fork_output: &mut ForkOutput,
+    ) -> (bool, bool) {
+        let mut improved = false;
+        // Distinct (value, shrink_to) pairs occurring in 2+ integer
+        // choices of the incumbent tape.
+        let mut groups: Vec<(u128, u128)> = Vec::new();
+        for choice in &best.tape.choices {
+            if let Choice::Integer {
+                value, shrink_to, ..
+            } = *choice
+            {
+                if value != shrink_to
+                    && best
+                        .tape
+                        .choices
+                        .iter()
+                        .filter(|c| {
+                            matches!(
+                                c,
+                                Choice::Integer { value: v, shrink_to: t, .. }
+                                    if *v == value && *t == shrink_to
+                            )
+                        })
+                        .count()
+                        >= 2
+                    && !groups.contains(&(value, shrink_to))
+                {
+                    groups.push((value, shrink_to));
+                }
+            }
+        }
+
+        for (value, shrink_to) in groups {
+            // Propose moving every member of the group to the same new
+            // value, bisecting the distance toward the shared target.
+            let above = value > shrink_to;
+            let dist = if above {
+                value - shrink_to
+            } else {
+                shrink_to - value
+            };
+            let mut d = dist;
+            while d > 0 {
+                let new_value =
+                    if above { value - d } else { value + d };
+                let mut proposal = best.tape.clone();
+                let mut members = 0;
+                for choice in &mut proposal.choices {
+                    if let Choice::Integer {
+                        value: v,
+                        shrink_to: t,
+                        ..
+                    } = choice
+                    {
+                        if *v == value && *t == shrink_to {
+                            *v = new_value;
+                            members += 1;
+                        }
+                    }
+                }
+                if members < 2 {
+                    // The group dissolved under earlier edits.
+                    break;
+                }
+                match self.tape_attempt(
+                    strategy,
+                    test,
+                    rng_snapshot,
+                    proposal,
+                    best,
+                    budget,
+                    result_cache,
+                    fork_output,
+                ) {
+                    TapeAttemptResult::Accepted => {
+                        improved = true;
+                        // The group's shared value changed; move on and
+                        // let the next round regroup.
+                        break;
+                    }
+                    TapeAttemptResult::Rejected => d /= 2,
+                    TapeAttemptResult::Exhausted => return (improved, true),
+                }
             }
         }
         (improved, false)

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1058,12 +1058,13 @@ impl TestRunner {
         )
     }
 
-    /// The phase-6 integer distribution, after Hypothesis: for wide
-    /// ranges (> 24 bits), 1/16 of draws take a boundary-ish value, 2/16
-    /// stay uniform over the whole range, and 13/16 land within a
-    /// weighted random bit-size of the shrink target — so small values
-    /// and exact bounds both show up often, while the full range remains
-    /// reachable. Narrow ranges stay uniform.
+    /// The phase-6 integer distribution, after Hypothesis: 1/16 of draws
+    /// take a boundary-ish value (any range width; this is what finds
+    /// bugs guarded by `x % y == 0`, `== 0`, or exact bounds, cf.
+    /// upstream issue #500); the rest stay uniform for narrow ranges,
+    /// while wide ranges (> 24 bits) additionally land mostly within a
+    /// weighted random bit-size of the shrink target, so small values
+    /// dominate without making the full range unreachable.
     fn sample_integer_biased<T>(
         &mut self,
         min: T,
@@ -1076,62 +1077,58 @@ impl TestRunner {
         let emin = T::encode(min);
         let emax = T::encode(max);
         let width = emax - emin;
-        if width < (1u128 << 24) {
-            return sample_uniform(self);
-        }
         let target = T::encode_zero().clamp(emin, emax);
 
-        match self.rng.random_range(0..16u32) {
-            0 => {
-                // Boundary-ish values.
-                let candidates = [
-                    emin,
-                    emin + 1,
-                    emax,
-                    emax - 1,
-                    target,
-                    target.saturating_add(1).min(emax),
-                ];
-                let pick =
-                    self.rng.random_range(0..candidates.len());
-                T::decode(candidates[pick])
-            }
-            1 | 2 => sample_uniform(self),
-            _ => {
-                // Magnitude within a weighted random bit-size of the
-                // target; the same spirit as Hypothesis's INT_SIZES
-                // (small sizes heavily preferred, huge tail retained).
-                let bits: u32 = match self.rng.random_range(0..15u32) {
-                    0..=3 => 8,
-                    4..=11 => 16,
-                    12 => 32,
-                    13 => 64,
-                    14 => 128,
-                    _ => unreachable!(),
-                };
-                let mask = if bits >= 128 {
-                    u128::MAX
-                } else {
-                    (1u128 << bits) - 1
-                };
-                let magnitude = self.rng.random::<u128>() & mask;
-                let up_room = emax - target;
-                let down_room = target - emin;
-                let up = if 0 == down_room {
-                    true
-                } else if 0 == up_room {
-                    false
-                } else {
-                    self.rng.random::<bool>()
-                };
-                let value = if up {
-                    target + magnitude.min(up_room)
-                } else {
-                    target - magnitude.min(down_room)
-                };
-                T::decode(value)
-            }
+        let roll = self.rng.random_range(0..16u32);
+        if 0 == roll {
+            // Boundary-ish values (saturate and clamp so degenerate
+            // ranges stay in bounds).
+            let candidates = [
+                emin,
+                emin.saturating_add(1).min(emax),
+                emax,
+                emax.saturating_sub(1).max(emin),
+                target,
+                target.saturating_add(1).min(emax),
+            ];
+            let pick = self.rng.random_range(0..candidates.len());
+            return T::decode(candidates[pick]);
         }
+        if width < (1u128 << 24) || roll <= 2 {
+            return sample_uniform(self);
+        }
+        // Magnitude within a weighted random bit-size of the target; the
+        // same spirit as Hypothesis's INT_SIZES (small sizes heavily
+        // preferred, huge tail retained).
+        let bits: u32 = match self.rng.random_range(0..15u32) {
+            0..=3 => 8,
+            4..=11 => 16,
+            12 => 32,
+            13 => 64,
+            14 => 128,
+            _ => unreachable!(),
+        };
+        let mask = if bits >= 128 {
+            u128::MAX
+        } else {
+            (1u128 << bits) - 1
+        };
+        let magnitude = self.rng.random::<u128>() & mask;
+        let up_room = emax - target;
+        let down_room = target - emin;
+        let up = if 0 == down_room {
+            true
+        } else if 0 == up_room {
+            false
+        } else {
+            self.rng.random::<bool>()
+        };
+        let value = if up {
+            target + magnitude.min(up_room)
+        } else {
+            target - magnitude.min(down_room)
+        };
+        T::decode(value)
     }
 
     /// Like `draw_integer_in`, but with custom shrinking metadata and a

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1317,7 +1317,11 @@ impl TestRunner {
             min,
             max,
             if min.is_finite() { min.next_up() } else { min },
-            if max.is_finite() { max.next_down() } else { max },
+            if max.is_finite() {
+                max.next_down()
+            } else {
+                max
+            },
             if allow_nan { f64::NAN } else { 0.0 },
         ];
         let candidate = candidates[self.rng.random_range(0..candidates.len())];
@@ -1545,6 +1549,20 @@ impl TestRunner {
             let mut improved = false;
 
             let (imp, ex) = self.tape_delete_spans(
+                strategy,
+                test,
+                &rng_snapshot,
+                &mut best,
+                &mut budget,
+                result_cache,
+                fork_output,
+            );
+            improved |= imp;
+            if ex {
+                break;
+            }
+
+            let (imp, ex) = self.tape_lower_and_delete(
                 strategy,
                 test,
                 &rng_snapshot,
@@ -1872,6 +1890,89 @@ impl TestRunner {
                 }
                 TapeAttemptResult::Exhausted => return (improved, true),
             }
+        }
+        (improved, false)
+    }
+
+    /// Cross-value pass: lower an integer choice by one while deleting a
+    /// span after it. This is what shrinks length-prefixed data behind a
+    /// `prop_flat_map`: the length is an explicit earlier choice there,
+    /// so deleting an element span alone desynchronizes replay (the
+    /// length still demands the old count) and lowering the length alone
+    /// regenerates different elements. A port of the corresponding
+    /// special case in Hypothesis's `minimize_individual_nodes`. Returns
+    /// `(improved_anything, budget_exhausted)`.
+    fn tape_lower_and_delete<S: Strategy>(
+        &mut self,
+        strategy: &S,
+        test: &impl Fn(S::Value) -> TestCaseResult,
+        rng_snapshot: &TestRng,
+        best: &mut TapeBest<S::Tree>,
+        budget: &mut TapeShrinkBudget,
+        result_cache: &mut dyn ResultCache,
+        fork_output: &mut ForkOutput,
+    ) -> (bool, bool) {
+        let mut improved = false;
+        let mut i = 0;
+        'outer: while i < best.tape.choices.len() {
+            // Re-read on every iteration: accepted attempts rewrite the
+            // tape. Only above-target integers participate; a length-like
+            // choice shrinks downward.
+            let (value, min, max, shrink_to) = match best.tape.choices[i] {
+                Choice::Integer {
+                    value,
+                    min,
+                    max,
+                    shrink_to,
+                } if value > shrink_to => (value, min, max, shrink_to),
+                _ => {
+                    i += 1;
+                    continue;
+                }
+            };
+            // Pair the lowered integer with each span after it, last to
+            // first (matching the deletion pass's direction).
+            let mut pos = 0;
+            loop {
+                let nspans = best.tape.spans.len();
+                if pos >= nspans {
+                    break;
+                }
+                let span = best.tape.spans[nspans - 1 - pos];
+                pos += 1;
+                if span.start <= i
+                    || span.end > best.tape.choices.len()
+                    || span.start >= span.end
+                {
+                    continue;
+                }
+                let mut proposal = best.tape.with_span_deleted(span);
+                proposal.choices[i] = Choice::Integer {
+                    value: value - 1,
+                    min,
+                    max,
+                    shrink_to,
+                };
+                match self.tape_attempt(
+                    strategy,
+                    test,
+                    rng_snapshot,
+                    proposal,
+                    best,
+                    budget,
+                    result_cache,
+                    fork_output,
+                ) {
+                    TapeAttemptResult::Accepted => {
+                        improved = true;
+                        // The tape was rewritten; restart this position.
+                        continue 'outer;
+                    }
+                    TapeAttemptResult::Rejected => {}
+                    TapeAttemptResult::Exhausted => return (improved, true),
+                }
+            }
+            i += 1;
         }
         (improved, false)
     }

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1154,6 +1154,12 @@ impl TestRunner {
         self.rng.tape.is_on()
     }
 
+    /// Record a structurally-forced boolean on the choice tape without
+    /// drawing entropy. See `TapeState::record_forced_bool`.
+    pub(crate) fn record_forced_bool(&mut self, value: bool) {
+        self.rng.tape.record_forced_bool(value);
+    }
+
     /// Open a span (a deletable logical unit) on the choice tape. No-op
     /// when the tape is off. Always pair with `end_span`.
     pub(crate) fn start_span(&mut self) {

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -986,26 +986,56 @@ impl TestRunner {
     where
         T: TapeInt,
     {
+        self.draw_integer_in_with(
+            min,
+            max,
+            |_| T::decode(T::encode_zero().clamp(T::encode(min), T::encode(max))),
+            |v| v,
+            sample,
+        )
+    }
+
+    /// Like `draw_integer_in`, but with custom shrinking metadata and a
+    /// `conform` hook for strategies whose support is not one contiguous
+    /// interval (e.g. `char`, whose support is a union of ranges with
+    /// surrogate holes).
+    ///
+    /// `shrink_to_of` gives the shrink target *for a particular value*
+    /// (chars shrink to 'a' when they start at or above 'a', etc.);
+    /// `conform` maps a replayed shrink proposal to the nearest value the
+    /// strategy could actually generate. The conformed value is what gets
+    /// re-recorded, so accepted tapes stay self-consistent. Sampled
+    /// values are assumed conformant by construction.
+    pub(crate) fn draw_integer_in_with<T>(
+        &mut self,
+        min: T,
+        max: T,
+        shrink_to_of: impl Fn(T) -> T,
+        conform: impl Fn(T) -> T,
+        sample: impl FnOnce(&mut Self) -> T,
+    ) -> T
+    where
+        T: TapeInt,
+    {
         if !self.rng.tape.is_on() {
             return sample(self);
         }
         let emin = T::encode(min);
         let emax = T::encode(max);
-        let shrink_to = T::encode_zero().clamp(emin, emax);
         if self.rng.tape.is_replaying() {
             if let Some(Choice::Integer { value, .. }) = self
                 .rng
                 .tape
                 .pop_replay(|c| matches!(c, Choice::Integer { .. }))
             {
-                let value = value.clamp(emin, emax);
+                let value = conform(T::decode(value.clamp(emin, emax)));
                 self.rng.tape.record(Choice::Integer {
-                    value,
+                    value: T::encode(value),
                     min: emin,
                     max: emax,
-                    shrink_to,
+                    shrink_to: T::encode(shrink_to_of(value)),
                 });
-                return T::decode(value);
+                return value;
             }
         }
         // Recording, or drawing fresh after a replay misalignment.
@@ -1016,7 +1046,7 @@ impl TestRunner {
             value: T::encode(sampled),
             min: emin,
             max: emax,
-            shrink_to,
+            shrink_to: T::encode(shrink_to_of(sampled)),
         });
         sampled
     }

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1323,7 +1323,7 @@ impl TestRunner {
     /// `false` is the shrink-target value, so strategies should encode
     /// "stop"/"simpler" as `false` (e.g. collection continuation flags
     /// are `true = one more element`).
-    pub(crate) fn draw_bool(&mut self, probability_true: f64) -> bool {
+    pub fn draw_bool(&mut self, probability_true: f64) -> bool {
         if !self.rng.tape.is_on() {
             return self.rng.random_bool(probability_true);
         }
@@ -1345,25 +1345,32 @@ impl TestRunner {
     /// Whether the choice tape is currently active (recording or
     /// replaying). Strategies use this to select tape-friendly encodings
     /// (e.g. continuation flags instead of an up-front collection size).
-    pub(crate) fn tape_is_on(&self) -> bool {
+    pub fn tape_is_on(&self) -> bool {
         self.rng.tape.is_on()
     }
 
     /// Record a structurally-forced boolean on the choice tape without
     /// drawing entropy. See `TapeState::record_forced_bool`.
-    pub(crate) fn record_forced_bool(&mut self, value: bool) {
+    pub fn record_forced_bool(&mut self, value: bool) {
         self.rng.tape.record_forced_bool(value);
     }
 
     /// Open a span (a deletable logical unit) on the choice tape. No-op
     /// when the tape is off. Always pair with `end_span`.
-    pub(crate) fn start_span(&mut self) {
+    pub fn start_span(&mut self) {
         self.rng.tape.start_span();
     }
 
     /// Close the innermost open span.
-    pub(crate) fn end_span(&mut self) {
+    pub fn end_span(&mut self) {
         self.rng.tape.end_span();
+    }
+
+    /// Record a boolean that generation forces to `forced` without
+    /// drawing entropy, but that the tape shrinker may edit (the
+    /// replayed value is honored). See `TapeState::draw_bool_forced`.
+    pub fn draw_bool_forced(&mut self, forced: bool) -> bool {
+        self.rng.tape.draw_bool_forced(forced)
     }
 
     /// The tape-engine analogue of `gen_and_run_case`.

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -748,6 +748,52 @@ mod test {
     }
 
     #[test]
+    fn replay_engine_shrinks_any_float_to_round_value() {
+        // f64::ANY (class-based generation) records its value as a typed
+        // Float choice, so it gets round-value shrinking too.
+        let mut runner = engine_runner();
+        let result = runner.run(&crate::num::f64::ANY, |v| {
+            if v.is_finite() && v >= 1.7 {
+                Err(crate::test_runner::TestCaseError::fail("too big"))
+            } else {
+                Ok(())
+            }
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(2.0, value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_keeps_class_restricted_floats_in_class() {
+        // Shrink proposals (0.0, truncation, ...) fall outside the
+        // allowed class set; the conform hook maps them back in, so the
+        // minimal example is the smallest positive subnormal, not 0.0.
+        let mut runner = engine_runner();
+        let strategy =
+            crate::num::f64::POSITIVE | crate::num::f64::SUBNORMAL;
+        let result = runner.run(&strategy, |_| {
+            Err(crate::test_runner::TestCaseError::fail("always"))
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert!(
+                    value.is_sign_positive()
+                        && value.classify()
+                            == core::num::FpCategory::Subnormal,
+                    "value left the strategy's class set: {:?}",
+                    value
+                );
+                assert_eq!(f64::from_bits(1), value);
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
     fn replay_engine_deletes_vec_elements() {
         // Element deletion is a generic span-deletion pass under the tape
         // engine; remaining elements minimize to their targets.

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -794,6 +794,44 @@ mod test {
     }
 
     #[test]
+    fn replay_engine_shrinks_char_range_to_boundary() {
+        let mut runner = engine_runner();
+        let result = runner.run(&crate::char::range('a', 'z'), |c| {
+            if c >= 'd' {
+                Err(crate::test_runner::TestCaseError::fail("too big"))
+            } else {
+                Ok(())
+            }
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!('d', value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_shrinks_any_char_to_convenient_bottom() {
+        // char shrink targets are the hard-wired convenient characters
+        // ('a', 'A', '0', ' ', '¡', or NUL), not necessarily NUL.
+        let mut runner = engine_runner();
+        let result = runner.run(&crate::char::any(), |_| {
+            Err(crate::test_runner::TestCaseError::fail("always"))
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert!(
+                    ['\0', ' ', '0', 'A', 'a', '¡'].contains(&value),
+                    "expected a convenient bottom, got {:?}",
+                    value
+                );
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
     fn replay_engine_deletes_vec_elements() {
         // Element deletion is a generic span-deletion pass under the tape
         // engine; remaining elements minimize to their targets.

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -922,6 +922,32 @@ mod test {
     }
 
     #[test]
+    fn replay_engine_shrinks_length_prefixed_vec_to_single_element() {
+        // Through a bind, the collection length is an explicit earlier
+        // choice, so getting from [.., 0, 100] to [100] needs the
+        // lower-and-delete pass: neither deleting a zero span (the
+        // length still demands the old count) nor lowering the length
+        // (the tail element falls off) works alone.
+        use crate::strategy::Strategy;
+        let mut runner = engine_runner();
+        let strategy = (1usize..=64)
+            .prop_flat_map(|len| crate::collection::vec(0i32..1000, len..=len));
+        let result = runner.run(&strategy, |v| {
+            if v.iter().sum::<i32>() >= 100 {
+                Err(crate::test_runner::TestCaseError::fail("sum too big"))
+            } else {
+                Ok(())
+            }
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(vec![100], value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
     fn replay_engine_shrinks_unmigrated_strategy_via_raw_choices() {
         // bool::ANY draws straight from the RNG; the compat wrapper
         // records that as a raw choice and the trivial pass zeroes it.
@@ -1427,9 +1453,8 @@ mod test {
         let mut map = BTreeMap::new();
         map.insert("corrupt_tape_test", entries);
         let mut config = engine_config();
-        config.failure_persistence = Some(Box::new(
-            crate::test_runner::MapFailurePersistence { map },
-        ));
+        config.failure_persistence =
+            Some(Box::new(crate::test_runner::MapFailurePersistence { map }));
         config.source_file = Some("corrupt_tape_test");
         let mut runner = crate::test_runner::TestRunner::new_with_rng(
             config,

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -211,10 +211,21 @@ fn base_float_to_lex(f: f64) -> u64 {
     (1u64 << 63) | (exponent_rank(exponent) << 52) | mantissa
 }
 
+/// A contiguous run of choices forming one logical unit of generation
+/// (e.g. one collection element together with its continuation flag).
+/// Spans are metadata for the deletion pass: replay ignores them and
+/// re-records them from the actual generation structure.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct Span {
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+}
+
 /// A recorded generation run.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct Tape {
     pub(crate) choices: Vec<Choice>,
+    pub(crate) spans: Vec<Span>,
 }
 
 impl Tape {
@@ -239,6 +250,7 @@ impl Tape {
     pub(crate) fn trivial(&self) -> Tape {
         Tape {
             choices: self.choices.iter().map(Choice::trivial).collect(),
+            spans: self.spans.clone(),
         }
     }
 
@@ -247,6 +259,21 @@ impl Tape {
         let mut out = self.clone();
         out.choices[idx] = choice;
         out
+    }
+
+    /// A copy of the tape with the choices of `span` removed. The copy's
+    /// span list is dropped (it would be stale); an accepted proposal gets
+    /// fresh spans from the replay's output tape anyway.
+    pub(crate) fn with_span_deleted(&self, span: Span) -> Tape {
+        let mut choices = Vec::with_capacity(
+            self.choices.len() - (span.end - span.start),
+        );
+        choices.extend_from_slice(&self.choices[..span.start]);
+        choices.extend_from_slice(&self.choices[span.end..]);
+        Tape {
+            choices,
+            spans: Vec::new(),
+        }
     }
 }
 
@@ -273,6 +300,9 @@ pub(crate) struct TapeState {
     /// draws set this while running their sample closures so the closure's
     /// raw entropy is subsumed by the single typed choice.
     suppress_raw: u32,
+    /// Start indices of currently-open spans (choice count at
+    /// `start_span` time).
+    span_stack: Vec<usize>,
 }
 
 impl Default for TapeState {
@@ -280,6 +310,7 @@ impl Default for TapeState {
         TapeState {
             mode: TapeMode::Off,
             suppress_raw: 0,
+            span_stack: Vec::new(),
         }
     }
 }
@@ -311,11 +342,13 @@ impl TapeState {
         self.mode = TapeMode::Recording {
             tape: Tape::default(),
         };
+        self.span_stack.clear();
     }
 
     /// Stop recording and return the recorded tape. Returns an empty tape
     /// if not recording.
     pub(crate) fn take_recording(&mut self) -> Tape {
+        self.span_stack.clear();
         match core::mem::replace(&mut self.mode, TapeMode::Off) {
             TapeMode::Recording { tape } => tape,
             _ => Tape::default(),
@@ -329,16 +362,54 @@ impl TapeState {
             output: Tape::default(),
             overrun: false,
         };
+        self.span_stack.clear();
     }
 
     /// Stop replaying and return the re-recorded output tape plus whether
     /// the input was overrun. Returns an empty tape if not replaying.
     pub(crate) fn finish_replay(&mut self) -> (Tape, bool) {
+        self.span_stack.clear();
         match core::mem::replace(&mut self.mode, TapeMode::Off) {
             TapeMode::Replaying {
                 output, overrun, ..
             } => (output, overrun),
             _ => (Tape::default(), false),
+        }
+    }
+
+    /// The tape currently being written: the recording, or the output
+    /// re-recording during replay.
+    fn active_tape_mut(&mut self) -> Option<&mut Tape> {
+        match &mut self.mode {
+            TapeMode::Off => None,
+            TapeMode::Recording { tape } => Some(tape),
+            TapeMode::Replaying { output, .. } => Some(output),
+        }
+    }
+
+    /// Open a span at the current position of the active tape. No-op when
+    /// the tape is off.
+    pub(crate) fn start_span(&mut self) {
+        let pos = match self.active_tape_mut() {
+            Some(tape) => tape.choices.len(),
+            None => return,
+        };
+        self.span_stack.push(pos);
+    }
+
+    /// Close the innermost open span. Robust against unbalanced calls
+    /// (e.g. when generation errors out mid-span): closing with no open
+    /// span is a no-op.
+    pub(crate) fn end_span(&mut self) {
+        let start = match self.span_stack.pop() {
+            Some(start) => start,
+            None => return,
+        };
+        if let Some(tape) = self.active_tape_mut() {
+            let end = tape.choices.len();
+            if end > start {
+                tape.spans.push(Span { start, end });
+            }
         }
     }
 
@@ -444,6 +515,13 @@ pub(crate) fn float_round_to_precision(v: f64, k: i32) -> f64 {
 mod test {
     use super::*;
 
+    fn tape_of(choices: Vec<Choice>) -> Tape {
+        Tape {
+            choices,
+            spans: Vec::new(),
+        }
+    }
+
     #[test]
     fn zigzag_prefers_target_then_positive_side() {
         let t = 100u128;
@@ -516,56 +594,46 @@ mod test {
 
     #[test]
     fn shortlex_shorter_tape_wins() {
-        let long = Tape {
-            choices: vec![
-                Choice::RawU32 { value: 0 },
-                Choice::RawU32 { value: 0 },
-            ],
-        };
-        let short = Tape {
-            choices: vec![Choice::RawU32 { value: u32::MAX }],
-        };
+        let long = tape_of(vec![
+            Choice::RawU32 { value: 0 },
+            Choice::RawU32 { value: 0 },
+        ]);
+        let short = tape_of(vec![Choice::RawU32 { value: u32::MAX }]);
         assert_eq!(Ordering::Less, short.cmp_key(&long));
     }
 
     #[test]
     fn shortlex_compares_keys_elementwise() {
-        let a = Tape {
-            choices: vec![
-                Choice::RawU32 { value: 1 },
-                Choice::RawU32 { value: 100 },
-            ],
-        };
-        let b = Tape {
-            choices: vec![
-                Choice::RawU32 { value: 2 },
-                Choice::RawU32 { value: 0 },
-            ],
-        };
+        let a = tape_of(vec![
+            Choice::RawU32 { value: 1 },
+            Choice::RawU32 { value: 100 },
+        ]);
+        let b = tape_of(vec![
+            Choice::RawU32 { value: 2 },
+            Choice::RawU32 { value: 0 },
+        ]);
         assert_eq!(Ordering::Less, a.cmp_key(&b));
     }
 
     #[test]
     fn trivial_tape_is_minimal() {
-        let tape = Tape {
-            choices: vec![
-                Choice::Integer {
-                    value: i32::encode(57),
-                    min: i32::encode(-100),
-                    max: i32::encode(100),
-                    shrink_to: i32::encode_zero(),
-                },
-                Choice::Float {
-                    value: 3.7,
-                    min: 1.5,
-                    max: 10.0,
-                    allow_nan: false,
-                },
-                Choice::RawBytes {
-                    value: vec![1, 2, 3],
-                },
-            ],
-        };
+        let tape = tape_of(vec![
+            Choice::Integer {
+                value: i32::encode(57),
+                min: i32::encode(-100),
+                max: i32::encode(100),
+                shrink_to: i32::encode_zero(),
+            },
+            Choice::Float {
+                value: 3.7,
+                min: 1.5,
+                max: 10.0,
+                allow_nan: false,
+            },
+            Choice::RawBytes {
+                value: vec![1, 2, 3],
+            },
+        ]);
         let trivial = tape.trivial();
         assert_eq!(Ordering::Less, trivial.cmp_key(&tape));
         assert_eq!(Ordering::Equal, trivial.cmp_key(&trivial.trivial()));
@@ -680,6 +748,66 @@ mod test {
     }
 
     #[test]
+    fn replay_engine_deletes_vec_elements() {
+        // Element deletion is a generic span-deletion pass under the tape
+        // engine; remaining elements minimize to their targets.
+        let mut runner = engine_runner();
+        let result =
+            runner.run(&crate::collection::vec(0i32..100, 0..10), |v| {
+                if v.len() >= 3 {
+                    Err(crate::test_runner::TestCaseError::fail("too long"))
+                } else {
+                    Ok(())
+                }
+            });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(vec![0, 0, 0], value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_minimizes_vec_elements() {
+        let mut runner = engine_runner();
+        let result =
+            runner.run(&crate::collection::vec(0i32..100, 3), |v| {
+                if v.iter().any(|&e| e >= 7) {
+                    Err(crate::test_runner::TestCaseError::fail("big elem"))
+                } else {
+                    Ok(())
+                }
+            });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, mut value)) => {
+                value.sort();
+                assert_eq!(vec![0, 0, 7], value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_shrinks_union_to_first_branch() {
+        use crate::strategy::Strategy;
+        let mut runner = engine_runner();
+        let strategy = crate::prop_oneof![
+            crate::strategy::Just(3i32),
+            10i32..20,
+        ];
+        let result = runner.run(&strategy.boxed(), |_| {
+            Err(crate::test_runner::TestCaseError::fail("always"))
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(3, value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
     fn replay_engine_respects_zero_shrink_budget() {
         let mut config = engine_config();
         config.max_shrink_iters = 0;
@@ -725,12 +853,10 @@ mod test {
     #[test]
     fn replay_pops_matching_choices() {
         let mut state = TapeState::default();
-        state.start_replay(Tape {
-            choices: vec![
-                Choice::RawU32 { value: 7 },
-                Choice::RawU64 { value: 9 },
-            ],
-        });
+        state.start_replay(tape_of(vec![
+            Choice::RawU32 { value: 7 },
+            Choice::RawU64 { value: 9 },
+        ]));
         // Matching kind pops.
         let popped =
             state.pop_replay(|c| matches!(c, Choice::RawU32 { .. }));

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -1,0 +1,756 @@
+//-
+// Copyright 2026 The proptest developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The choice tape: a Conjecture-style typed record of every decision made
+//! while generating a test case, used by the experimental tape shrink engine
+//! (`Config::shrink_engine = ShrinkEngine::Tape`).
+//!
+//! See `design/choice-tape-shrinking.md` in the repository root for the full
+//! design. In short: generation records each random draw as a `Choice`;
+//! shrinking edits the recorded tape and re-runs generation in `Replaying`
+//! mode, accepting an edit iff the test still fails and the re-recorded
+//! output tape is shortlex-smaller than the incumbent.
+
+use crate::std_facade::Vec;
+use core::cmp::Ordering;
+
+#[cfg(not(feature = "std"))]
+use num_traits::float::FloatCore;
+
+/// One recorded decision.
+///
+/// `Integer` values (and their constraints) are stored in u128 "offset
+/// space": an order-preserving embedding of the original integer type
+/// (unsigned: identity; signed: offset binary, i.e. `x ^ (1 << 127)` of the
+/// sign-extended value). This gives all integer widths a single canonical
+/// unsigned ordering.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Choice {
+    Integer {
+        value: u128,
+        min: u128,
+        max: u128,
+        /// The value shrinking moves toward; `encode(0)` clamped into
+        /// `[min, max]` for numeric strategies.
+        shrink_to: u128,
+    },
+    Float {
+        value: f64,
+        min: f64,
+        max: f64,
+        allow_nan: bool,
+    },
+    #[allow(dead_code)] // constructed starting with the collection encoding
+    Bool { value: bool },
+    /// Untyped entropy recorded by the `RngCore` compat wrapper.
+    RawU32 { value: u32 },
+    RawU64 { value: u64 },
+    RawBytes { value: Vec<u8> },
+}
+
+/// Complexity key of a single choice. Lower keys are "simpler" values; the
+/// all-target tape has all-zero keys.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Key {
+    Int(u128),
+    Bytes(usize, Vec<u8>),
+}
+
+impl Choice {
+    pub(crate) fn key(&self) -> Key {
+        match self {
+            Choice::Integer {
+                value, shrink_to, ..
+            } => Key::Int(zigzag(*value, *shrink_to)),
+            Choice::Float { value, .. } => Key::Int(float_key(*value)),
+            Choice::Bool { value } => Key::Int(*value as u128),
+            Choice::RawU32 { value } => Key::Int(*value as u128),
+            Choice::RawU64 { value } => Key::Int(*value as u128),
+            Choice::RawBytes { value } => {
+                Key::Bytes(value.len(), value.clone())
+            }
+        }
+    }
+
+    /// The same choice with its value replaced by its shrink target.
+    pub(crate) fn trivial(&self) -> Choice {
+        match self {
+            Choice::Integer {
+                min,
+                max,
+                shrink_to,
+                ..
+            } => Choice::Integer {
+                value: *shrink_to,
+                min: *min,
+                max: *max,
+                shrink_to: *shrink_to,
+            },
+            Choice::Float {
+                min,
+                max,
+                allow_nan,
+                ..
+            } => Choice::Float {
+                value: float_shrink_target(*min, *max),
+                min: *min,
+                max: *max,
+                allow_nan: *allow_nan,
+            },
+            Choice::Bool { .. } => Choice::Bool { value: false },
+            Choice::RawU32 { .. } => Choice::RawU32 { value: 0 },
+            Choice::RawU64 { .. } => Choice::RawU64 { value: 0 },
+            Choice::RawBytes { value } => Choice::RawBytes {
+                value: vec![0; value.len()],
+            },
+        }
+    }
+}
+
+/// Distance of `v` from the shrink target `t`, zigzag-encoded so that the
+/// target keys to 0 and, at equal distance, the positive direction is
+/// preferred (`t` < `t+1` < `t-1` < `t+2` < ...).
+///
+/// Saturates at the extremes of u128, which slightly coarsens the ordering
+/// for astronomically distant values; that only weakens tie-breaking, never
+/// soundness.
+pub(crate) fn zigzag(v: u128, t: u128) -> u128 {
+    if v >= t {
+        (v - t).saturating_mul(2).saturating_sub(1)
+    } else {
+        (t - v).saturating_mul(2)
+    }
+}
+
+/// Complexity key for floats: NaN worst, then by sign (non-negative
+/// simpler), then by the lexicographic encoding of the magnitude.
+pub(crate) fn float_key(v: f64) -> u128 {
+    if v.is_nan() {
+        return u128::MAX;
+    }
+    let sign = if v.is_sign_negative() { 1u128 << 64 } else { 0 };
+    sign | float_to_lex(v.abs()) as u128
+}
+
+/// The shrink target of a float draw constrained to `[min, max]`: the
+/// in-range value closest to +0.0.
+pub(crate) fn float_shrink_target(min: f64, max: f64) -> f64 {
+    min.max(0.0).min(max)
+}
+
+/// Port of Hypothesis's lexicographic float encoding
+/// (`hypothesis.internal.conjecture.floats.float_to_lex`).
+///
+/// Maps non-negative floats to u64 such that lexicographically smaller
+/// integers correspond to "simpler" floats:
+///
+/// - Integer-valued floats below 2^56 encode as themselves (tag bit 0), so
+///   0 < 1 < 2 < ... in encoded space.
+/// - Everything else gets the tag bit set, an exponent reordered so that
+///   integer-like exponents come first, and the fractional mantissa bits
+///   reversed so that shorter decimal fractions are smaller.
+pub(crate) fn float_to_lex(f: f64) -> u64 {
+    debug_assert!(
+        !(f < 0.0),
+        "float_to_lex requires a non-negative input, got {}",
+        f
+    );
+    if f.is_finite() && f == f.trunc() && f < (1u64 << 56) as f64 {
+        return f as u64;
+    }
+    base_float_to_lex(f)
+}
+
+const MANTISSA_MASK: u64 = (1u64 << 52) - 1;
+const MAX_EXPONENT: u64 = 0x7FF;
+const BIAS: i64 = 1023;
+
+/// Rank of an 11-bit exponent under Hypothesis's ordering: non-negative
+/// unbiased exponents first in increasing order, then negative unbiased
+/// exponents in decreasing order, then the inf/NaN exponent last.
+///
+/// This is a closed form of Hypothesis's sorted `ENCODING_TABLE`.
+fn exponent_rank(e: u64) -> u64 {
+    debug_assert!(e <= MAX_EXPONENT);
+    if e == MAX_EXPONENT {
+        MAX_EXPONENT
+    } else if e >= BIAS as u64 {
+        e - BIAS as u64
+    } else {
+        // unbiased = e - 1023 in -1023..=-1; rank 1024..=2046 with the
+        // least negative exponent first.
+        2046 - e
+    }
+}
+
+fn update_mantissa(unbiased_exponent: i64, mut mantissa: u64) -> u64 {
+    if unbiased_exponent <= 0 {
+        // Subnormals and values in [0, 2): all 52 bits are fractional;
+        // reverse them all so that "fewer fraction bits" sorts lower.
+        mantissa = mantissa.reverse_bits() >> (64 - 52);
+    } else if unbiased_exponent <= 51 {
+        let n_fractional = (52 - unbiased_exponent) as u32;
+        let fractional = mantissa & ((1u64 << n_fractional) - 1);
+        mantissa -= fractional;
+        mantissa |= fractional.reverse_bits() >> (64 - n_fractional);
+    }
+    mantissa
+}
+
+fn base_float_to_lex(f: f64) -> u64 {
+    let bits = f.to_bits() & !(1u64 << 63);
+    let exponent = bits >> 52;
+    let mantissa =
+        update_mantissa(exponent as i64 - BIAS, bits & MANTISSA_MASK);
+    (1u64 << 63) | (exponent_rank(exponent) << 52) | mantissa
+}
+
+/// A recorded generation run.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct Tape {
+    pub(crate) choices: Vec<Choice>,
+}
+
+impl Tape {
+    /// Shortlex comparison: fewer choices first, then elementwise by
+    /// complexity key. `Less` means `self` is simpler than `other`.
+    pub(crate) fn cmp_key(&self, other: &Tape) -> Ordering {
+        self.choices
+            .len()
+            .cmp(&other.choices.len())
+            .then_with(|| {
+                for (a, b) in self.choices.iter().zip(&other.choices) {
+                    match a.key().cmp(&b.key()) {
+                        Ordering::Equal => continue,
+                        unequal => return unequal,
+                    }
+                }
+                Ordering::Equal
+            })
+    }
+
+    /// The tape with every choice at its shrink target.
+    pub(crate) fn trivial(&self) -> Tape {
+        Tape {
+            choices: self.choices.iter().map(Choice::trivial).collect(),
+        }
+    }
+
+    /// A copy of the tape with the choice at `idx` replaced.
+    pub(crate) fn with_choice(&self, idx: usize, choice: Choice) -> Tape {
+        let mut out = self.clone();
+        out.choices[idx] = choice;
+        out
+    }
+}
+
+/// Recording/replaying state, owned by `TestRng` so that both the typed
+/// draws on `TestRunner` and the raw `RngCore` calls write to the same tape.
+#[derive(Clone, Debug)]
+pub(crate) enum TapeMode {
+    Off,
+    Recording {
+        tape: Tape,
+    },
+    Replaying {
+        input: Tape,
+        cursor: usize,
+        output: Tape,
+        overrun: bool,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TapeState {
+    mode: TapeMode,
+    /// While positive, raw RngCore draws bypass the tape entirely. Typed
+    /// draws set this while running their sample closures so the closure's
+    /// raw entropy is subsumed by the single typed choice.
+    suppress_raw: u32,
+}
+
+impl Default for TapeState {
+    fn default() -> Self {
+        TapeState {
+            mode: TapeMode::Off,
+            suppress_raw: 0,
+        }
+    }
+}
+
+impl TapeState {
+    pub(crate) fn is_on(&self) -> bool {
+        !matches!(self.mode, TapeMode::Off)
+    }
+
+    pub(crate) fn is_replaying(&self) -> bool {
+        matches!(self.mode, TapeMode::Replaying { .. })
+    }
+
+    /// Whether raw RngCore draws should currently be recorded/replayed.
+    pub(crate) fn raw_active(&self) -> bool {
+        self.is_on() && 0 == self.suppress_raw
+    }
+
+    pub(crate) fn suppress_raw(&mut self) {
+        self.suppress_raw += 1;
+    }
+
+    pub(crate) fn unsuppress_raw(&mut self) {
+        debug_assert!(self.suppress_raw > 0);
+        self.suppress_raw -= 1;
+    }
+
+    pub(crate) fn start_recording(&mut self) {
+        self.mode = TapeMode::Recording {
+            tape: Tape::default(),
+        };
+    }
+
+    /// Stop recording and return the recorded tape. Returns an empty tape
+    /// if not recording.
+    pub(crate) fn take_recording(&mut self) -> Tape {
+        match core::mem::replace(&mut self.mode, TapeMode::Off) {
+            TapeMode::Recording { tape } => tape,
+            _ => Tape::default(),
+        }
+    }
+
+    pub(crate) fn start_replay(&mut self, input: Tape) {
+        self.mode = TapeMode::Replaying {
+            input,
+            cursor: 0,
+            output: Tape::default(),
+            overrun: false,
+        };
+    }
+
+    /// Stop replaying and return the re-recorded output tape plus whether
+    /// the input was overrun. Returns an empty tape if not replaying.
+    pub(crate) fn finish_replay(&mut self) -> (Tape, bool) {
+        match core::mem::replace(&mut self.mode, TapeMode::Off) {
+            TapeMode::Replaying {
+                output, overrun, ..
+            } => (output, overrun),
+            _ => (Tape::default(), false),
+        }
+    }
+
+    /// Append the choice actually used to the active tape (the recording,
+    /// or the output re-recording during replay). No-op when off.
+    pub(crate) fn record(&mut self, choice: Choice) {
+        match &mut self.mode {
+            TapeMode::Off => (),
+            TapeMode::Recording { tape } => tape.choices.push(choice),
+            TapeMode::Replaying { output, .. } => output.choices.push(choice),
+        }
+    }
+
+    /// During replay, consume and return the next input choice if `matcher`
+    /// accepts it. Returns `None` (and samples must go fresh) on kind
+    /// mismatch, on overrun (also setting the overrun flag), or when not
+    /// replaying.
+    pub(crate) fn pop_replay(
+        &mut self,
+        matcher: impl FnOnce(&Choice) -> bool,
+    ) -> Option<Choice> {
+        if let TapeMode::Replaying {
+            input,
+            cursor,
+            overrun,
+            ..
+        } = &mut self.mode
+        {
+            if *cursor >= input.choices.len() {
+                *overrun = true;
+                return None;
+            }
+            if matcher(&input.choices[*cursor]) {
+                let choice = input.choices[*cursor].clone();
+                *cursor += 1;
+                return Some(choice);
+            }
+        }
+        None
+    }
+}
+
+/// Order-preserving embedding of primitive integers into u128 offset space.
+pub(crate) trait TapeInt: Copy {
+    fn encode(self) -> u128;
+    fn decode(encoded: u128) -> Self;
+    /// `encode(0)`, the natural shrink target before range clamping.
+    fn encode_zero() -> u128;
+}
+
+macro_rules! tape_int_unsigned {
+    ($($typ:ty),*) => {$(
+        impl TapeInt for $typ {
+            fn encode(self) -> u128 {
+                self as u128
+            }
+            fn decode(encoded: u128) -> Self {
+                encoded as $typ
+            }
+            fn encode_zero() -> u128 {
+                0
+            }
+        }
+    )*};
+}
+
+macro_rules! tape_int_signed {
+    ($($typ:ty),*) => {$(
+        impl TapeInt for $typ {
+            fn encode(self) -> u128 {
+                (self as i128 as u128) ^ (1u128 << 127)
+            }
+            fn decode(encoded: u128) -> Self {
+                (encoded ^ (1u128 << 127)) as i128 as $typ
+            }
+            fn encode_zero() -> u128 {
+                1u128 << 127
+            }
+        }
+    )*};
+}
+
+tape_int_unsigned!(u8, u16, u32, u64, u128, usize);
+tape_int_signed!(i8, i16, i32, i64, i128, isize);
+
+/// `trunc` usable from both std and no_std builds.
+pub(crate) fn float_trunc(v: f64) -> f64 {
+    v.trunc()
+}
+
+/// Round `v` to `k` binary digits of fraction, for the precision-dropping
+/// shrink pass.
+pub(crate) fn float_round_to_precision(v: f64, k: i32) -> f64 {
+    let scale = 2.0f64.powi(k);
+    let scaled = v * scale;
+    if !scaled.is_finite() {
+        return v;
+    }
+    scaled.round() / scale
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn zigzag_prefers_target_then_positive_side() {
+        let t = 100u128;
+        assert_eq!(0, zigzag(100, t));
+        assert_eq!(1, zigzag(101, t));
+        assert_eq!(2, zigzag(99, t));
+        assert_eq!(3, zigzag(102, t));
+        assert_eq!(4, zigzag(98, t));
+    }
+
+    #[test]
+    fn tape_int_roundtrip_and_order() {
+        fn check<T: TapeInt + PartialEq + core::fmt::Debug>(values: &[T]) {
+            for &v in values {
+                assert_eq!(v, T::decode(T::encode(v)));
+            }
+            for pair in values.windows(2) {
+                assert!(pair[0].encode() < pair[1].encode());
+            }
+        }
+        check(&[0u8, 1, 200, u8::MAX]);
+        check(&[i8::MIN, -1, 0, 1, i8::MAX]);
+        check(&[i64::MIN, -1, 0, 1, i64::MAX]);
+        check(&[u128::MIN, 1, u128::MAX]);
+        check(&[i128::MIN, -1, 0, i128::MAX]);
+        assert_eq!(i64::encode(0), i64::encode_zero());
+        assert_eq!(u64::encode(0), u64::encode_zero());
+    }
+
+    #[test]
+    fn float_lex_simple_integers_encode_as_themselves() {
+        // (Values must be exactly representable as f64, so no 2^56 - 1:
+        // that rounds up to 2^56, which is no longer "simple".)
+        for i in [0u64, 1, 2, 3, 10, 1000, 1 << 53, 1 << 55] {
+            assert_eq!(i, float_to_lex(i as f64));
+        }
+    }
+
+    #[test]
+    fn float_lex_integers_are_simpler_than_fractions() {
+        // Any integer below 2^56 keys below any non-integer.
+        assert!(float_to_lex(1000000.0) < float_to_lex(1.5));
+        assert!(float_to_lex(3.0) < float_to_lex(2.5));
+        // Ties on the integer part: fewer fraction bits is simpler.
+        assert!(float_to_lex(2.5) < float_to_lex(2.25));
+        assert!(float_to_lex(2.25) < float_to_lex(2.125));
+        // Infinity is worse than all finite values.
+        assert!(float_to_lex(f64::MAX) < float_to_lex(f64::INFINITY));
+        assert!(float_to_lex(1e300) < float_to_lex(f64::INFINITY));
+    }
+
+    #[test]
+    fn float_key_sign_and_nan_ordering() {
+        assert!(float_key(1.0) < float_key(-1.0));
+        assert!(float_key(-1.0) < float_key(f64::NAN));
+        assert!(float_key(f64::INFINITY) < float_key(f64::NAN));
+        assert_eq!(0, float_key(0.0));
+    }
+
+    #[test]
+    fn float_shrink_target_clamps_toward_zero() {
+        assert_eq!(0.0, float_shrink_target(-10.0, 10.0));
+        assert_eq!(1.5, float_shrink_target(1.5, 10.0));
+        assert_eq!(-1.5, float_shrink_target(-10.0, -1.5));
+        assert_eq!(
+            0.0,
+            float_shrink_target(f64::NEG_INFINITY, f64::INFINITY)
+        );
+    }
+
+    #[test]
+    fn shortlex_shorter_tape_wins() {
+        let long = Tape {
+            choices: vec![
+                Choice::RawU32 { value: 0 },
+                Choice::RawU32 { value: 0 },
+            ],
+        };
+        let short = Tape {
+            choices: vec![Choice::RawU32 { value: u32::MAX }],
+        };
+        assert_eq!(Ordering::Less, short.cmp_key(&long));
+    }
+
+    #[test]
+    fn shortlex_compares_keys_elementwise() {
+        let a = Tape {
+            choices: vec![
+                Choice::RawU32 { value: 1 },
+                Choice::RawU32 { value: 100 },
+            ],
+        };
+        let b = Tape {
+            choices: vec![
+                Choice::RawU32 { value: 2 },
+                Choice::RawU32 { value: 0 },
+            ],
+        };
+        assert_eq!(Ordering::Less, a.cmp_key(&b));
+    }
+
+    #[test]
+    fn trivial_tape_is_minimal() {
+        let tape = Tape {
+            choices: vec![
+                Choice::Integer {
+                    value: i32::encode(57),
+                    min: i32::encode(-100),
+                    max: i32::encode(100),
+                    shrink_to: i32::encode_zero(),
+                },
+                Choice::Float {
+                    value: 3.7,
+                    min: 1.5,
+                    max: 10.0,
+                    allow_nan: false,
+                },
+                Choice::RawBytes {
+                    value: vec![1, 2, 3],
+                },
+            ],
+        };
+        let trivial = tape.trivial();
+        assert_eq!(Ordering::Less, trivial.cmp_key(&tape));
+        assert_eq!(Ordering::Equal, trivial.cmp_key(&trivial.trivial()));
+        match &trivial.choices[1] {
+            Choice::Float { value, .. } => assert_eq!(1.5, *value),
+            other => panic!("unexpected {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_shrinks_float_range_to_round_value() {
+        // The headline feature: a float threshold failure shrinks to the
+        // smallest *round* failing value, not to an ugly boundary
+        // approximation like 1.7000000000000002.
+        let mut runner = engine_runner();
+        let result = runner.run(&(0.0f64..10.0), |v| {
+            if v >= 1.7 {
+                Err(crate::test_runner::TestCaseError::fail("too big"))
+            } else {
+                Ok(())
+            }
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(2.0, value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_shrinks_filtered_integers_to_boundary() {
+        // The ValueTree shrinker can stall on filters because simplify()
+        // has no way to skip over rejected values; the tape engine
+        // re-vets every proposal through the filter.
+        use crate::strategy::Strategy;
+        let mut runner = engine_runner();
+        let strategy = (0i32..1000)
+            .prop_filter("even", |v| 0 == v % 2);
+        let result = runner.run(&strategy, |v| {
+            if v >= 100 {
+                Err(crate::test_runner::TestCaseError::fail("too big"))
+            } else {
+                Ok(())
+            }
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(100, value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_shrinks_each_tuple_component() {
+        // Per-choice minimization drives the pair onto the failure
+        // boundary. (Redistribution *along* the boundary toward (0, 100)
+        // is a phase-4 cross-value pass.)
+        let mut runner = engine_runner();
+        let result = runner.run(&(0i32..1000, 0i32..1000), |(a, b)| {
+            if a + b >= 100 {
+                Err(crate::test_runner::TestCaseError::fail("too big"))
+            } else {
+                Ok(())
+            }
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, (a, b))) => {
+                assert_eq!(100, a + b, "final pair: ({}, {})", a, b);
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_shrinks_through_flat_map() {
+        // flat_map replays naturally: shrinking the outer choice reuses
+        // the recorded inner choice, clamped into the new constraints.
+        use crate::strategy::Strategy;
+        let mut runner = engine_runner();
+        let strategy = (1i32..=5).prop_flat_map(|n| 0i32..(n * 100));
+        let result = runner.run(&strategy, |v| {
+            if v >= 57 {
+                Err(crate::test_runner::TestCaseError::fail("too big"))
+            } else {
+                Ok(())
+            }
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(57, value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_shrinks_unmigrated_strategy_via_raw_choices() {
+        // bool::ANY draws straight from the RNG; the compat wrapper
+        // records that as a raw choice and the trivial pass zeroes it.
+        let mut runner = engine_runner();
+        let result = runner.run(&crate::bool::ANY, |_| {
+            Err(crate::test_runner::TestCaseError::fail("always"))
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(false, value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_respects_zero_shrink_budget() {
+        let mut config = engine_config();
+        config.max_shrink_iters = 0;
+        let mut runner = crate::test_runner::TestRunner::new_with_rng(
+            config,
+            crate::test_runner::TestRng::deterministic_rng(
+                crate::test_runner::RngAlgorithm::default(),
+            ),
+        );
+        let result = runner.run(&(0.0f64..10.0), |v| {
+            if v >= 1.7 {
+                Err(crate::test_runner::TestCaseError::fail("too big"))
+            } else {
+                Ok(())
+            }
+        });
+        // No shrinking happened, so we only know the value fails.
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert!(value >= 1.7)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    fn engine_config() -> crate::test_runner::Config {
+        crate::test_runner::Config {
+            shrink_engine: crate::test_runner::ShrinkEngine::Tape,
+            failure_persistence: None,
+            ..crate::test_runner::Config::default()
+        }
+    }
+
+    fn engine_runner() -> crate::test_runner::TestRunner {
+        crate::test_runner::TestRunner::new_with_rng(
+            engine_config(),
+            crate::test_runner::TestRng::deterministic_rng(
+                crate::test_runner::RngAlgorithm::default(),
+            ),
+        )
+    }
+
+    #[test]
+    fn replay_pops_matching_choices() {
+        let mut state = TapeState::default();
+        state.start_replay(Tape {
+            choices: vec![
+                Choice::RawU32 { value: 7 },
+                Choice::RawU64 { value: 9 },
+            ],
+        });
+        // Matching kind pops.
+        let popped =
+            state.pop_replay(|c| matches!(c, Choice::RawU32 { .. }));
+        assert_eq!(Some(Choice::RawU32 { value: 7 }), popped);
+        // Kind mismatch does not consume...
+        assert_eq!(
+            None,
+            state.pop_replay(|c| matches!(c, Choice::RawU32 { .. }))
+        );
+        // ...so the u64 is still there.
+        let popped =
+            state.pop_replay(|c| matches!(c, Choice::RawU64 { .. }));
+        assert_eq!(Some(Choice::RawU64 { value: 9 }), popped);
+        // Overrun.
+        assert_eq!(
+            None,
+            state.pop_replay(|c| matches!(c, Choice::RawU32 { .. }))
+        );
+        let (output, overrun) = state.finish_replay();
+        assert!(overrun);
+        assert!(output.choices.is_empty());
+    }
+}

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -472,6 +472,132 @@ impl TapeState {
     }
 }
 
+/// Serialize a tape for failure persistence (the payload of the "ct1"
+/// persisted-failure format). Spans are shrinking metadata and are not
+/// persisted; replay ignores them.
+pub(crate) fn serialize_tape(tape: &Tape) -> Vec<u8> {
+    let mut out = Vec::new();
+    for choice in &tape.choices {
+        match choice {
+            Choice::Integer {
+                value,
+                min,
+                max,
+                shrink_to,
+            } => {
+                out.push(0);
+                out.extend_from_slice(&value.to_le_bytes());
+                out.extend_from_slice(&min.to_le_bytes());
+                out.extend_from_slice(&max.to_le_bytes());
+                out.extend_from_slice(&shrink_to.to_le_bytes());
+            }
+            Choice::Float {
+                value,
+                min,
+                max,
+                allow_nan,
+            } => {
+                out.push(1);
+                out.extend_from_slice(&value.to_le_bytes());
+                out.extend_from_slice(&min.to_le_bytes());
+                out.extend_from_slice(&max.to_le_bytes());
+                out.push(*allow_nan as u8);
+            }
+            Choice::Bool { value } => {
+                out.push(2);
+                out.push(*value as u8);
+            }
+            Choice::RawU32 { value } => {
+                out.push(3);
+                out.extend_from_slice(&value.to_le_bytes());
+            }
+            Choice::RawU64 { value } => {
+                out.push(4);
+                out.extend_from_slice(&value.to_le_bytes());
+            }
+            Choice::RawBytes { value } => {
+                out.push(5);
+                out.extend_from_slice(&(value.len() as u32).to_le_bytes());
+                out.extend_from_slice(value);
+            }
+        }
+    }
+    out
+}
+
+/// Inverse of `serialize_tape`. Strict: any malformed input yields `None`
+/// (the persistence layer then ignores the entry).
+pub(crate) fn deserialize_tape(bytes: &[u8]) -> Option<Tape> {
+    fn take<'a>(bytes: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+        if bytes.len() < n {
+            return None;
+        }
+        let (head, tail) = bytes.split_at(n);
+        *bytes = tail;
+        Some(head)
+    }
+    fn take_u128(bytes: &mut &[u8]) -> Option<u128> {
+        let mut buf = [0u8; 16];
+        buf.copy_from_slice(take(bytes, 16)?);
+        Some(u128::from_le_bytes(buf))
+    }
+    fn take_f64(bytes: &mut &[u8]) -> Option<f64> {
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(take(bytes, 8)?);
+        Some(f64::from_le_bytes(buf))
+    }
+
+    let mut bytes = bytes;
+    let mut choices = Vec::new();
+    while !bytes.is_empty() {
+        let tag = take(&mut bytes, 1)?[0];
+        choices.push(match tag {
+            0 => Choice::Integer {
+                value: take_u128(&mut bytes)?,
+                min: take_u128(&mut bytes)?,
+                max: take_u128(&mut bytes)?,
+                shrink_to: take_u128(&mut bytes)?,
+            },
+            1 => Choice::Float {
+                value: take_f64(&mut bytes)?,
+                min: take_f64(&mut bytes)?,
+                max: take_f64(&mut bytes)?,
+                allow_nan: 0 != take(&mut bytes, 1)?[0],
+            },
+            2 => Choice::Bool {
+                value: 0 != take(&mut bytes, 1)?[0],
+            },
+            3 => {
+                let mut buf = [0u8; 4];
+                buf.copy_from_slice(take(&mut bytes, 4)?);
+                Choice::RawU32 {
+                    value: u32::from_le_bytes(buf),
+                }
+            }
+            4 => {
+                let mut buf = [0u8; 8];
+                buf.copy_from_slice(take(&mut bytes, 8)?);
+                Choice::RawU64 {
+                    value: u64::from_le_bytes(buf),
+                }
+            }
+            5 => {
+                let mut buf = [0u8; 4];
+                buf.copy_from_slice(take(&mut bytes, 4)?);
+                let len = u32::from_le_bytes(buf) as usize;
+                Choice::RawBytes {
+                    value: take(&mut bytes, len)?.to_vec(),
+                }
+            }
+            _ => return None,
+        });
+    }
+    Some(Tape {
+        choices,
+        spans: Vec::new(),
+    })
+}
+
 /// Order-preserving embedding of primitive integers into u128 offset space.
 pub(crate) trait TapeInt: Copy {
     fn encode(self) -> u128;
@@ -534,6 +660,7 @@ pub(crate) fn float_round_to_precision(v: f64, k: i32) -> f64 {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::std_facade::Box;
 
     fn tape_of(choices: Vec<Choice>) -> Tape {
         Tape {
@@ -1082,6 +1209,131 @@ mod test {
                 crate::test_runner::RngAlgorithm::default(),
             ),
         )
+    }
+
+    #[test]
+    fn tape_serialization_roundtrips() {
+        let tape = tape_of(vec![
+            Choice::Integer {
+                value: i64::encode(-42),
+                min: i64::encode(i64::MIN),
+                max: i64::encode(i64::MAX),
+                shrink_to: i64::encode_zero(),
+            },
+            Choice::Float {
+                value: 2.5,
+                min: f64::NEG_INFINITY,
+                max: f64::INFINITY,
+                allow_nan: true,
+            },
+            Choice::Bool { value: true },
+            Choice::RawU32 { value: 0xDEAD },
+            Choice::RawU64 { value: 0xBEEF_CAFE },
+            Choice::RawBytes {
+                value: vec![1, 2, 3, 4, 5],
+            },
+        ]);
+        let bytes = serialize_tape(&tape);
+        assert_eq!(Some(tape), deserialize_tape(&bytes));
+        // Strictness: truncated input is rejected.
+        assert_eq!(None, deserialize_tape(&bytes[..bytes.len() - 1]));
+        assert_eq!(None, deserialize_tape(&[99]));
+    }
+
+    #[test]
+    fn persisted_tape_form_roundtrips_as_string() {
+        use core::str::FromStr;
+        let seed = crate::test_runner::PersistedSeed(
+            crate::test_runner::failure_persistence::PersistedFailure::Tape(
+                vec![0xab, 0xcd, 0x01],
+            ),
+        );
+        let string = format!("{}", seed);
+        assert!(string.starts_with("ct1 "), "got: {}", string);
+        assert_eq!(
+            Ok(seed),
+            crate::test_runner::PersistedSeed::from_str(&string)
+        );
+    }
+
+    #[test]
+    fn persisted_tape_replays_exact_shrunken_value() {
+        use crate::strategy::Strategy;
+
+        // Run 1: fail on v >= 1.7, shrink to 2.0, persist.
+        let mut config = engine_config();
+        config.failure_persistence = Some(Box::new(
+            crate::test_runner::MapFailurePersistence::default(),
+        ));
+        config.source_file = Some("tape_persistence_test");
+        let mut runner = crate::test_runner::TestRunner::new_with_rng(
+            config,
+            crate::test_runner::TestRng::deterministic_rng(
+                crate::test_runner::RngAlgorithm::default(),
+            ),
+        );
+        let strategy = 0.0f64..10.0;
+        match runner.run(&strategy, |v| {
+            if v >= 1.7 {
+                Err(crate::test_runner::TestCaseError::fail("too big"))
+            } else {
+                Ok(())
+            }
+        }) {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(2.0, value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+
+        // The persisted entry is a tape, not a seed.
+        let map = runner
+            .config()
+            .failure_persistence
+            .as_ref()
+            .unwrap()
+            .as_any()
+            .downcast_ref::<crate::test_runner::MapFailurePersistence>()
+            .unwrap()
+            .map
+            .clone();
+        let entries = &map[&"tape_persistence_test"];
+        assert_eq!(1, entries.len());
+        assert!(format!("{}", entries.iter().next().unwrap())
+            .starts_with("ct1 "));
+
+        // Run 2: fresh runner and RNG; the test only fails at *exactly*
+        // 2.0, which random generation will essentially never produce.
+        // Only replaying the persisted tape can find it.
+        let mut config = engine_config();
+        config.cases = 10;
+        config.failure_persistence = Some(Box::new(
+            crate::test_runner::MapFailurePersistence { map },
+        ));
+        config.source_file = Some("tape_persistence_test");
+        let mut runner = crate::test_runner::TestRunner::new_with_rng(
+            config,
+            crate::test_runner::TestRng::from_seed(
+                crate::test_runner::RngAlgorithm::ChaCha,
+                &[7; 32],
+            ),
+        );
+        match runner.run(&(0.0f64..10.0), |v| {
+            if v == 2.0 {
+                Err(crate::test_runner::TestCaseError::fail("replayed"))
+            } else {
+                Ok(())
+            }
+        }) {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(2.0, value)
+            }
+            other => panic!(
+                "persisted tape did not replay the failure: {:?}",
+                other
+            ),
+        }
+        let _ = strategy;
     }
 
     #[test]

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -974,6 +974,74 @@ mod test {
     }
 
     #[test]
+    fn replay_engine_redistributes_vec_sum_to_single_element() {
+        // Needs the cross-value redistribute pass: [27, 23] -> [0, 50],
+        // then deletion of the zero -> [50].
+        let mut runner = engine_runner();
+        let result =
+            runner.run(&crate::collection::vec(0i32..100, 0..20), |v| {
+                if v.iter().sum::<i32>() >= 50 {
+                    Err(crate::test_runner::TestCaseError::fail("big sum"))
+                } else {
+                    Ok(())
+                }
+            });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(vec![50], value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_redistributes_pair_within_constraints() {
+        // Transfer clamps at the second component's upper bound.
+        let mut runner = engine_runner();
+        let result = runner.run(&(0i32..60, 0i32..60), |(a, b)| {
+            if a + b >= 100 {
+                Err(crate::test_runner::TestCaseError::fail("big sum"))
+            } else {
+                Ok(())
+            }
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, (a, b))) => {
+                assert_eq!((41, 59), (a, b))
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_lowers_duplicates_together() {
+        // No single-choice edit preserves a == b; the duplicates pass
+        // lowers both together. Equal pairs are rare (1/1000 per case),
+        // so give the runner enough cases to find one.
+        let mut config = engine_config();
+        config.cases = 20_000;
+        let mut runner = crate::test_runner::TestRunner::new_with_rng(
+            config,
+            crate::test_runner::TestRng::deterministic_rng(
+                crate::test_runner::RngAlgorithm::default(),
+            ),
+        );
+        let result = runner.run(&(0i32..1000, 0i32..1000), |(a, b)| {
+            if a == b && a >= 10 {
+                Err(crate::test_runner::TestCaseError::fail("equal"))
+            } else {
+                Ok(())
+            }
+        });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!((10, 10), value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
     fn replay_engine_respects_zero_shrink_budget() {
         let mut config = engine_config();
         config.max_shrink_iters = 0;

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -769,6 +769,27 @@ mod test {
     }
 
     #[test]
+    fn replay_engine_deletes_long_vec_via_batched_deletion() {
+        // Starts around 50 elements on average; batched span deletion
+        // takes out long runs in O(log n) attempts.
+        let mut runner = engine_runner();
+        let result =
+            runner.run(&crate::collection::vec(0i32..100, 0..100), |v| {
+                if v.len() >= 5 {
+                    Err(crate::test_runner::TestCaseError::fail("too long"))
+                } else {
+                    Ok(())
+                }
+            });
+        match result {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(vec![0, 0, 0, 0, 0], value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
     fn replay_engine_minimizes_vec_elements() {
         let mut runner = engine_runner();
         let result =

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -47,11 +47,19 @@ pub(crate) enum Choice {
         allow_nan: bool,
     },
     #[allow(dead_code)] // constructed starting with the collection encoding
-    Bool { value: bool },
+    Bool {
+        value: bool,
+    },
     /// Untyped entropy recorded by the `RngCore` compat wrapper.
-    RawU32 { value: u32 },
-    RawU64 { value: u64 },
-    RawBytes { value: Vec<u8> },
+    RawU32 {
+        value: u32,
+    },
+    RawU64 {
+        value: u64,
+    },
+    RawBytes {
+        value: Vec<u8>,
+    },
 }
 
 /// Complexity key of a single choice. Lower keys are "simpler" values; the
@@ -232,18 +240,15 @@ impl Tape {
     /// Shortlex comparison: fewer choices first, then elementwise by
     /// complexity key. `Less` means `self` is simpler than `other`.
     pub(crate) fn cmp_key(&self, other: &Tape) -> Ordering {
-        self.choices
-            .len()
-            .cmp(&other.choices.len())
-            .then_with(|| {
-                for (a, b) in self.choices.iter().zip(&other.choices) {
-                    match a.key().cmp(&b.key()) {
-                        Ordering::Equal => continue,
-                        unequal => return unequal,
-                    }
+        self.choices.len().cmp(&other.choices.len()).then_with(|| {
+            for (a, b) in self.choices.iter().zip(&other.choices) {
+                match a.key().cmp(&b.key()) {
+                    Ordering::Equal => continue,
+                    unequal => return unequal,
                 }
-                Ordering::Equal
-            })
+            }
+            Ordering::Equal
+        })
     }
 
     /// The tape with every choice at its shrink target.
@@ -265,9 +270,8 @@ impl Tape {
     /// span list is dropped (it would be stale); an accepted proposal gets
     /// fresh spans from the replay's output tape anyway.
     pub(crate) fn with_span_deleted(&self, span: Span) -> Tape {
-        let mut choices = Vec::with_capacity(
-            self.choices.len() - (span.end - span.start),
-        );
+        let mut choices =
+            Vec::with_capacity(self.choices.len() - (span.end - span.start));
         choices.extend_from_slice(&self.choices[..span.start]);
         choices.extend_from_slice(&self.choices[span.end..]);
         Tape {
@@ -759,10 +763,7 @@ mod test {
         assert_eq!(0.0, float_shrink_target(-10.0, 10.0));
         assert_eq!(1.5, float_shrink_target(1.5, 10.0));
         assert_eq!(-1.5, float_shrink_target(-10.0, -1.5));
-        assert_eq!(
-            0.0,
-            float_shrink_target(f64::NEG_INFINITY, f64::INFINITY)
-        );
+        assert_eq!(0.0, float_shrink_target(f64::NEG_INFINITY, f64::INFINITY));
     }
 
     #[test]
@@ -844,8 +845,7 @@ mod test {
         // re-vets every proposal through the filter.
         use crate::strategy::Strategy;
         let mut runner = engine_runner();
-        let strategy = (0i32..1000)
-            .prop_filter("even", |v| 0 == v % 2);
+        let strategy = (0i32..1000).prop_filter("even", |v| 0 == v % 2);
         let result = runner.run(&strategy, |v| {
             if v >= 100 {
                 Err(crate::test_runner::TestCaseError::fail("too big"))
@@ -946,8 +946,7 @@ mod test {
         // allowed class set; the conform hook maps them back in, so the
         // minimal example is the smallest positive subnormal, not 0.0.
         let mut runner = engine_runner();
-        let strategy =
-            crate::num::f64::POSITIVE | crate::num::f64::SUBNORMAL;
+        let strategy = crate::num::f64::POSITIVE | crate::num::f64::SUBNORMAL;
         let result = runner.run(&strategy, |_| {
             Err(crate::test_runner::TestCaseError::fail("always"))
         });
@@ -955,8 +954,7 @@ mod test {
             Err(crate::test_runner::TestError::Fail(_, value)) => {
                 assert!(
                     value.is_sign_positive()
-                        && value.classify()
-                            == core::num::FpCategory::Subnormal,
+                        && value.classify() == core::num::FpCategory::Subnormal,
                     "value left the strategy's class set: {:?}",
                     value
                 );
@@ -1060,24 +1058,17 @@ mod test {
                     &[seed_byte; 32],
                 ),
             );
-            let result = runner
-                .run(&crate::collection::vec(0i32..100, 0..6), |v| {
+            let result =
+                runner.run(&crate::collection::vec(0i32..100, 0..6), |v| {
                     if v.len() >= 2 {
-                        Err(crate::test_runner::TestCaseError::fail(
-                            "too long",
-                        ))
+                        Err(crate::test_runner::TestCaseError::fail("too long"))
                     } else {
                         Ok(())
                     }
                 });
             match result {
                 Err(crate::test_runner::TestError::Fail(_, value)) => {
-                    assert_eq!(
-                        vec![0, 0],
-                        value,
-                        "seed byte {}",
-                        seed_byte
-                    )
+                    assert_eq!(vec![0, 0], value, "seed byte {}", seed_byte)
                 }
                 other => panic!(
                     "unexpected result for seed byte {}: {:?}",
@@ -1090,14 +1081,13 @@ mod test {
     #[test]
     fn replay_engine_minimizes_vec_elements() {
         let mut runner = engine_runner();
-        let result =
-            runner.run(&crate::collection::vec(0i32..100, 3), |v| {
-                if v.iter().any(|&e| e >= 7) {
-                    Err(crate::test_runner::TestCaseError::fail("big elem"))
-                } else {
-                    Ok(())
-                }
-            });
+        let result = runner.run(&crate::collection::vec(0i32..100, 3), |v| {
+            if v.iter().any(|&e| e >= 7) {
+                Err(crate::test_runner::TestCaseError::fail("big elem"))
+            } else {
+                Ok(())
+            }
+        });
         match result {
             Err(crate::test_runner::TestError::Fail(_, mut value)) => {
                 value.sort();
@@ -1111,10 +1101,8 @@ mod test {
     fn replay_engine_shrinks_union_to_first_branch() {
         use crate::strategy::Strategy;
         let mut runner = engine_runner();
-        let strategy = crate::prop_oneof![
-            crate::strategy::Just(3i32),
-            10i32..20,
-        ];
+        let strategy =
+            crate::prop_oneof![crate::strategy::Just(3i32), 10i32..20,];
         let result = runner.run(&strategy.boxed(), |_| {
             Err(crate::test_runner::TestCaseError::fail("always"))
         });
@@ -1325,17 +1313,17 @@ mod test {
             .clone();
         let entries = &map[&"tape_persistence_test"];
         assert_eq!(1, entries.len());
-        assert!(format!("{}", entries.iter().next().unwrap())
-            .starts_with("ct1 "));
+        assert!(
+            format!("{}", entries.iter().next().unwrap()).starts_with("ct1 ")
+        );
 
         // Run 2: fresh runner and RNG; the test only fails at *exactly*
         // 2.0, which random generation will essentially never produce.
         // Only replaying the persisted tape can find it.
         let mut config = engine_config();
         config.cases = 10;
-        config.failure_persistence = Some(Box::new(
-            crate::test_runner::MapFailurePersistence { map },
-        ));
+        config.failure_persistence =
+            Some(Box::new(crate::test_runner::MapFailurePersistence { map }));
         config.source_file = Some("tape_persistence_test");
         let mut runner = crate::test_runner::TestRunner::new_with_rng(
             config,
@@ -1354,10 +1342,9 @@ mod test {
             Err(crate::test_runner::TestError::Fail(_, value)) => {
                 assert_eq!(2.0, value)
             }
-            other => panic!(
-                "persisted tape did not replay the failure: {:?}",
-                other
-            ),
+            other => {
+                panic!("persisted tape did not replay the failure: {:?}", other)
+            }
         }
         let _ = strategy;
     }
@@ -1370,8 +1357,7 @@ mod test {
             Choice::RawU64 { value: 9 },
         ]));
         // Matching kind pops.
-        let popped =
-            state.pop_replay(|c| matches!(c, Choice::RawU32 { .. }));
+        let popped = state.pop_replay(|c| matches!(c, Choice::RawU32 { .. }));
         assert_eq!(Some(Choice::RawU32 { value: 7 }), popped);
         // Kind mismatch does not consume...
         assert_eq!(
@@ -1379,8 +1365,7 @@ mod test {
             state.pop_replay(|c| matches!(c, Choice::RawU32 { .. }))
         );
         // ...so the u64 is still there.
-        let popped =
-            state.pop_replay(|c| matches!(c, Choice::RawU64 { .. }));
+        let popped = state.pop_replay(|c| matches!(c, Choice::RawU64 { .. }));
         assert_eq!(Some(Choice::RawU64 { value: 9 }), popped);
         // Overrun.
         assert_eq!(

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -443,6 +443,32 @@ impl TapeState {
         self.record(Choice::Bool { value });
     }
 
+    /// Record a boolean that generation forces to `forced` (drawing no
+    /// entropy), but that shrinking may edit: during replay the next
+    /// input Bool's value is honored if present. Used for units that are
+    /// structurally mandatory during generation yet deletable during
+    /// shrinking, e.g. a state-machine sequence's transitions below the
+    /// declared minimum length, which the classic shrinker deliberately
+    /// deletes past.
+    ///
+    /// Contrast `record_forced_bool`, which ignores the replayed value
+    /// (for markers whose value can never matter, like the stop flag of
+    /// a maximum-length collection).
+    pub(crate) fn draw_bool_forced(&mut self, forced: bool) -> bool {
+        if !self.is_on() {
+            return forced;
+        }
+        if let Some(Choice::Bool { value }) =
+            self.pop_replay(|c| matches!(c, Choice::Bool { .. }))
+        {
+            self.record(Choice::Bool { value });
+            return value;
+        }
+        // Not replaying, kind mismatch, or overrun: use the forced value.
+        self.record(Choice::Bool { value: forced });
+        forced
+    }
+
     /// During replay, consume and return the next input choice if `matcher`
     /// accepts it. Returns `None` (and samples must go fresh) on kind
     /// mismatch, on overrun (also setting the overrun flag), or when not

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -62,27 +62,38 @@ pub(crate) enum Choice {
     },
 }
 
-/// Complexity key of a single choice. Lower keys are "simpler" values; the
-/// all-target tape has all-zero keys.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum Key {
-    Int(u128),
-    Bytes(usize, Vec<u8>),
-}
-
 impl Choice {
-    pub(crate) fn key(&self) -> Key {
+    /// Complexity of a scalar choice. Lower is "simpler"; the shrink
+    /// target keys to 0. `None` for RawBytes, which order after all
+    /// scalars by (len, bytes) in `cmp_complexity`.
+    fn scalar_key(&self) -> Option<u128> {
         match self {
             Choice::Integer {
                 value, shrink_to, ..
-            } => Key::Int(zigzag(*value, *shrink_to)),
-            Choice::Float { value, .. } => Key::Int(float_key(*value)),
-            Choice::Bool { value } => Key::Int(*value as u128),
-            Choice::RawU32 { value } => Key::Int(*value as u128),
-            Choice::RawU64 { value } => Key::Int(*value as u128),
-            Choice::RawBytes { value } => {
-                Key::Bytes(value.len(), value.clone())
-            }
+            } => Some(zigzag(*value, *shrink_to)),
+            Choice::Float { value, .. } => Some(float_key(*value)),
+            Choice::Bool { value } => Some(*value as u128),
+            Choice::RawU32 { value } => Some(*value as u128),
+            Choice::RawU64 { value } => Some(*value as u128),
+            Choice::RawBytes { .. } => None,
+        }
+    }
+
+    /// Allocation-free complexity comparison between two choices,
+    /// consistent with the historical ordering (all scalar keys order
+    /// before byte blobs; byte blobs order by length then contents).
+    pub(crate) fn cmp_complexity(&self, other: &Choice) -> Ordering {
+        match (self.scalar_key(), other.scalar_key()) {
+            (Some(a), Some(b)) => a.cmp(&b),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => match (self, other) {
+                (
+                    Choice::RawBytes { value: a },
+                    Choice::RawBytes { value: b },
+                ) => a.len().cmp(&b.len()).then_with(|| a.cmp(b)),
+                _ => unreachable!(),
+            },
         }
     }
 
@@ -242,7 +253,7 @@ impl Tape {
     pub(crate) fn cmp_key(&self, other: &Tape) -> Ordering {
         self.choices.len().cmp(&other.choices.len()).then_with(|| {
             for (a, b) in self.choices.iter().zip(&other.choices) {
-                match a.key().cmp(&b.key()) {
+                match a.cmp_complexity(b) {
                     Ordering::Equal => continue,
                     unequal => return unequal,
                 }
@@ -259,11 +270,17 @@ impl Tape {
         }
     }
 
-    /// A copy of the tape with the choice at `idx` replaced.
+    /// A copy of the tape with the choice at `idx` replaced. Like
+    /// `with_span_deleted`, the copy's span list is dropped: replay
+    /// ignores input spans, and an accepted proposal re-records fresh
+    /// ones on its output tape.
     pub(crate) fn with_choice(&self, idx: usize, choice: Choice) -> Tape {
-        let mut out = self.clone();
-        out.choices[idx] = choice;
-        out
+        let mut choices = self.choices.clone();
+        choices[idx] = choice;
+        Tape {
+            choices,
+            spans: Vec::new(),
+        }
     }
 
     /// A copy of the tape with the choices of `span` removed. The copy's
@@ -1258,9 +1275,10 @@ mod test {
     fn persisted_tape_form_roundtrips_as_string() {
         use core::str::FromStr;
         let seed = crate::test_runner::PersistedSeed(
-            crate::test_runner::failure_persistence::PersistedFailure::Tape(
-                vec![0xab, 0xcd, 0x01],
-            ),
+            crate::test_runner::failure_persistence::PersistedFailure::Tape {
+                bytes: vec![0xab, 0xcd, 0x01],
+                seed: None,
+            },
         );
         let string = format!("{}", seed);
         assert!(string.starts_with("ct1 "), "got: {}", string);
@@ -1272,8 +1290,6 @@ mod test {
 
     #[test]
     fn persisted_tape_replays_exact_shrunken_value() {
-        use crate::strategy::Strategy;
-
         // Run 1: fail on v >= 1.7, shrink to 2.0, persist.
         let mut config = engine_config();
         config.failure_persistence = Some(Box::new(
@@ -1347,6 +1363,84 @@ mod test {
             }
         }
         let _ = strategy;
+    }
+
+    #[test]
+    fn replay_engine_shrinks_weighted_bool_to_false() {
+        // bool::weighted draws through a typed Bool choice; the raw
+        // fallback would shrink toward `true` (rand's Bernoulli maps a
+        // zeroed u64 to true for any p > 0).
+        let mut runner = engine_runner();
+        match runner.run(&crate::bool::weighted(0.5), |_| {
+            Err(crate::test_runner::TestCaseError::fail("always"))
+        }) {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(false, value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_shrinking_does_not_exhaust_local_rejects() {
+        // Shrink attempts re-vet proposals through filters; the local
+        // rejects they incur must not drain the run-wide budget, or
+        // shrinking silently stalls once it crosses max_local_rejects.
+        let mut config = engine_config();
+        config.max_local_rejects = 32;
+        let mut runner = crate::test_runner::TestRunner::new_with_rng(
+            config,
+            crate::test_runner::TestRng::deterministic_rng(
+                crate::test_runner::RngAlgorithm::default(),
+            ),
+        );
+        use crate::strategy::Strategy;
+        let strategy = (0i32..1000).prop_filter("even", |v| 0 == v % 2);
+        match runner.run(&strategy, |v| {
+            if v >= 100 {
+                Err(crate::test_runner::TestCaseError::fail("too big"))
+            } else {
+                Ok(())
+            }
+        }) {
+            Err(crate::test_runner::TestError::Fail(_, value)) => {
+                assert_eq!(100, value)
+            }
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn corrupt_persisted_tape_aborts_loudly() {
+        // A regression entry that cannot replay guards nothing; it must
+        // fail the run like a dead persisted seed does, not continue as
+        // a pass.
+        use crate::std_facade::BTreeMap;
+        use crate::std_facade::BTreeSet;
+        let mut entries = BTreeSet::new();
+        entries.insert(crate::test_runner::PersistedSeed(
+            crate::test_runner::failure_persistence::PersistedFailure::Tape {
+                bytes: vec![99],
+                seed: None,
+            },
+        ));
+        let mut map = BTreeMap::new();
+        map.insert("corrupt_tape_test", entries);
+        let mut config = engine_config();
+        config.failure_persistence = Some(Box::new(
+            crate::test_runner::MapFailurePersistence { map },
+        ));
+        config.source_file = Some("corrupt_tape_test");
+        let mut runner = crate::test_runner::TestRunner::new_with_rng(
+            config,
+            crate::test_runner::TestRng::deterministic_rng(
+                crate::test_runner::RngAlgorithm::default(),
+            ),
+        );
+        match runner.run(&(0i32..10), |_| Ok(())) {
+            Err(crate::test_runner::TestError::Abort(_)) => (),
+            other => panic!("expected loud abort, got: {:?}", other),
+        }
     }
 
     #[test]

--- a/proptest/src/test_runner/tape.rs
+++ b/proptest/src/test_runner/tape.rs
@@ -423,6 +423,26 @@ impl TapeState {
         }
     }
 
+    /// Record a choice whose value is forced by generation structure
+    /// rather than drawn (e.g. the "stop" continuation flag of a
+    /// maximum-length collection). During replay a matching next input
+    /// choice is consumed so edits stay aligned, but its value is
+    /// ignored, and running off the end of the input is NOT an overrun —
+    /// no information is being read.
+    pub(crate) fn record_forced_bool(&mut self, value: bool) {
+        if !self.is_on() {
+            return;
+        }
+        if let TapeMode::Replaying { input, cursor, .. } = &mut self.mode {
+            if *cursor < input.choices.len()
+                && matches!(input.choices[*cursor], Choice::Bool { .. })
+            {
+                *cursor += 1;
+            }
+        }
+        self.record(Choice::Bool { value });
+    }
+
     /// During replay, consume and return the next input choice if `matcher`
     /// accepts it. Returns `None` (and samples must go fresh) on kind
     /// mismatch, on overrun (also setting the overrun flag), or when not
@@ -870,6 +890,47 @@ mod test {
                 assert_eq!(vec![0, 0, 0, 0, 0], value)
             }
             other => panic!("unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_engine_deletes_elements_from_max_length_vecs() {
+        // Regression test: maximum-length vecs draw no natural "stop"
+        // flag, and without the forced stop marker every deletion edit
+        // overran the tape and was rejected. Sweep seeds so some initial
+        // failing cases are at maximum length.
+        for seed_byte in 0..20u8 {
+            let mut runner = crate::test_runner::TestRunner::new_with_rng(
+                engine_config(),
+                crate::test_runner::TestRng::from_seed(
+                    crate::test_runner::RngAlgorithm::ChaCha,
+                    &[seed_byte; 32],
+                ),
+            );
+            let result = runner
+                .run(&crate::collection::vec(0i32..100, 0..6), |v| {
+                    if v.len() >= 2 {
+                        Err(crate::test_runner::TestCaseError::fail(
+                            "too long",
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                });
+            match result {
+                Err(crate::test_runner::TestError::Fail(_, value)) => {
+                    assert_eq!(
+                        vec![0, 0],
+                        value,
+                        "seed byte {}",
+                        seed_byte
+                    )
+                }
+                other => panic!(
+                    "unexpected result for seed byte {}: {:?}",
+                    seed_byte, other
+                ),
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds an experimental choice-tape shrinking engine to proptest. Generation records typed choices and raw RNG reads; shrinking edits that record, replays the strategy, and keeps proposals that still reproduce the failure with a simpler tape.

The aim is to improve cases where independent `ValueTree` shrinking stalls: filtered values, related values that must move together, structured deletion, and floats whose simplest failing example is a round boundary. Existing strategies remain usable. Migrated strategies provide typed constraints and shrink targets, while other strategies participate through intercepted raw RNG draws with less specialised shrinking.

Collections use continuation choices and structural spans, allowing elements to be deleted independently. The sequential state-machine strategy uses the same representation and rechecks preconditions against the replayed state. The shrinker also includes per-choice minimisation, batched span deletion, redistribution between related integers, and joint lowering of duplicate values.

Failing tapes are persisted in the versioned `ct1` format. This reproduces the recorded choices rather than reconstructing them from an RNG seed, but it remains positional implementation data rather than a stable cross-version format. Custom persistence implementations need the newer persistence hook; legacy seed-only hooks cannot store tape failures.

This design follows Hypothesis's Conjecture engine. Hegel, developed by Hypothesis authors, is an earlier Rust implementation of the same architecture and likewise records typed choices with their constraints, including per-integer `shrink_towards` values. The contribution here is adapting the Hypothesis model to proptest's existing `Strategy`, `ValueTree`, `TestRunner`, RNG, and persistence interfaces rather than introducing the typed-choice representation itself.

The tape engine remains experimental and opt-in through `Config::shrink_engine` or `PROPTEST_SHRINK_ENGINE=tape`; `ValueTree` remains the default. Numeric edge-case generation changes are independent of the selected shrink engine and are called out separately in the changelog.

### Testing

- `cargo test -p proptest`
- `cargo test -p proptest-state-machine`
- `PROPTEST_SHRINK_ENGINE=tape cargo test -p proptest-state-machine`
- `cargo clippy -p proptest --lib`

The design and remaining limitations are documented in `design/choice-tape-shrinking.md`. In particular, fork and timeout configurations continue to use the `ValueTree` engine.
