### PR TITLE
Add max_run_time config option to bound a run by wall-clock time

### DIFF
--- a/proptest/CHANGELOG.md
+++ b/proptest/CHANGELOG.md
@@ -10,6 +10,10 @@
 - [Soundness] Asserts that rdrand feature is supported by the CPU before invoking rdrand functions ([\#648](https://github.com/proptest-rs/proptest/issues/648))
 - [Soundness] Fixes data race on static mut between assigning thread and accessing thread ([\#648](https://github.com/proptest-rs/proptest/issues/648))
 
+### New Additions
+
+- Added the `max_run_time` config option (and the `PROPTEST_MAX_RUN_TIME` environment variable) to bound a run by wall-clock time in milliseconds instead of a fixed case count. ([\#655](https://github.com/proptest-rs/proptest/issues/655))
+
 ### Other Notes
 
 - Updated the rand dependency family to 0.10 and migrated `TestRng` and internal RNG integration to rand 0.10's trait and seeding APIs, preserving seeded behavior.

--- a/proptest/src/test_runner/config.rs
+++ b/proptest/src/test_runner/config.rs
@@ -1,5 +1,5 @@
 //-
-// Copyright 2017, 2018, 2019 The proptest developers
+// Copyright 2017, 2018, 2019, 2026 The proptest developers
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -30,6 +30,7 @@ pub fn contextualize_config(mut result: Config) -> Config {
     const MAX_FLAT_MAP_REGENS: &str = "PROPTEST_MAX_FLAT_MAP_REGENS";
     const MAX_SHRINK_TIME: &str = "PROPTEST_MAX_SHRINK_TIME";
     const MAX_SHRINK_ITERS: &str = "PROPTEST_MAX_SHRINK_ITERS";
+    const MAX_RUN_TIME: &str = "PROPTEST_MAX_RUN_TIME";
     const MAX_DEFAULT_SIZE_RANGE: &str = "PROPTEST_MAX_DEFAULT_SIZE_RANGE";
     #[cfg(feature = "fork")]
     const FORK: &str = "PROPTEST_FORK";
@@ -120,6 +121,13 @@ pub fn contextualize_config(mut result: Config) -> Config {
                 "u32",
                 MAX_SHRINK_ITERS,
             );
+        } else if var == MAX_RUN_TIME {
+            parse_or_warn(
+                &value,
+                &mut result.max_run_time,
+                "u32",
+                MAX_RUN_TIME,
+            );
         } else if var == MAX_DEFAULT_SIZE_RANGE {
             parse_or_warn(
                 &value,
@@ -169,6 +177,8 @@ fn default_default_config() -> Config {
         timeout: 0,
         #[cfg(feature = "std")]
         max_shrink_time: 0,
+        #[cfg(feature = "std")]
+        max_run_time: 0,
         max_shrink_iters: u32::MAX,
         max_default_size_range: 100,
         result_cache: noop_result_cache,
@@ -350,6 +360,30 @@ pub struct Config {
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub max_shrink_time: u32,
+
+    /// If non-zero, stop generating and running new test cases once this many
+    /// milliseconds have elapsed since the run started, and treat the test as
+    /// passed.
+    ///
+    /// This is useful when you want to bound a test by wall-clock time rather
+    /// than by a fixed number of cases, for example running a shorter budget
+    /// locally and a longer one in CI. The `cases` limit still applies, so a
+    /// run stops at whichever of the two is reached first. The time is only
+    /// checked between cases, so a single long-running case can overshoot the
+    /// budget.
+    ///
+    /// This does not include time spent shrinking a discovered failure; see
+    /// `max_shrink_time` for that.
+    ///
+    /// This configuration is only available when the `std` feature is enabled
+    /// (which it is by default).
+    ///
+    /// The default is `0` (i.e., no limit), which can be overridden by setting
+    /// the `PROPTEST_MAX_RUN_TIME` environment variable. (The variable is only
+    /// considered when the `std` feature is enabled, which it is by default.)
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub max_run_time: u32,
 
     /// Give up on shrinking if more than this number of iterations of the test
     /// code are run.

--- a/proptest/src/test_runner/runner.rs
+++ b/proptest/src/test_runner/runner.rs
@@ -1,5 +1,5 @@
 //-
-// Copyright 2017, 2018, 2019, 2024 The proptest developers
+// Copyright 2017, 2018, 2019, 2024, 2026 The proptest developers
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -613,7 +613,24 @@ impl TestRunner {
         }
         self.rng = old_rng;
 
+        #[cfg(feature = "std")]
+        let run_start = std::time::Instant::now();
+
         while self.successes < self.config.cases {
+            // Stop early if we've used up the configured run-time budget. The
+            // check is between cases, so an already-running case is never
+            // interrupted.
+            #[cfg(feature = "std")]
+            if self.config.max_run_time > 0 {
+                let elapsed = run_start.elapsed();
+                let elapsed_ms = (elapsed.as_secs() as u64)
+                    .saturating_mul(1000)
+                    .saturating_add(elapsed.subsec_millis().into());
+                if elapsed_ms > self.config.max_run_time as u64 {
+                    break;
+                }
+            }
+
             // Generate a new seed and make an RNG from that so that we know
             // what seed to persist if this case fails.
             let seed = self.rng.gen_get_seed();
@@ -1099,6 +1116,55 @@ mod test {
             Ok(())
         });
         assert_eq!(Ok(()), result);
+    }
+
+    #[test]
+    fn max_run_time_stops_early() {
+        use std::time::Duration;
+
+        let config = Config {
+            failure_persistence: None,
+            // A count far larger than we could ever reach inside the budget.
+            cases: 1_000_000,
+            max_run_time: 50,
+            ..Config::default()
+        };
+        let mut runner = TestRunner::new(config);
+        let runs = Cell::new(0u32);
+        let result = runner.run(&(0u32..), |_| {
+            runs.set(runs.get() + 1);
+            std::thread::sleep(Duration::from_millis(2));
+            Ok(())
+        });
+
+        assert_eq!(Ok(()), result);
+        // We should have run at least one case but bailed out long before
+        // exhausting the case count once the budget elapsed.
+        assert!(runs.get() >= 1);
+        assert!(
+            runs.get() < 1000,
+            "expected to stop early, but ran {} cases",
+            runs.get()
+        );
+    }
+
+    #[test]
+    fn max_run_time_zero_runs_all_cases() {
+        let config = Config {
+            failure_persistence: None,
+            cases: 32,
+            max_run_time: 0,
+            ..Config::default()
+        };
+        let mut runner = TestRunner::new(config);
+        let runs = Cell::new(0u32);
+        let result = runner.run(&(0u32..), |_| {
+            runs.set(runs.get() + 1);
+            Ok(())
+        });
+
+        assert_eq!(Ok(()), result);
+        assert_eq!(32, runs.get());
     }
 
     #[test]


### PR DESCRIPTION
Closes #655.

Adds a `max_run_time` config option (and a matching `PROPTEST_MAX_RUN_TIME` env var) so a run can be bounded by wall-clock time instead of a fixed case count. It mirrors the existing `max_shrink_time` option. When it's non-zero the runner stops generating new cases once the budget has elapsed and treats the test as passed, so you can use a short budget locally and a longer one in CI without keeping case-count estimates in sync. The `cases` limit still applies, so a run stops at whichever is reached first, and the default of `0` keeps today's behavior.

The time is only checked between cases, so a single long-running case can overshoot the budget, same as `max_shrink_time`. Added tests for the early-stop path and for the default `0` (unlimited) path, and noted it in the changelog.